### PR TITLE
fix: single-line disco decls so codegen emits them

### DIFF
--- a/src/plugin.h
+++ b/src/plugin.h
@@ -144,13 +144,11 @@ public:
 
     StdLogosResult discoStart();
     StdLogosResult discoStop();
-    StdLogosResult discoStartAdvertising(const std::string& serviceId,
-                                         const std::string& serviceData = {});
+    StdLogosResult discoStartAdvertising(const std::string& serviceId, const std::string& serviceData = {});
     StdLogosResult discoStopAdvertising(const std::string& serviceId);
     StdLogosResult discoRegisterInterest(const std::string& serviceId);
     StdLogosResult discoUnregisterInterest(const std::string& serviceId);
-    StdLogosResult discoLookup(const std::string& serviceId,
-                               const std::string& serviceData = {});
+    StdLogosResult discoLookup(const std::string& serviceId, const std::string& serviceData = {});
     StdLogosResult discoRandomLookup();
 
     StdLogosResult peerstoreGetPeers();


### PR DESCRIPTION
It seems the logos-cpp-generator only properly parses declarations on a single line (confirmed experimentally, but quick glance [here](https://github.com/logos-co/logos-cpp-sdk/blob/master/cpp-generator/experimental/impl_header_parser.cpp#L92) seems to confirm this suspicion. The correct fix is probably to sanitise the header file and compact run-on line declarations before passing it to the cpp generator [here](https://github.com/logos-co/logos-module-builder/blob/master/lib/modulePreConfigure.nix#L50-L59).

For now I've just added the fix for Service Disco headers, but this might affect other run-on line declarations in this header too. Probably worth checking @gmelodie.