### PR TITLE
feat: multi-node bootstrap service discovery example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,35 @@ Check the examples/ directory for complete usage demonstrations.
 
 ---
 
+# Configuration
+
+When the module is loaded by `logoscore`, it is constructed without arguments, so
+options are supplied through the `LIBP2P_MODULE_CONFIG` environment variable — set
+to either inline JSON or a path to a JSON file. The config is overlaid onto the
+defaults at load time; every key is optional, and an omitted key keeps its default.
+If the config is unset, unreadable, not valid JSON, or has a wrong-typed field, the
+module logs a warning and falls back to the full default options.
+
+```bash
+# inline
+export LIBP2P_MODULE_CONFIG='{
+  "addrs": ["/ip4/0.0.0.0/tcp/9000"],
+  "bootstrapNodes": [
+    { "peerId": "16Uiu2...", "addrs": ["/ip4/1.2.3.4/tcp/9000"] }
+  ],
+  "transport": "tcp"
+}'
+
+# or a file
+export LIBP2P_MODULE_CONFIG=/etc/logos/libp2p.json
+```
+
+See the `config` section of [`metadata.json`](./metadata.json) for the full schema.
+Code that constructs `Libp2pModuleImpl` directly (examples, tests) passes
+`Libp2pModuleOptions` to the constructor and bypasses this path.
+
+---
+
 # Building
 Currently the recommended and supported building way is using Nix
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,6 +23,12 @@ use cases using the `logos-libp2p-module`.
   - Publishing to that topic
   - Receiving the message on the subscribed topic
 
+- [Service Discovery](service_discovery.cpp) — Demonstrates the Service Discovery API over a multi-node DHT with a bootstrap node:
+  - Anchoring a DHT with a bootstrap node
+  - Advertising a named service (`discoStartAdvertising`)
+  - Registering interest and looking it up from another node (`discoRegisterInterest` / `discoLookup`)
+  - Resolving the advertiser's peer record (peerId, seqNo, addrs)
+
 ## Building
 Enter the development shell and configure cmake
 
@@ -43,5 +49,6 @@ After building, run the executable from the build directory:
 ./build/examples/example_ping
 ./build/examples/example_kademlia
 ./build/examples/example_gossipsub
