### PR TITLE
feat(ci): ASan and TSan jobs for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,19 +48,40 @@ jobs:
       - name: Setup Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v5
 
-      - name: Setup Cachix
-        uses: cachix/cachix-action@v15
-        with:
-          name: nix-community
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-        continue-on-error: true
-
       - name: Run flake checks
         env:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_target }}
         run: |
           nix flake check \
             --system ${{ matrix.system }} \
+            --print-build-logs \
+            --show-trace
+
+  sanitizers:
+    name: Sanitizers (${{ matrix.sanitizer }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [asan, tsan]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v12
+
+      - name: Setup Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v5
+
+      - name: Build + run tests under ${{ matrix.sanitizer }}
+        run: |
+          nix build \
+            ".#unit-tests-${{ matrix.sanitizer }}" \
+            --system x86_64-linux \
             --print-build-logs \
             --show-trace
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,16 +8,18 @@
 
   outputs = inputs@{ logos-module-builder, ... }:
     let
+      externalLibInputs = {
+        libp2p = {
+          input = inputs.libp2p;
+          packages.default = "cbind";
+        };
+      };
+
       module = logos-module-builder.lib.mkLogosModule {
         src = ./.;
         configFile = ./metadata.json;
         flakeInputs = inputs;
-        externalLibInputs = {
-          libp2p = {
-            input = inputs.libp2p;
-            packages.default = "cbind";
-          };
-        };
+        inherit externalLibInputs;
         tests = {
           dir = ./tests;
         };
@@ -25,6 +27,70 @@
 
       nixpkgs = logos-module-builder.inputs.nixpkgs;
       systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
+
+      # mkLogosModuleTests splats extraCmakeFlags into cmake unquoted, so
+      # multi-token values get shell-split. Inject sanitizer flags via env vars.
+      baseSanitizerTests = logos-module-builder.lib.mkLogosModuleTests {
+        src = ./.;
+        testDir = ./tests;
+        configFile = ./metadata.json;
+        flakeInputs = inputs;
+        inherit externalLibInputs;
+        extraCmakeFlags = [ "-DCMAKE_BUILD_TYPE=Debug" ];
+      };
+
+      mkSanitized = system: sanitizer: runtimeOpts:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          clang = pkgs.clang;
+          llvm = pkgs.llvm;  # llvm-symbolizer; symbol-based suppressions need it
+          sanFlags = "-fsanitize=${sanitizer} -fno-omit-frame-pointer -g -O1";
+          tsanSuppressions = pkgs.writeText "tsan.supp" ''
+            race:libp2p.so
+          '';
+          # Wrapper code (Libp2pModuleImpl, src/*.cpp) is NOT suppressed —
+          # real wrapper leaks (e.g. src/plugin.cpp:121 privkey) still surface.
+          lsanSuppressions = pkgs.writeText "lsan.supp" ''
+            leak:libp2p.so
+            leak:std::promise
+            leak:std::__future_base
+            leak:QCoreApplication
+            leak:QMetaObject
+            leak:QArrayData
+            leak:QObjectPrivate
+            leak:LogosTestRunner
+            leak:LogosTestContext
+          '';
+          extraRuntime =
+            if sanitizer == "address" then ''
+              export ASAN_SYMBOLIZER_PATH=${llvm}/bin/llvm-symbolizer
+              export LSAN_OPTIONS="suppressions=${lsanSuppressions}:print_suppressions=0"
+            '' else ''
+              export TSAN_OPTIONS="$TSAN_OPTIONS:suppressions=${tsanSuppressions}:external_symbolizer_path=${llvm}/bin/llvm-symbolizer"
+            '';
+        in baseSanitizerTests.${system}.unit-tests.overrideAttrs (old: {
+          nativeBuildInputs = (old.nativeBuildInputs or []) ++ [ clang llvm ];
+          hardeningDisable = (old.hardeningDisable or []) ++ [ "all" ];
+          preBuild = (old.preBuild or "") + ''
+            export CC=${clang}/bin/clang
+            export CXX=${clang}/bin/clang++
+            export CFLAGS="${sanFlags}"
+            export CXXFLAGS="${sanFlags}"
+            export LDFLAGS="-fsanitize=${sanitizer}"
+            export ${runtimeOpts}
+            ${extraRuntime}
+          '';
+        });
+
+      sanitizerPackages = builtins.listToAttrs (map (system: {
+        name = system;
+        value = {
+          unit-tests-asan = mkSanitized system "address"
+            "ASAN_OPTIONS=detect_leaks=1:abort_on_error=1:print_stacktrace=1:strict_string_checks=1:check_initialization_order=1";
+          unit-tests-tsan = mkSanitized system "thread"
+            "TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1:history_size=7";
+        };
+      }) systems);
 
       testsApps = builtins.listToAttrs (map (system:
         let
@@ -59,8 +125,14 @@
         value = (existingApps.${system} or {}) // (testsApps.${system} or {});
       }) systems);
 
+      mergedPackages = builtins.listToAttrs (map (system: {
+        name = system;
+        value = (module.packages.${system} or {}) // (sanitizerPackages.${system} or {});
+      }) systems);
+
     in module // {
       apps = mergedApps;
       checks = module.checks or {};
+      packages = mergedPackages;
     };
 }


### PR DESCRIPTION
## Summary

Adds ASan and TSan CI coverage for the unit tests. CI previously ran only `nix flake check` with no instrumentation, so wrapper bugs (raw `new`/`delete`, raw pointers shared across the worker thread, "contexts live forever" lifetime model) would not fail the build.

### Changes

**`flake.nix`** — adds `unit-tests-asan` and `unit-tests-tsan` packages per system. Built via `mkLogosModuleTests` with sanitizer flags and runtime opts injected via `preBuild` (env vars: `CC`/`CXX`/`CFLAGS`/`CXXFLAGS`/`LDFLAGS`/`ASAN_OPTIONS`/`TSAN_OPTIONS`). Clang is used as the compiler for better sanitizer diagnostics. `hardeningDisable = ["all"]` to drop Nix stdenv fortify (conflicts with sanitizers). `llvm` added to `nativeBuildInputs` so `llvm-symbolizer` resolves frames to function names — symbol-based suppressions can't match raw hex offsets.

Curated suppression files cover known-noise sources without hiding wrapper bugs:
- **LSan** (`lsan.supp`): suppresses `libp2p.so` (uninstrumented Nim runtime), `std::promise` / `std::__future_base` (the wrapper allocates a `SyncPromise` per async libp2p call; tests that exit while callbacks are in flight leave them undeleted — not a real bug), Qt singletons (`QCoreApplication`, `QMetaObject`, `QArrayData`, `QObjectPrivate`), and `LogosTestRunner` / `LogosTestContext`. Wrapper code (`Libp2pModuleImpl`, `src/*.cpp`) is NOT suppressed — the privkey leak at `src/plugin.cpp:121` still surfaces.
- **TSan** (`tsan.supp`): suppresses `libp2p.so` (Nim runtime races on glibc's non-thread-safe `localtime`). Wrapper-only races (`m_subscribeContexts` in `src/gossipsub.cpp:48-57`) have all-C++ stacks and are unaffected.

**`.github/workflows/ci.yml`**:
- New `sanitizers` matrix job (`[asan, tsan]`) on `ubuntu-latest`, runs `nix build .#unit-tests-<sanitizer>`. Linux x86_64 only.
- Dropped the `cachix-action` step pointing at `name: nix-community` — that cache isn't ours. `magic-nix-cache-action` still handles per-repo caching.

`libp2p.so` itself isn't sanitizer-instrumented, so bugs inside the Nim library are out of scope.