### PR TITLE
feat: enable service discovery in plugin configuration

### DIFF
--- a/src/plugin.h
+++ b/src/plugin.h
@@ -37,7 +37,7 @@ struct Libp2pModuleOptions {
     bool gossipsubTriggerSelf = true;
     bool mountGossipsub = true;
     bool mountKad = true;
-    bool mountServiceDiscovery = false;
+    bool mountServiceDiscovery = true;
 };
 
 // Result type for internal sync-over-async operations.


### PR DESCRIPTION
I'm not sure if we want this enabled by default, but it seems like it may just simplify usage of the module (especially given https://github.com/logos-co/logos-docs/issues/307). LMK what you think .