+./build/examples/example_service_discovery
 ```
 

--- a/examples/service_discovery.cpp
+++ b/examples/service_discovery.cpp
@@ -1,97 +1,137 @@
 #include <cstdio>
 #include <thread>
 #include <chrono>
+#include <string>
+#include <utility>
+#include <vector>
 #include "plugin.h"
+
+static std::pair<std::string, std::vector<std::string>> peerInfoOf(Libp2pModuleImpl& node)
+{
+    auto info = node.peerInfo().value;
+    std::string peerId = info["peerId"].get<std::string>();
+    std::vector<std::string> addrs;
+    for (const auto& a : info["addrs"]) addrs.push_back(a.get<std::string>());
+    return {peerId, addrs};
+}
+
+static nlohmann::json lookupUntilFound(Libp2pModuleImpl& node,
+                                       const std::string& serviceId,
+                                       const std::string& serviceData,
+                                       int attempts, int delayMs)
+{
+    for (int i = 0; i < attempts; ++i) {
+        auto res = node.discoLookup(serviceId, serviceData);
+        if (res.success && !res.value.empty()) {
+            return res.value;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
+    }
+    return nlohmann::json::array();
+}
 
 int main()
 {
-    Libp2pModuleImpl nodeA(Libp2pModuleOptions{ .mountServiceDiscovery = true });
-    Libp2pModuleImpl nodeB(Libp2pModuleOptions{ .mountServiceDiscovery = true });
-
     printf("Starting nodes...\n");
 
-    if (!nodeA.start().success) {
-        fprintf(stderr, "Node A failed to start\n");
+    Libp2pModuleImpl bootstrap;
+    if (!bootstrap.start().success) {
+        fprintf(stderr, "Bootstrap node failed to start\n");
+        return 1;
+    }
+    if (!bootstrap.discoStart().success) {
+        fprintf(stderr, "Bootstrap node: discoStart failed\n");
+        return 1;
+    }
+    auto [bootstrapId, bootstrapAddrs] = peerInfoOf(bootstrap);
+
+    // connectPeer below forces an immediate connection instead of waiting on background bootstrap.
+    Libp2pModuleImpl advertiser(Libp2pModuleOptions{
+        .bootstrapNodes = { {bootstrapId, bootstrapAddrs} }
+    });
+    if (!advertiser.start().success) {
+        fprintf(stderr, "Advertiser failed to start\n");
+        return 1;
+    }
+    if (!advertiser.discoStart().success) {
+        fprintf(stderr, "Advertiser: discoStart failed\n");
+        return 1;
+    }
+    if (!advertiser.connectPeer(bootstrapId, bootstrapAddrs, 5000).success) {
+        fprintf(stderr, "Advertiser failed to connect to bootstrap\n");
         return 1;
     }
 
-    if (!nodeB.start().success) {
-        fprintf(stderr, "Node B failed to start\n");
+    Libp2pModuleImpl discoverer(Libp2pModuleOptions{
+        .bootstrapNodes = { {bootstrapId, bootstrapAddrs} }
+    });
+    if (!discoverer.start().success) {
+        fprintf(stderr, "Discoverer failed to start\n");
         return 1;
     }
-
-    if (!nodeA.discoStart().success) {
-        fprintf(stderr, "Node A: discoStart failed\n");
+    if (!discoverer.discoStart().success) {
+        fprintf(stderr, "Discoverer: discoStart failed\n");
         return 1;
     }
-
-    if (!nodeB.discoStart().success) {
-        fprintf(stderr, "Node B: discoStart failed\n");
-        return 1;
-    }
-
-    auto infoA = nodeA.peerInfo().value;
-    std::string peerIdA = infoA["peerId"].get<std::string>();
-    std::vector<std::string> addrsA;
-    for (const auto& a : infoA["addrs"]) addrsA.push_back(a.get<std::string>());
-
-    if (!nodeB.connectPeer(peerIdA, addrsA, 500).success) {
-        fprintf(stderr, "Node B failed to connect to Node A\n");
+    if (!discoverer.connectPeer(bootstrapId, bootstrapAddrs, 5000).success) {
+        fprintf(stderr, "Discoverer failed to connect to bootstrap\n");
         return 1;
     }
 
     std::string serviceId = "demo-service";
     std::string serviceData = "version=1";
 
-    printf("Node A: starting advertising %s\n", serviceId.c_str());
-    if (!nodeA.discoStartAdvertising(serviceId, serviceData).success) {
-        fprintf(stderr, "Node A: discoStartAdvertising failed\n");
+    printf("Advertiser: advertising %s\n", serviceId.c_str());
+    if (!advertiser.discoStartAdvertising(serviceId, serviceData).success) {
+        fprintf(stderr, "Advertiser: discoStartAdvertising failed\n");
         return 1;
     }
 
-    printf("Node B: registering interest in %s\n", serviceId.c_str());
-    if (!nodeB.discoRegisterInterest(serviceId).success) {
-        fprintf(stderr, "Node B: discoRegisterInterest failed\n");
+    printf("Discoverer: registering interest in %s\n", serviceId.c_str());
+    if (!discoverer.discoRegisterInterest(serviceId).success) {
+        fprintf(stderr, "Discoverer: discoRegisterInterest failed\n");
         return 1;
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    printf("Discoverer: looking up %s\n", serviceId.c_str());
+    constexpr int lookupAttempts = 20;
+    constexpr int lookupDelayMs = 250; // ~5s total to let the advertisement propagate
+    auto records = lookupUntilFound(discoverer, serviceId, serviceData, lookupAttempts, lookupDelayMs);
 
-    printf("Node B: looking up %s\n", serviceId.c_str());
-    auto res = nodeB.discoLookup(serviceId, serviceData);
-
-    if (!res.success) {
-        printf("Lookup returned no results\n");
-    } else {
-        auto records = res.value;
-        printf("Node B found %zu peer(s) advertising %s\n", records.size(), serviceId.c_str());
-        for (const auto& rec : records) {
-            printf("  peer: %s seq: %llu addrs: %zu\n",
-                   rec["peerId"].get<std::string>().c_str(),
-                   (unsigned long long)rec["seqNo"].get<uint64_t>(),
-                   rec["addrs"].size());
-        }
+    printf("Discoverer found %zu peer(s) advertising %s\n", records.size(), serviceId.c_str());
+    for (const auto& rec : records) {
+        printf("  peer: %s seq: %llu addrs: %zu\n",
+               rec["peerId"].get<std::string>().c_str(),
+               (unsigned long long)rec["seqNo"].get<uint64_t>(),
+               rec["addrs"].size());
     }
 
-    printf("Node A: random lookup\n");
-    auto randRes = nodeA.discoRandomLookup();
+    std::string advertiserId = peerInfoOf(advertiser).first;
+    bool matched = !records.empty() && records[0]["peerId"].get<std::string>() == advertiserId;
+    printf(matched ? "Discoverer matched the advertiser: %s\n"
+                   : "Discoverer did not find the advertiser (%s) yet\n",
+           advertiserId.c_str());
+
+    printf("Advertiser: random lookup\n");
+    auto randRes = advertiser.discoRandomLookup();
     if (randRes.success) {
         printf("Random lookup returned %zu peer(s)\n", randRes.value.size());
     }
 
-    printf("Node B: unregistering interest in %s\n", serviceId.c_str());
-    nodeB.discoUnregisterInterest(serviceId);
+    printf("Discoverer: unregistering interest in %s\n", serviceId.c_str());
+    discoverer.discoUnregisterInterest(serviceId);
 
-    printf("Node A: stopping advertising %s\n", serviceId.c_str());
-    nodeA.discoStopAdvertising(serviceId);
+    printf("Advertiser: stopping advertising %s\n", serviceId.c_str());
+    advertiser.discoStopAdvertising(serviceId);
 
-    nodeA.discoStop();
-    nodeB.discoStop();
+    discoverer.discoStop();
+    advertiser.discoStop();
+    bootstrap.discoStop();
 
-    nodeA.stop();
-    nodeB.stop();
+    discoverer.stop();
+    advertiser.stop();
+    bootstrap.stop();
 
     printf("Done\n");
-
     return 0;
 }

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,29 @@
     "include": ["libp2p.so", "libp2p.dylib", "libp2p.dll"],
     "capabilities": [],
 
+    "config": {
+        "env": "LIBP2P_MODULE_CONFIG",
+        "description": "JSON config — inline, or a path to a JSON file — overlaid onto the default options when the module is loaded. Every key is optional; an omitted key keeps its default.",
+        "schema": {
+            "addrs": "array<multiaddr string> — listen addresses",
+            "bootstrapNodes": "array<{ peerId: string, addrs: array<multiaddr string> }> — DHT bootstrap peers",
+            "transport": "string — \"tcp\" | \"quic\" (\"quic-v1\" accepted as an alias for \"quic\")",
+            "maxConnections": "int",
+            "maxInConnections": "int",
+            "maxOutConnections": "int",
+            "maxConnsPerPeer": "int",
+            "autonat": "bool",
+            "autonatV2": "bool",
+            "autonatV2Server": "bool",
+            "circuitRelay": "bool",
+            "circuitRelayClient": "bool",
+            "gossipsubTriggerSelf": "bool",
+            "mountGossipsub": "bool",
+            "mountKad": "bool",
+            "mountServiceDiscovery": "bool"
+        }
+    },
+
     "nix": {
         "packages": {
             "runtime": ["nlohmann_json"]

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -2,12 +2,16 @@
 
 #include <atomic>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
 #include <functional>
 #include <map>
 #include <future>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -39,7 +43,98 @@ struct Libp2pModuleOptions {
     bool mountGossipsub = true;
     bool mountKad = true;
     bool mountServiceDiscovery = true;
+
+    /// Builds options from the LIBP2P_MODULE_CONFIG deployment config (codegen
+    /// default-constructs a loaded module). See readme; absent/invalid → defaults.
+    static Libp2pModuleOptions load();
 };
+
+namespace libp2p_module_config {
+
+/// Reads LIBP2P_MODULE_CONFIG: inline JSON when the first non-space char is '{',
+/// otherwise a path to a JSON file. Returns "" when unset or unreadable.
+inline std::string readSource() {
+    const char* cfg = std::getenv("LIBP2P_MODULE_CONFIG");
+    if (!cfg || !*cfg) {
+        return "";
+    }
+    std::string value(cfg);
+    auto firstChar = value.find_first_not_of(" \t\r\n");
+    if (firstChar != std::string::npos && value[firstChar] == '{') {
+        return value;
+    }
+    std::ifstream f(value);
+    if (!f) {
+        fprintf(stderr, "libp2p_module: cannot read config file %s\n", value.c_str());
+        return "";
+    }
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+inline int parseTransport(const nlohmann::json& j, int fallback) {
+    auto it = j.find("transport");
+    if (it == j.end() || !it->is_string()) {
+        return fallback;
+    }
+    std::string t = it->get<std::string>();
+    if (t == "tcp") return LIBP2P_TRANSPORT_TCP;
+    if (t == "quic" || t == "quic-v1") return LIBP2P_TRANSPORT_QUIC;
+    return fallback;
+}
+
+/// Overlays present keys onto `o`. Throws nlohmann type_error on a wrong-typed
+/// field; load() catches it and falls back to defaults.
+inline void apply(const nlohmann::json& j, Libp2pModuleOptions& o) {
+    if (!j.is_object()) {
+        return;
+    }
+    o.addrs = j.value("addrs", o.addrs);
+    if (auto it = j.find("bootstrapNodes"); it != j.end() && it->is_array()) {
+        o.bootstrapNodes.clear();
+        for (const auto& n : *it) {
+            o.bootstrapNodes.emplace_back(n.value("peerId", std::string{}),
+                                          n.value("addrs", std::vector<std::string>{}));
+        }
+    }
+    o.transport = parseTransport(j, o.transport);
+    o.autonat = j.value("autonat", o.autonat);
+    o.autonatV2 = j.value("autonatV2", o.autonatV2);
+    o.autonatV2Server = j.value("autonatV2Server", o.autonatV2Server);
+    o.circuitRelay = j.value("circuitRelay", o.circuitRelay);
+    o.circuitRelayClient = j.value("circuitRelayClient", o.circuitRelayClient);
+    o.maxConnections = j.value("maxConnections", o.maxConnections);
+    o.maxInConnections = j.value("maxInConnections", o.maxInConnections);
+    o.maxOutConnections = j.value("maxOutConnections", o.maxOutConnections);
+    o.maxConnsPerPeer = j.value("maxConnsPerPeer", o.maxConnsPerPeer);
+    o.gossipsubTriggerSelf = j.value("gossipsubTriggerSelf", o.gossipsubTriggerSelf);
+    o.mountGossipsub = j.value("mountGossipsub", o.mountGossipsub);
+    o.mountKad = j.value("mountKad", o.mountKad);
+    o.mountServiceDiscovery = j.value("mountServiceDiscovery", o.mountServiceDiscovery);
+}
+
+} // namespace libp2p_module_config
+
+inline Libp2pModuleOptions Libp2pModuleOptions::load() {
+    std::string raw = libp2p_module_config::readSource();
+    if (raw.empty()) {
+        return {};
+    }
+    auto j = nlohmann::json::parse(raw, nullptr, false);
+    if (j.is_discarded()) {
+        fprintf(stderr, "libp2p_module: ignoring invalid LIBP2P_MODULE_CONFIG\n");
+        return {};
+    }
+    Libp2pModuleOptions opts;
+    try {
+        libp2p_module_config::apply(j, opts);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "libp2p_module: ignoring invalid LIBP2P_MODULE_CONFIG: %s\n", e.what());
+        return {};
+    }
+    return opts;
+}
 
 // Result type for internal sync-over-async operations.
 struct SyncResult {
@@ -115,7 +210,7 @@ inline void to_json(nlohmann::json& j, const Metric& m) {
 
 class Libp2pModuleImpl {
 public:
-    Libp2pModuleImpl(const Libp2pModuleOptions& options = {});
+    Libp2pModuleImpl(const Libp2pModuleOptions& options = Libp2pModuleOptions::load());
     ~Libp2pModuleImpl();
 
     std::function<void(const std::string& eventName, const std::string& data)> emitEvent;

--- a/tests/config.cpp
+++ b/tests/config.cpp
@@ -1,6 +1,122 @@
 #include <logos_test.h>
 #include <plugin.h>
 
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <unistd.h>
+
+namespace {
+// Sets LIBP2P_MODULE_CONFIG for the test body and restores it on scope exit so
+// later default-constructed plugins don't pick up a stale config.
+struct ScopedModuleConfig {
+    explicit ScopedModuleConfig(const std::string& value) {
+        setenv("LIBP2P_MODULE_CONFIG", value.c_str(), 1);
+    }
+    ~ScopedModuleConfig() { unsetenv("LIBP2P_MODULE_CONFIG"); }
+};
+}
+
+LOGOS_TEST(config_from_json_overlay) {
+    auto j = nlohmann::json::parse(R"({
+        "addrs": ["/ip4/0.0.0.0/tcp/9000"],
+        "bootstrapNodes": [
+            {"peerId": "16Uiu2bootstrap", "addrs": ["/ip4/1.2.3.4/tcp/9000", "/ip4/1.2.3.4/udp/9000/quic-v1"]}
+        ],
+        "transport": "quic",
+        "maxConnections": 200,
+        "mountServiceDiscovery": false
+    })");
+
+    Libp2pModuleOptions opts;
+    libp2p_module_config::apply(j, opts);
+
+    LOGOS_ASSERT_EQ(opts.addrs.size(), 1u);
+    LOGOS_ASSERT_TRUE(opts.addrs[0] == "/ip4/0.0.0.0/tcp/9000");
+    LOGOS_ASSERT_EQ(opts.bootstrapNodes.size(), 1u);
+    LOGOS_ASSERT_TRUE(opts.bootstrapNodes[0].first == "16Uiu2bootstrap");
+    LOGOS_ASSERT_EQ(opts.bootstrapNodes[0].second.size(), 2u);
+    LOGOS_ASSERT_EQ(opts.transport, LIBP2P_TRANSPORT_QUIC);
+    LOGOS_ASSERT_EQ(opts.maxConnections, 200);
+    LOGOS_ASSERT_FALSE(opts.mountServiceDiscovery);
+    // Untouched keys keep their defaults.
+    LOGOS_ASSERT_TRUE(opts.mountKad);
+    LOGOS_ASSERT_EQ(opts.maxInConnections, 25);
+}
+
+LOGOS_TEST(config_from_json_partial_keeps_defaults) {
+    auto j = nlohmann::json::parse(R"({"maxConnsPerPeer": 4})");
+
+    Libp2pModuleOptions opts;
+    libp2p_module_config::apply(j, opts);
+
+    LOGOS_ASSERT_EQ(opts.maxConnsPerPeer, 4);
+    LOGOS_ASSERT_TRUE(opts.addrs.empty());
+    LOGOS_ASSERT_TRUE(opts.bootstrapNodes.empty());
+    LOGOS_ASSERT_EQ(opts.transport, LIBP2P_TRANSPORT_TCP);
+}
+
+LOGOS_TEST(config_load_unset_returns_defaults) {
+    unsetenv("LIBP2P_MODULE_CONFIG");
+    Libp2pModuleOptions opts = Libp2pModuleOptions::load();
+    LOGOS_ASSERT_TRUE(opts.addrs.empty());
+    LOGOS_ASSERT_TRUE(opts.bootstrapNodes.empty());
+    LOGOS_ASSERT_EQ(opts.transport, LIBP2P_TRANSPORT_TCP);
+}
+
+LOGOS_TEST(config_load_inline_json) {
+    ScopedModuleConfig cfg(R"({"addrs": ["/ip4/0.0.0.0/tcp/7000"], "transport": "quic"})");
+
+    Libp2pModuleOptions opts = Libp2pModuleOptions::load();
+    LOGOS_ASSERT_EQ(opts.addrs.size(), 1u);
+    LOGOS_ASSERT_TRUE(opts.addrs[0] == "/ip4/0.0.0.0/tcp/7000");
+    LOGOS_ASSERT_EQ(opts.transport, LIBP2P_TRANSPORT_QUIC);
+}
+
+LOGOS_TEST(config_load_inline_json_leading_whitespace) {
+    ScopedModuleConfig cfg("  \n\t{\"transport\": \"quic\"}");
+
+    Libp2pModuleOptions opts = Libp2pModuleOptions::load();
+    LOGOS_ASSERT_EQ(opts.transport, LIBP2P_TRANSPORT_QUIC);
+}
+
+LOGOS_TEST(config_load_from_file) {
+    char path[] = "/tmp/libp2p_module_test_config.XXXXXX";
+    int fd = mkstemp(path);
+    LOGOS_ASSERT_TRUE(fd != -1);
+    close(fd);
+    {
+        std::ofstream f(path);
+        f << R"({"bootstrapNodes": [{"peerId": "16Uiu2file", "addrs": ["/ip4/9.9.9.9/tcp/9000"]}]})";
+    }
+    ScopedModuleConfig cfg(path);
+
+    Libp2pModuleOptions opts = Libp2pModuleOptions::load();
+    LOGOS_ASSERT_EQ(opts.bootstrapNodes.size(), 1u);
+    LOGOS_ASSERT_TRUE(opts.bootstrapNodes[0].first == "16Uiu2file");
+    LOGOS_ASSERT_TRUE(opts.bootstrapNodes[0].second[0] == "/ip4/9.9.9.9/tcp/9000");
+
+    std::remove(path);
+}
+
+LOGOS_TEST(config_load_invalid_json_returns_defaults) {
+    ScopedModuleConfig cfg("{not valid json");
+
+    Libp2pModuleOptions opts = Libp2pModuleOptions::load();
+    LOGOS_ASSERT_TRUE(opts.addrs.empty());
+    LOGOS_ASSERT_TRUE(opts.bootstrapNodes.empty());
+    LOGOS_ASSERT_EQ(opts.transport, LIBP2P_TRANSPORT_TCP);
+}
+
+// Valid JSON but a wrong-typed field must not throw out of construction.
+LOGOS_TEST(config_load_wrong_field_type_returns_defaults) {
+    ScopedModuleConfig cfg(R"({"maxConnections": "not-a-number"})");
+
+    Libp2pModuleOptions opts = Libp2pModuleOptions::load();
+    LOGOS_ASSERT_EQ(opts.maxConnections, 50);
+    LOGOS_ASSERT_TRUE(opts.addrs.empty());
+}
+
 LOGOS_TEST(config_options_defaults) {
     Libp2pModuleOptions opts;
     LOGOS_ASSERT_TRUE(opts.addrs.empty());


### PR DESCRIPTION
## Summary

Two related changes:

1. **Service Discovery example** now demonstrates real cross-node discovery. It went from two directly-connected nodes (where `discoLookup` returned `[]` and looked broken) to a three-node bootstrap topology — a bootstrap node anchors the DHT, an advertiser and a discoverer bootstrap off it, and the discoverer resolves the advertiser through the DHT.
2. **Module config plumbing** so a `logoscore`-loaded module can be pointed at listen addrs / bootstrap nodes. Since loaded modules are default-constructed, options come from the `LIBP2P_MODULE_CONFIG` env var (inline JSON or a path to a JSON file), overlaid onto the defaults at construction.

## Changes

- `examples/service_discovery.cpp` — three-node bootstrap topology; lookup polls until a peer appears instead of a fixed sleep; soft-reports match/no-match (exit 0) so it stays a teaching example.
- `src/plugin.h` — `Libp2pModuleOptions::load()` reads `LIBP2P_MODULE_CONFIG` and overlays it onto the defaults. Unset / unreadable / invalid-JSON / wrong-typed field all log a warning and fall back to defaults (never throws out of construction).
- `metadata.json` / `README.md` / `examples/README.md` — document the env var, schema, and the new example.
- `tests/config.cpp` — overlay, partial config, env inline/file, and the fallback cases.
