### PR TITLE
fix(build): fixed linking of libp2p.so on Linux (#33)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,11 @@ if(APPLE)
         BUILD_RPATH "${CMAKE_CURRENT_SOURCE_DIR}/lib"
         INSTALL_RPATH "@loader_path;@loader_path/../lib"
     )
+elseif(UNIX)
+    set_target_properties(libp2p_module_module_plugin PROPERTIES
+        BUILD_RPATH "${CMAKE_CURRENT_SOURCE_DIR}/lib"
+        INSTALL_RPATH "$ORIGIN"
+    )
 endif()
 
 enable_testing()

--- a/flake.nix
+++ b/flake.nix
@@ -35,8 +35,14 @@
 
           postInstall = ''
             mkdir -p $out/lib
-            cp lib/*.dylib $out/lib/ 2>/dev/null || true
-            cp lib/*.so $out/lib/ 2>/dev/null || true
+            cp ${libp2pCbind system}/lib/*.dylib $out/lib/ 2>/dev/null || true
+            cp ${libp2pCbind system}/lib/*.so $out/lib/ 2>/dev/null || true
+          '' + lib.optionalString (lib.hasSuffix "darwin" system) ''
+            for f in $out/lib/*.dylib; do
+              [ -f "$f" ] || continue
+              chmod +w "$f"
+              install_name_tool -id "@rpath/$(basename "$f")" "$f"
+            done
           '';
         };
 


### PR DESCRIPTION
These changes fix the libp2p.so linking of the build process (post-install phase).

Closes #33 