### PR TITLE
chore(service-disco): rename `startDiscovering` to `registerInterest`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ logos_module(
         src/callbacks.cpp
         src/kademlia.cpp
         src/stream.cpp
-        src/mix.cpp
+        # src/mix.cpp  # temporarily disabled — extracted to separate repo, no cbindings yet
         src/gossipsub.cpp
         src/service_discovery.cpp
     EXTERNAL_LIBS

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,6 @@
 file(GLOB EXAMPLE_SOURCES CONFIGURE_DEPENDS *.cpp)
+# mix.cpp temporarily disabled — extracted to separate repo, no cbindings yet
+list(FILTER EXAMPLE_SOURCES EXCLUDE REGEX "/mix\\.cpp$")
 
 foreach(example_src ${EXAMPLE_SOURCES})
     get_filename_component(example_name ${example_src} NAME_WE)

--- a/examples/service_discovery.cpp
+++ b/examples/service_discovery.cpp
@@ -49,9 +49,9 @@ int main()
         return 1;
     }
 
-    printf("Node B: starting discovering %s\n", serviceId.c_str());
-    if (!nodeB.discoStartDiscovering(serviceId).success) {
-        fprintf(stderr, "Node B: discoStartDiscovering failed\n");
+    printf("Node B: registering interest in %s\n", serviceId.c_str());
+    if (!nodeB.discoRegisterInterest(serviceId).success) {
+        fprintf(stderr, "Node B: discoRegisterInterest failed\n");
         return 1;
     }
 
@@ -79,8 +79,8 @@ int main()
         printf("Random lookup returned %zu peer(s)\n", randRes.value.size());
     }
 
-    printf("Node B: stopping discovering %s\n", serviceId.c_str());
-    nodeB.discoStopDiscovering(serviceId);
+    printf("Node B: unregistering interest in %s\n", serviceId.c_str());
+    nodeB.discoUnregisterInterest(serviceId);
 
     printf("Node A: stopping advertising %s\n", serviceId.c_str());
     nodeA.discoStopAdvertising(serviceId);

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1777291945,
-        "narHash": "sha256-JgK3enVh6Ks+VlBmsHZIgDo6JqGlYVSszvKhK/Qm9Sk=",
+        "lastModified": 1778495002,
+        "narHash": "sha256-UtYbipIPzJnHwRBXUaDVZbpCgBaisCjgfXn8M4ttVt8=",
         "owner": "vacp2p",
         "repo": "nim-libp2p",
