### PR TITLE
chore: normalize module header so the LIDL codegen emits all methods

### DIFF
--- a/src/gossipsub.cpp
+++ b/src/gossipsub.cpp
@@ -96,7 +96,7 @@ StdLogosResult Libp2pModuleImpl::gossipsubUnsubscribe(const std::string& topic) 
     return {true, {}, ""};
 }
 
-StdLogosResult Libp2pModuleImpl::gossipsubNextMessage(const std::string& topic, int timeoutMs) {
+StdLogosResult Libp2pModuleImpl::gossipsubNextMessage(const std::string& topic, int64_t timeoutMs) {
     std::unique_lock<std::mutex> lock(m_queueMutex);
 
     // .find() avoids inserting an empty queue for every polled topic.

--- a/src/kademlia.cpp
+++ b/src/kademlia.cpp
@@ -26,7 +26,7 @@ StdLogosResult Libp2pModuleImpl::kadPutValue(const std::string& key, const std::
     });
 }
 
-StdLogosResult Libp2pModuleImpl::kadGetValue(const std::string& key, int quorum) {
+StdLogosResult Libp2pModuleImpl::kadGetValue(const std::string& key, int64_t quorum) {
     return callSyncWith("Failed to get value",
         [&](SyncPromise* p) {
             return libp2p_kad_get_value(

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -271,7 +271,7 @@ StdLogosResult Libp2pModuleImpl::peerInfo() {
         [](const SyncResult& r) { return parseJsonResponse(r.message, "peerInfo"); });
 }
 
-StdLogosResult Libp2pModuleImpl::connectedPeers(int direction) {
+StdLogosResult Libp2pModuleImpl::connectedPeers(int64_t direction) {
     return callSyncWith("Failed to get connected peers",
         [&](SyncPromise* p) {
             return libp2p_connected_peers(ctx, direction,

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -80,24 +80,19 @@ public:
     StdLogosResult publicKey();
     StdLogosResult newPrivateKey();
 
-    StdLogosResult connectPeer(const std::string& peerId,
-                               const std::vector<std::string>& multiaddrs,
-                               int64_t timeoutMs = -1);
+    StdLogosResult connectPeer(const std::string& peerId, const std::vector<std::string>& multiaddrs, int64_t timeoutMs);
     StdLogosResult disconnectPeer(const std::string& peerId);
     StdLogosResult peerInfo();
-    StdLogosResult connectedPeers(int direction);
+    StdLogosResult connectedPeers(int64_t direction);
     StdLogosResult dial(const std::string& peerId, const std::string& proto);
 
-    StdLogosResult circuitRelayReserve(const std::string& relayPeerId,
-                                       const std::vector<std::string>& relayAddrs);
-    StdLogosResult dialCircuitRelay(const std::string& dstPeerId,
-                                    const std::string& multiaddr,
-                                    const std::string& proto);
+    StdLogosResult circuitRelayReserve(const std::string& relayPeerId, const std::vector<std::string>& relayAddrs);
+    StdLogosResult dialCircuitRelay(const std::string& dstPeerId, const std::string& multiaddr, const std::string& proto);
 
     StdLogosResult mountProtocol(const std::string& proto);
 
-    StdLogosResult streamReadExactly(uint64_t streamId, size_t len);
-    StdLogosResult streamReadLp(uint64_t streamId, size_t maxSize);
+    StdLogosResult streamReadExactly(uint64_t streamId, uint64_t len);
+    StdLogosResult streamReadLp(uint64_t streamId, uint64_t maxSize);
     StdLogosResult streamWrite(uint64_t streamId, const std::string& data);
     StdLogosResult streamWriteLp(uint64_t streamId, const std::string& data);
     StdLogosResult streamClose(uint64_t streamId);
@@ -107,12 +102,12 @@ public:
     StdLogosResult gossipsubPublish(const std::string& topic, const std::string& data);
     StdLogosResult gossipsubSubscribe(const std::string& topic);
     StdLogosResult gossipsubUnsubscribe(const std::string& topic);
-    StdLogosResult gossipsubNextMessage(const std::string& topic, int timeoutMs);
+    StdLogosResult gossipsubNextMessage(const std::string& topic, int64_t timeoutMs);
 
     StdLogosResult toCid(const std::string& key);
     StdLogosResult kadFindNode(const std::string& peerId);
     StdLogosResult kadPutValue(const std::string& key, const std::string& value);
-    StdLogosResult kadGetValue(const std::string& key, int quorum);
+    StdLogosResult kadGetValue(const std::string& key, int64_t quorum);
     StdLogosResult kadAddProvider(const std::string& cid);
     StdLogosResult kadStartProviding(const std::string& cid);
     StdLogosResult kadStopProviding(const std::string& cid);
@@ -144,22 +139,18 @@ public:
 
     StdLogosResult discoStart();
     StdLogosResult discoStop();
-    StdLogosResult discoStartAdvertising(const std::string& serviceId, const std::string& serviceData = {});
+    StdLogosResult discoStartAdvertising(const std::string& serviceId, const std::string& serviceData);
     StdLogosResult discoStopAdvertising(const std::string& serviceId);
     StdLogosResult discoRegisterInterest(const std::string& serviceId);
     StdLogosResult discoUnregisterInterest(const std::string& serviceId);
-    StdLogosResult discoLookup(const std::string& serviceId, const std::string& serviceData = {});
+    StdLogosResult discoLookup(const std::string& serviceId, const std::string& serviceData);
     StdLogosResult discoRandomLookup();
 
     StdLogosResult peerstoreGetPeers();
     StdLogosResult peerstoreGetPeerInfo(const std::string& peerId);
-    StdLogosResult peerstoreAddPeer(const std::string& peerId,
-                                    const std::vector<std::string>& addrs,
-                                    const std::vector<std::string>& protos = {});
-    StdLogosResult peerstoreSetPeerAddresses(const std::string& peerId,
-                                             const std::vector<std::string>& addrs);
-    StdLogosResult peerstoreSetPeerProtocols(const std::string& peerId,
-                                             const std::vector<std::string>& protos);
+    StdLogosResult peerstoreAddPeer(const std::string& peerId, const std::vector<std::string>& addrs, const std::vector<std::string>& protos);
+    StdLogosResult peerstoreSetPeerAddresses(const std::string& peerId, const std::vector<std::string>& addrs);
+    StdLogosResult peerstoreSetPeerProtocols(const std::string& peerId, const std::vector<std::string>& protos);
     StdLogosResult peerstoreDeletePeer(const std::string& peerId);
 
     LogosMap collectMetrics();

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -69,7 +69,7 @@ StdLogosResult Libp2pModuleImpl::streamRelease(uint64_t streamId) {
     return {true, {}, ""};
 }
 
-StdLogosResult Libp2pModuleImpl::streamReadExactly(uint64_t streamId, size_t len) {
+StdLogosResult Libp2pModuleImpl::streamReadExactly(uint64_t streamId, uint64_t len) {
     return callSyncStreamWith(streamId, "Failed to read from stream",
         [&](libp2p_stream_t* s, SyncPromise* p) {
             return libp2p_stream_readExactly(ctx, s, len,
@@ -80,7 +80,7 @@ StdLogosResult Libp2pModuleImpl::streamReadExactly(uint64_t streamId, size_t len
         });
 }
 
-StdLogosResult Libp2pModuleImpl::streamReadLp(uint64_t streamId, size_t maxSize) {
+StdLogosResult Libp2pModuleImpl::streamReadLp(uint64_t streamId, uint64_t maxSize) {
     return callSyncStreamWith(streamId, "Failed to read LP from stream",
         [&](libp2p_stream_t* s, SyncPromise* p) {
             return libp2p_stream_readLp(ctx, s, maxSize,

--- a/tests/integration_service_discovery.cpp
+++ b/tests/integration_service_discovery.cpp
@@ -39,12 +39,12 @@ LOGOS_TEST(disco_advertise_and_lookup) {
     LOGOS_ASSERT_TRUE(nodeB.connectPeer(peerIdC, addrsC, 5000).success);
 
     std::string serviceId = "test-service";
-    LOGOS_ASSERT_TRUE(nodeA.discoStartAdvertising(serviceId).success);
+    LOGOS_ASSERT_TRUE(nodeA.discoStartAdvertising(serviceId, "").success);
     LOGOS_ASSERT_TRUE(nodeB.discoRegisterInterest(serviceId).success);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
-    auto res = nodeB.discoLookup(serviceId);
+    auto res = nodeB.discoLookup(serviceId, "");
     LOGOS_ASSERT_TRUE(res.success);
 
     auto records = res.value;
@@ -120,13 +120,13 @@ LOGOS_TEST(disco_start_stop_advertising) {
 
     std::string serviceId = "ephemeral-service";
 
-    LOGOS_ASSERT_TRUE(nodeA.discoStartAdvertising(serviceId).success);
+    LOGOS_ASSERT_TRUE(nodeA.discoStartAdvertising(serviceId, "").success);
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     LOGOS_ASSERT_TRUE(nodeA.discoStopAdvertising(serviceId).success);
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
-    auto res = nodeB.discoLookup(serviceId);
+    auto res = nodeB.discoLookup(serviceId, "");
     LOGOS_ASSERT_TRUE(res.success);
 
     auto records = res.value;

--- a/tests/sync.cpp
+++ b/tests/sync.cpp
@@ -8,7 +8,7 @@ LOGOS_TEST(sync_connect_disconnect_peer) {
     std::string fakePeer = "12D3KooWInvalidPeerForTest";
     std::vector<std::string> fakeAddrs = { "/ip4/127.0.0.1/tcp/9999" };
 
-    LOGOS_ASSERT_FALSE(plugin.connectPeer(fakePeer, fakeAddrs).success);
+    LOGOS_ASSERT_FALSE(plugin.connectPeer(fakePeer, fakeAddrs, -1).success);
     LOGOS_ASSERT_FALSE(plugin.disconnectPeer(fakePeer).success);
 
     LOGOS_ASSERT_TRUE(plugin.stop().success);


### PR DESCRIPTION
## Summary

The impl-header parser (`logos-cpp-generator --header-to-lidl`) is strictly line-based and **silently drops** declarations it can't parse — no error, just fewer methods in the generated LIDL/RPC interface. `src/plugin.h` is normalized so every `Libp2pModuleImpl` method is emitted correctly:

- **No default arguments.** `connectPeer`, `discoStartAdvertising`, `discoLookup`, `peerstoreAddPeer` drop their `= -1` / `= {}` defaults; callers pass explicit args. Impls already treat `-1` / empty string / empty vector as the "unset" sentinel, so no behavior change.
- **One physical line per declaration.** Multi-line decls (`connectPeer`, `peerstoreAddPeer`, `circuitRelayReserve`, `dialCircuitRelay`, `peerstoreSetPeerAddresses`, `peerstoreSetPeerProtocols`) are collapsed — multi-line decls are dropped entirely by the parser.
- **Fixed-width integer types.** `int` / `size_t` parameters fall back to opaque `any` in the LIDL, so they're replaced: `connectedPeers`, `kadGetValue`, `gossipsubNextMessage` → `int64_t`; `streamReadExactly`, `streamReadLp` → `uint64_t`. Matching definitions in `plugin.cpp`, `kademlia.cpp`, `gossipsub.cpp`, `stream.cpp` updated to match.

## Notes

Chose "callers pass explicit sentinels" over introducing `connectPeerWithTimeout`-style variants, to stay consistent with the existing sentinel convention and keep the method count down. The integer widenings are lossless for the value ranges in use (peer direction, quorum, timeout, lengths).

## Test plan

- Updated affected callers in `tests/` to pass explicit args (`discoLookup(id, "")`, `connectPeer(peer, addrs, -1)`).
- No runtime behavior change.