-        "rev": "60de577175248e87eab93f0e1da998ac808ecd37",
+        "rev": "2f65aad835d56f8c34301cea671db26c838ba962",
         "type": "github"
       },
       "original": {
@@ -2579,11 +2579,7 @@
     "root": {
       "inputs": {
         "libp2p": "libp2p",
-        "logos-module-builder": "logos-module-builder",
-        "nixpkgs": [
-          "logos-module-builder",
-          "nixpkgs"
-        ]
+        "logos-module-builder": "logos-module-builder"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1778495002,
-        "narHash": "sha256-UtYbipIPzJnHwRBXUaDVZbpCgBaisCjgfXn8M4ttVt8=",
+        "lastModified": 1778508233,
+        "narHash": "sha256-lSD+ypRXbt/Dy6puLrvU74PXhQ1cdXfXMznU8laRGok=",
         "owner": "vacp2p",
         "repo": "nim-libp2p",
-        "rev": "2f65aad835d56f8c34301cea671db26c838ba962",
+        "rev": "3f5a4dce286674aefd01a1ca21538ee7252efbc0",
         "type": "github"
       },
       "original": {

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -106,7 +106,8 @@ Libp2pModuleImpl::Libp2pModuleImpl(const Libp2pModuleOptions& options)
 
     m_libp2pConfig.mount_kad = options.mountKad ? 1 : 0;
     m_libp2pConfig.mount_service_discovery = options.mountServiceDiscovery ? 1 : 0;
-    m_libp2pConfig.mount_mix = options.mountMix ? 1 : 0;
+    // m_libp2pConfig.mount_mix = options.mountMix ? 1 : 0; # temporarily disabled — extracted to separate repo, no cbindings yet
+    
 
     // Generate private key
     auto keyResult = newPrivateKey();

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -126,6 +126,7 @@ public:
     StdLogosResult kadGetProviders(const std::string& cid);
     StdLogosResult kadGetRandomRecords();
 
+#if 0  // mix temporarily disabled — extracted to separate repo, no cbindings yet
     /* ----------- Mix Network ----------- */
 
     StdLogosResult mixGeneratePrivKey();
@@ -147,6 +148,7 @@ public:
                                   const std::string& multiaddr,
                                   const std::string& mixPubKey,
                                   const std::string& libp2pPubKey);
+#endif
 
     /* ----------- Service Discovery ----------- */
 

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -155,8 +155,8 @@ public:
     StdLogosResult discoStartAdvertising(const std::string& serviceId,
                                          const std::string& serviceData = {});
     StdLogosResult discoStopAdvertising(const std::string& serviceId);
-    StdLogosResult discoStartDiscovering(const std::string& serviceId);
-    StdLogosResult discoStopDiscovering(const std::string& serviceId);
+    StdLogosResult discoRegisterInterest(const std::string& serviceId);
+    StdLogosResult discoUnregisterInterest(const std::string& serviceId);
     StdLogosResult discoLookup(const std::string& serviceId,
                                const std::string& serviceData = {});
     StdLogosResult discoRandomLookup();

--- a/src/service_discovery.cpp
+++ b/src/service_discovery.cpp
@@ -70,28 +70,28 @@ StdLogosResult Libp2pModuleImpl::discoStopAdvertising(const std::string& service
     return {true, {}, ""};
 }
 
-StdLogosResult Libp2pModuleImpl::discoStartDiscovering(const std::string& serviceId) {
+StdLogosResult Libp2pModuleImpl::discoRegisterInterest(const std::string& serviceId) {
     if (!ctx) return {false, {}, "No libp2p context"};
 
     auto* p = new SyncPromise();
     auto f = p->get_future();
-    int ret = libp2p_service_disco_start_discovering(ctx, serviceId.c_str(),
-                                                     &Libp2pModuleImpl::promiseCallback, p);
-    if (ret != RET_OK) { delete p; return {false, {}, "Failed to start discovering"}; }
+    int ret = libp2p_service_disco_register_interest(ctx, serviceId.c_str(),
+                                                    &Libp2pModuleImpl::promiseCallback, p);
+    if (ret != RET_OK) { delete p; return {false, {}, "Failed to register interest"}; }
 
     auto r = awaitResult(f);
     if (!r.ok) return {false, {}, r.message};
     return {true, {}, ""};
 }
 
-StdLogosResult Libp2pModuleImpl::discoStopDiscovering(const std::string& serviceId) {
+StdLogosResult Libp2pModuleImpl::discoUnregisterInterest(const std::string& serviceId) {
     if (!ctx) return {false, {}, "No libp2p context"};
 
     auto* p = new SyncPromise();
     auto f = p->get_future();
-    int ret = libp2p_service_disco_stop_discovering(ctx, serviceId.c_str(),
-                                                    &Libp2pModuleImpl::promiseCallback, p);
-    if (ret != RET_OK) { delete p; return {false, {}, "Failed to stop discovering"}; }
+    int ret = libp2p_service_disco_unregister_interest(ctx, serviceId.c_str(),
+                                                      &Libp2pModuleImpl::promiseCallback, p);
+    if (ret != RET_OK) { delete p; return {false, {}, "Failed to unregister interest"}; }
 
     auto r = awaitResult(f);
     if (!r.ok) return {false, {}, r.message};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,7 +20,7 @@ if(LIBP2P_PATH)
             ../src/callbacks.cpp
             ../src/kademlia.cpp
             ../src/stream.cpp
-            ../src/mix.cpp
+            # ../src/mix.cpp  # temporarily disabled — extracted to separate repo, no cbindings yet
             ../src/gossipsub.cpp
             ../src/service_discovery.cpp
         TEST_SOURCES
@@ -30,7 +30,7 @@ if(LIBP2P_PATH)
             integration.cpp
             integration_gossipsub.cpp
             integration_kad.cpp
-            integration_mix.cpp
+            # integration_mix.cpp  # temporarily disabled — extracted to separate repo, no cbindings yet
             integration_service_discovery.cpp
         EXTRA_INCLUDES
             ../lib

--- a/tests/integration_service_discovery.cpp
+++ b/tests/integration_service_discovery.cpp
@@ -50,7 +50,7 @@ LOGOS_TEST(disco_advertise_and_lookup) {
 
     std::string serviceId = "test-service";
     LOGOS_ASSERT_TRUE(nodeA.discoStartAdvertising(serviceId).success);
-    LOGOS_ASSERT_TRUE(nodeB.discoStartDiscovering(serviceId).success);
+    LOGOS_ASSERT_TRUE(nodeB.discoRegisterInterest(serviceId).success);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
@@ -96,7 +96,7 @@ LOGOS_TEST(disco_advertise_with_data) {
     std::string serviceData = "version=2;proto=test";
 
     LOGOS_ASSERT_TRUE(nodeA.discoStartAdvertising(serviceId, serviceData).success);
-    LOGOS_ASSERT_TRUE(nodeB.discoStartDiscovering(serviceId).success);
+    LOGOS_ASSERT_TRUE(nodeB.discoRegisterInterest(serviceId).success);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 

--- a/tests/sync.cpp
+++ b/tests/sync.cpp
@@ -239,6 +239,7 @@ LOGOS_TEST(sync_kad_random_records) {
     LOGOS_ASSERT_TRUE(plugin.stop().success);
 }
 
+#if 0  // mix temporarily disabled — extracted to separate repo, no cbindings yet
 LOGOS_TEST(sync_mix_dial) {
     Libp2pModuleImpl plugin;
     LOGOS_ASSERT_TRUE(plugin.start().success);
@@ -315,3 +316,4 @@ LOGOS_TEST(sync_mix_nodepool_add) {
 
     LOGOS_ASSERT_TRUE(plugin.stop().success);
 }
+#endif


### PR DESCRIPTION
## Summary

Renames service-discovery calls to match [vacp2p/nim-libp2p#2441](https://github.com/vacp2p/nim-libp2p/pull/2441), and bumps the flake to current nim-libp2p master.

- `discoStartDiscovering` → `discoRegisterInterest`
- `discoStopDiscovering` → `discoUnregisterInterest`
- C symbols and log strings updated to match.

### Mix disabled

[vacp2p/nim-libp2p#2378](https://github.com/vacp2p/nim-libp2p/pull/2378) moved mix out of nim-libp2p. The cbind layer no longer exports `libp2p_mix_*` / `mount_mix` / `Libp2pMixReadBehavior` / `libp2p_curve25519_key_t` etc. 

Mix code has been disabled, with the assumption that it should stay in this module and can be easily brought back once a new cbind is available.
