### PR TITLE
chore: bump nix-bundle-lgx

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,62 @@
 {
   "nodes": {
+    "default-container": {
+      "inputs": {
+        "logos-container": "logos-container",
+        "logos-nix": "logos-nix_168",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "default-container",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781741375,
+        "narHash": "sha256-PP/2tFfwrbqTzbZKVl46I96xz/ZZj7hi9C3/QeLHtQE=",
+        "owner": "logos-co",
+        "repo": "logos-container-subprocess",
+        "rev": "f4860708a982b361a2e25c5260e13800bcee126e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-container-subprocess",
+        "type": "github"
+      }
+    },
+    "default-module-loader": {
+      "inputs": {
+        "logos-container": "logos-container_2",
+        "logos-cpp-sdk": "logos-cpp-sdk_18",
+        "logos-module": "logos-module_23",
+        "logos-module-loader": "logos-module-loader",
+        "logos-nix": "logos-nix_174",
+        "logos-protocol": "logos-protocol_3",
+        "logos-qt-sdk": "logos-qt-sdk_3",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781741734,
+        "narHash": "sha256-GHyeMvVho8AWDeWb8cKQQLU0dIM0ynsnrJkvS2Q6Ihs=",
+        "owner": "logos-co",
+        "repo": "logos-module-loader-qt",
+        "rev": "331760de70938e98a8756aaf2cdbe99e763376f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module-loader-qt",
+        "type": "github"
+      }
+    },
     "libp2p": {
       "inputs": {
         "nixpkgs": "nixpkgs"
@@ -42,11 +99,11 @@
         "logos-module-builder": "logos-module-builder_5"
       },
       "locked": {
-        "lastModified": 1781129198,
-        "narHash": "sha256-vnJCkDQlGKXStnXFGhATzY3dXwwQT4/nnljReFmAzQc=",
+        "lastModified": 1781210397,
+        "narHash": "sha256-LaQ5EuAVZeW6H2JUaBXtXfke6ZZvsqgE9qfeFueKAHI=",
         "owner": "logos-co",
         "repo": "logos-capability-module",
-        "rev": "5d438961e2defe72b76028150787d59e586eec8c",
+        "rev": "13441afc8e8af8cfd22d6e007c6f46874eac97d9",
         "type": "github"
       },
       "original": {
@@ -57,32 +114,14 @@
     },
     "logos-capability-module_11": {
       "inputs": {
-        "logos-cpp-sdk": [
-          "logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk"
-        ],
-        "logos-module": "logos-module_26",
-        "logos-nix": "logos-nix_175",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix",
-          "nixpkgs"
-        ]
+        "logos-module-builder": "logos-module-builder_6"
       },
       "locked": {
-        "lastModified": 1774455138,
-        "narHash": "sha256-szx2dnnY9MP1NpdBnR8E2DRSz9CtQlo/6698zgJcAEM=",
+        "lastModified": 1780946924,
+        "narHash": "sha256-8wFILW1oMS1L77Ff4bcC/5W9dytNe6I1rhf5AHhQW2U=",
         "owner": "logos-co",
         "repo": "logos-capability-module",
-        "rev": "0655be68e0078bede0682bb6a5b53330dac37a72",
+        "rev": "0013e7653eb1b23d5495e39f149259bd60dc1db4",
         "type": "github"
       },
       "original": {
@@ -93,17 +132,28 @@
     },
     "logos-capability-module_12": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_20",
-        "logos-module": "logos-module_27",
-        "logos-nix": "logos-nix_180",
+        "logos-cpp-sdk": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-module": "logos-module_30",
+        "logos-nix": "logos-nix_192",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-nix",
           "nixpkgs"
         ]
@@ -124,42 +174,20 @@
     },
     "logos-capability-module_13": {
       "inputs": {
-        "logos-module-builder": "logos-module-builder_6"
-      },
-      "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "type": "github"
-      }
-    },
-    "logos-capability-module_14": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk"
-        ],
-        "logos-module": "logos-module_33",
-        "logos-nix": "logos-nix_231",
+        "logos-cpp-sdk": "logos-cpp-sdk_22",
+        "logos-module": "logos-module_31",
+        "logos-nix": "logos-nix_197",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-nix",
           "nixpkgs"
         ]
@@ -178,20 +206,50 @@
         "type": "github"
       }
     },
+    "logos-capability-module_14": {
+      "inputs": {
+        "logos-module-builder": "logos-module-builder_7"
+      },
+      "locked": {
+        "lastModified": 1778182598,
+        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
     "logos-capability-module_15": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_25",
-        "logos-module": "logos-module_34",
-        "logos-nix": "logos-nix_236",
-        "nixpkgs": [
+        "logos-cpp-sdk": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-module": "logos-module_36",
+        "logos-nix": "logos-nix_236",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-nix",
           "nixpkgs"
         ]
@@ -212,69 +270,16 @@
     },
     "logos-capability-module_16": {
       "inputs": {
-        "logos-module-builder": "logos-module-builder_7"
-      },
-      "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "type": "github"
-      }
-    },
-    "logos-capability-module_17": {
-      "inputs": {
-        "logos-cpp-sdk": [
+        "logos-cpp-sdk": "logos-cpp-sdk_27",
+        "logos-module": "logos-module_37",
+        "logos-nix": "logos-nix_241",
+        "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk"
-        ],
-        "logos-module": "logos-module_40",
-        "logos-nix": "logos-nix_282",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455138,
-        "narHash": "sha256-szx2dnnY9MP1NpdBnR8E2DRSz9CtQlo/6698zgJcAEM=",
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "rev": "0655be68e0078bede0682bb6a5b53330dac37a72",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "type": "github"
-      }
-    },
-    "logos-capability-module_18": {
-      "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_30",
-        "logos-module": "logos-module_41",
-        "logos-nix": "logos-nix_287",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -298,7 +303,7 @@
         "type": "github"
       }
     },
-    "logos-capability-module_19": {
+    "logos-capability-module_17": {
       "inputs": {
         "logos-module-builder": "logos-module-builder_8"
       },
@@ -308,6 +313,76 @@
         "owner": "logos-co",
         "repo": "logos-capability-module",
         "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
+    "logos-capability-module_18": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-module": "logos-module_44",
+        "logos-nix": "logos-nix_323",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455138,
+        "narHash": "sha256-szx2dnnY9MP1NpdBnR8E2DRSz9CtQlo/6698zgJcAEM=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "0655be68e0078bede0682bb6a5b53330dac37a72",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
+    "logos-capability-module_19": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_34",
+        "logos-module": "logos-module_45",
+        "logos-nix": "logos-nix_328",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455138,
+        "narHash": "sha256-szx2dnnY9MP1NpdBnR8E2DRSz9CtQlo/6698zgJcAEM=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "0655be68e0078bede0682bb6a5b53330dac37a72",
         "type": "github"
       },
       "original": {
@@ -354,36 +429,14 @@
     },
     "logos-capability-module_20": {
       "inputs": {
-        "logos-cpp-sdk": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk"
-        ],
-        "logos-module": "logos-module_46",
-        "logos-nix": "logos-nix_325",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix",
-          "nixpkgs"
-        ]
+        "logos-module-builder": "logos-module-builder_9"
       },
       "locked": {
-        "lastModified": 1774455138,
-        "narHash": "sha256-szx2dnnY9MP1NpdBnR8E2DRSz9CtQlo/6698zgJcAEM=",
+        "lastModified": 1778182598,
+        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
         "owner": "logos-co",
         "repo": "logos-capability-module",
-        "rev": "0655be68e0078bede0682bb6a5b53330dac37a72",
+        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
         "type": "github"
       },
       "original": {
@@ -394,19 +447,24 @@
     },
     "logos-capability-module_21": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_35",
-        "logos-module": "logos-module_47",
-        "logos-nix": "logos-nix_330",
+        "logos-cpp-sdk": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-module": "logos-module_51",
+        "logos-nix": "logos-nix_374",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-nix",
           "nixpkgs"
         ]
@@ -427,46 +485,18 @@
     },
     "logos-capability-module_22": {
       "inputs": {
-        "logos-module-builder": "logos-module-builder_9"
-      },
-      "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "type": "github"
-      }
-    },
-    "logos-capability-module_23": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk"
-        ],
-        "logos-module": "logos-module_53",
+        "logos-cpp-sdk": "logos-cpp-sdk_39",
+        "logos-module": "logos-module_52",
         "logos-nix": "logos-nix_379",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-nix",
           "nixpkgs"
         ]
@@ -485,22 +515,46 @@
         "type": "github"
       }
     },
+    "logos-capability-module_23": {
+      "inputs": {
+        "logos-module-builder": "logos-module-builder_10"
+      },
+      "locked": {
+        "lastModified": 1778182598,
+        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
     "logos-capability-module_24": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_41",
-        "logos-module": "logos-module_54",
-        "logos-nix": "logos-nix_384",
-        "nixpkgs": [
+        "logos-cpp-sdk": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-module": "logos-module_57",
+        "logos-nix": "logos-nix_417",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-nix",
           "nixpkgs"
         ]
@@ -521,46 +575,19 @@
     },
     "logos-capability-module_25": {
       "inputs": {
-        "logos-module-builder": "logos-module-builder_10"
-      },
-      "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "type": "github"
-      }
-    },
-    "logos-capability-module_26": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk"
-        ],
-        "logos-module": "logos-module_60",
-        "logos-nix": "logos-nix_430",
+        "logos-cpp-sdk": "logos-cpp-sdk_44",
+        "logos-module": "logos-module_58",
+        "logos-nix": "logos-nix_422",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-nix",
           "nixpkgs"
         ]
@@ -579,22 +606,48 @@
         "type": "github"
       }
     },
+    "logos-capability-module_26": {
+      "inputs": {
+        "logos-module-builder": "logos-module-builder_11"
+      },
+      "locked": {
+        "lastModified": 1778182598,
+        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
     "logos-capability-module_27": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_46",
-        "logos-module": "logos-module_61",
-        "logos-nix": "logos-nix_435",
+        "logos-cpp-sdk": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-module": "logos-module_64",
+        "logos-nix": "logos-nix_471",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-nix",
           "nixpkgs"
         ]
@@ -615,48 +668,20 @@
     },
     "logos-capability-module_28": {
       "inputs": {
-        "logos-module-builder": "logos-module-builder_11"
-      },
-      "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "type": "github"
-      }
-    },
-    "logos-capability-module_29": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk"
-        ],
-        "logos-module": "logos-module_66",
-        "logos-nix": "logos-nix_473",
+        "logos-cpp-sdk": "logos-cpp-sdk_50",
+        "logos-module": "logos-module_65",
+        "logos-nix": "logos-nix_476",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-nix",
           "nixpkgs"
         ]
@@ -667,6 +692,24 @@
         "owner": "logos-co",
         "repo": "logos-capability-module",
         "rev": "0655be68e0078bede0682bb6a5b53330dac37a72",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
+    "logos-capability-module_29": {
+      "inputs": {
+        "logos-module-builder": "logos-module-builder_12"
+      },
+      "locked": {
+        "lastModified": 1778182598,
+        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
         "type": "github"
       },
       "original": {
@@ -708,21 +751,28 @@
     },
     "logos-capability-module_30": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_51",
-        "logos-module": "logos-module_67",
-        "logos-nix": "logos-nix_478",
+        "logos-cpp-sdk": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-module": "logos-module_71",
+        "logos-nix": "logos-nix_522",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-nix",
           "nixpkgs"
         ]
@@ -743,24 +793,20 @@
     },
     "logos-capability-module_31": {
       "inputs": {
-        "logos-cpp-sdk": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk"
-        ],
-        "logos-module": "logos-module_73",
-        "logos-nix": "logos-nix_539",
+        "logos-cpp-sdk": "logos-cpp-sdk_55",
+        "logos-module": "logos-module_72",
+        "logos-nix": "logos-nix_527",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-nix",
           "nixpkgs"
         ]
@@ -781,9 +827,144 @@
     },
     "logos-capability-module_32": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_57",
-        "logos-module": "logos-module_74",
-        "logos-nix": "logos-nix_544",
+        "logos-module-builder": "logos-module-builder_13"
+      },
+      "locked": {
+        "lastModified": 1778182598,
+        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
+    "logos-capability-module_33": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-module": "logos-module_77",
+        "logos-nix": "logos-nix_565",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455138,
+        "narHash": "sha256-szx2dnnY9MP1NpdBnR8E2DRSz9CtQlo/6698zgJcAEM=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "0655be68e0078bede0682bb6a5b53330dac37a72",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
+    "logos-capability-module_34": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_60",
+        "logos-module": "logos-module_78",
+        "logos-nix": "logos-nix_570",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455138,
+        "narHash": "sha256-szx2dnnY9MP1NpdBnR8E2DRSz9CtQlo/6698zgJcAEM=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "0655be68e0078bede0682bb6a5b53330dac37a72",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
+    "logos-capability-module_35": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-module": "logos-module_84",
+        "logos-nix": "logos-nix_631",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455138,
+        "narHash": "sha256-szx2dnnY9MP1NpdBnR8E2DRSz9CtQlo/6698zgJcAEM=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "0655be68e0078bede0682bb6a5b53330dac37a72",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
+    "logos-capability-module_36": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_66",
+        "logos-module": "logos-module_85",
+        "logos-nix": "logos-nix_636",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -811,149 +992,16 @@
         "type": "github"
       }
     },
-    "logos-capability-module_33": {
-      "inputs": {
-        "logos-module-builder": "logos-module-builder_14"
-      },
-      "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "type": "github"
-      }
-    },
-    "logos-capability-module_34": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk"
-        ],
-        "logos-module": "logos-module_82",
-        "logos-nix": "logos-nix_601",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455138,
-        "narHash": "sha256-szx2dnnY9MP1NpdBnR8E2DRSz9CtQlo/6698zgJcAEM=",
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "rev": "0655be68e0078bede0682bb6a5b53330dac37a72",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "type": "github"
-      }
-    },
-    "logos-capability-module_35": {
-      "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_62",
-        "logos-module": "logos-module_83",
-        "logos-nix": "logos-nix_606",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455138,
-        "narHash": "sha256-szx2dnnY9MP1NpdBnR8E2DRSz9CtQlo/6698zgJcAEM=",
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "rev": "0655be68e0078bede0682bb6a5b53330dac37a72",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "type": "github"
-      }
-    },
-    "logos-capability-module_36": {
-      "inputs": {
-        "logos-module-builder": "logos-module-builder_15"
-      },
-      "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-capability-module",
-        "type": "github"
-      }
-    },
     "logos-capability-module_37": {
       "inputs": {
-        "logos-cpp-sdk": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk"
-        ],
-        "logos-module": "logos-module_88",
-        "logos-nix": "logos-nix_645",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix",
-          "nixpkgs"
-        ]
+        "logos-module-builder": "logos-module-builder_16"
       },
       "locked": {
-        "lastModified": 1774455138,
-        "narHash": "sha256-szx2dnnY9MP1NpdBnR8E2DRSz9CtQlo/6698zgJcAEM=",
+        "lastModified": 1778182598,
+        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
         "owner": "logos-co",
         "repo": "logos-capability-module",
-        "rev": "0655be68e0078bede0682bb6a5b53330dac37a72",
+        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
         "type": "github"
       },
       "original": {
@@ -964,15 +1012,54 @@
     },
     "logos-capability-module_38": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_67",
-        "logos-module": "logos-module_89",
-        "logos-nix": "logos-nix_650",
+        "logos-cpp-sdk": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-module": "logos-module_93",
+        "logos-nix": "logos-nix_693",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455138,
+        "narHash": "sha256-szx2dnnY9MP1NpdBnR8E2DRSz9CtQlo/6698zgJcAEM=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "0655be68e0078bede0682bb6a5b53330dac37a72",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
+    "logos-capability-module_39": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_71",
+        "logos-module": "logos-module_94",
+        "logos-nix": "logos-nix_698",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -1006,6 +1093,100 @@
         "owner": "logos-co",
         "repo": "logos-capability-module",
         "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
+    "logos-capability-module_40": {
+      "inputs": {
+        "logos-module-builder": "logos-module-builder_17"
+      },
+      "locked": {
+        "lastModified": 1778182598,
+        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
+    "logos-capability-module_41": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-module": "logos-module_99",
+        "logos-nix": "logos-nix_737",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455138,
+        "narHash": "sha256-szx2dnnY9MP1NpdBnR8E2DRSz9CtQlo/6698zgJcAEM=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "0655be68e0078bede0682bb6a5b53330dac37a72",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
+    "logos-capability-module_42": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_76",
+        "logos-module": "logos-module_100",
+        "logos-nix": "logos-nix_742",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455138,
+        "narHash": "sha256-szx2dnnY9MP1NpdBnR8E2DRSz9CtQlo/6698zgJcAEM=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "0655be68e0078bede0682bb6a5b53330dac37a72",
         "type": "github"
       },
       "original": {
@@ -1166,6 +1347,136 @@
         "type": "github"
       }
     },
+    "logos-container": {
+      "inputs": {
+        "logos-nix": "logos-nix_167",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "default-container",
+          "logos-container",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781732360,
+        "narHash": "sha256-RJjquPiZz3/LkJaFUGpDxFbt1+paBiVtbbxjVhDMR3o=",
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "rev": "15adc74f829f0cc662bce4f0bfae917cd50e7db4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "type": "github"
+      }
+    },
+    "logos-container_2": {
+      "inputs": {
+        "logos-nix": "logos-nix_169",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-container",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781732360,
+        "narHash": "sha256-RJjquPiZz3/LkJaFUGpDxFbt1+paBiVtbbxjVhDMR3o=",
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "rev": "15adc74f829f0cc662bce4f0bfae917cd50e7db4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "type": "github"
+      }
+    },
+    "logos-container_3": {
+      "inputs": {
+        "logos-nix": "logos-nix_172",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-module-loader",
+          "logos-container",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781732360,
+        "narHash": "sha256-RJjquPiZz3/LkJaFUGpDxFbt1+paBiVtbbxjVhDMR3o=",
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "rev": "15adc74f829f0cc662bce4f0bfae917cd50e7db4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "type": "github"
+      }
+    },
+    "logos-container_4": {
+      "inputs": {
+        "logos-nix": "logos-nix_298",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-container",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781732360,
+        "narHash": "sha256-RJjquPiZz3/LkJaFUGpDxFbt1+paBiVtbbxjVhDMR3o=",
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "rev": "15adc74f829f0cc662bce4f0bfae917cd50e7db4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "type": "github"
+      }
+    },
+    "logos-container_5": {
+      "inputs": {
+        "logos-nix": "logos-nix_301",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-module-loader",
+          "logos-container",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781732360,
+        "narHash": "sha256-RJjquPiZz3/LkJaFUGpDxFbt1+paBiVtbbxjVhDMR3o=",
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "rev": "15adc74f829f0cc662bce4f0bfae917cd50e7db4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "type": "github"
+      }
+    },
     "logos-cpp-sdk": {
       "inputs": {
         "logos-lidl": "logos-lidl",
@@ -1182,11 +1493,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781785832,
-        "narHash": "sha256-f9Q4lmQQ9pKJIEi1zK+R3eggYNb8alygOybMbZPfTFg=",
+        "lastModified": 1781897505,
+        "narHash": "sha256-sRVgfo8VfWOXb3IH2JqZQAqBSfL0bYo3FrFSgS6yvqk=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "f032cf291e7adc70b13e6a0f7be4d80ca2248f56",
+        "rev": "aea29d37975aa0c32fdf37d7119830be905acf34",
         "type": "github"
       },
       "original": {
@@ -1422,23 +1733,29 @@
     },
     "logos-cpp-sdk_18": {
       "inputs": {
-        "logos-nix": "logos-nix_167",
+        "logos-lidl": "logos-lidl_4",
+        "logos-nix": "logos-nix_170",
+        "logos-protocol": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "default-module-loader",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "lastModified": 1781663756,
+        "narHash": "sha256-q1Q2MCax3L1RLfcS40sDStVipK6dhfiPHYk31YeGyUI=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "rev": "182d850e722c820b3640a09541d7c469ef79f0e6",
         "type": "github"
       },
       "original": {
@@ -1449,24 +1766,23 @@
     },
     "logos-cpp-sdk_19": {
       "inputs": {
-        "logos-nix": "logos-nix_176",
+        "logos-nix": "logos-nix_177",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "lastModified": 1781207077,
+        "narHash": "sha256-ZamVbPJxW364RFOa0WnYTJV7AiEjnUcOgfxIbfNgTO0=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "rev": "f5a127dd11589c8fc6db0a1bd4332d09ac080bb6",
         "type": "github"
       },
       "original": {
@@ -1504,26 +1820,26 @@
     },
     "logos-cpp-sdk_20": {
       "inputs": {
-        "logos-nix": "logos-nix_178",
+        "logos-nix": "logos-nix_184",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773956385,
-        "narHash": "sha256-CV0Lo1FrosBt/MSP+GWQGWXnYobxRGXGOREylNuwZ58=",
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "4b66dac015e4b977d33cfae80a4c8e1d518679f3",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
         "type": "github"
       },
       "original": {
@@ -1534,14 +1850,16 @@
     },
     "logos-cpp-sdk_21": {
       "inputs": {
-        "logos-nix": "logos-nix_181",
+        "logos-nix": "logos-nix_193",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -1563,26 +1881,29 @@
     },
     "logos-cpp-sdk_22": {
       "inputs": {
-        "logos-nix": "logos-nix_209",
-        "logos-protocol": [
-          "logoscore-cli",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
+        "logos-nix": "logos-nix_195",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781304979,
-        "narHash": "sha256-uCCoJJRVCUUO6j03GO6/02+uuLd9GaAi/0dHaiW2bXs=",
+        "lastModified": 1773956385,
+        "narHash": "sha256-CV0Lo1FrosBt/MSP+GWQGWXnYobxRGXGOREylNuwZ58=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "f0fe8cbfeb1fe62d934b4abf8c300047a49420c9",
+        "rev": "4b66dac015e4b977d33cfae80a4c8e1d518679f3",
         "type": "github"
       },
       "original": {
@@ -1593,10 +1914,73 @@
     },
     "logos-cpp-sdk_23": {
       "inputs": {
-        "logos-nix": "logos-nix_223",
+        "logos-nix": "logos-nix_198",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_24": {
+      "inputs": {
+        "logos-nix": "logos-nix_226",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781027175,
+        "narHash": "sha256-NjODUctwKSIi3vMUSMgk6bxfW4fJM9vX5jndk8CfZJ4=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "bb6d87b6ec7a64814df48fbdb10cf5290ce4b724",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_25": {
+      "inputs": {
+        "logos-nix": "logos-nix_228",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -1619,12 +2003,15 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_24": {
+    "logos-cpp-sdk_26": {
       "inputs": {
-        "logos-nix": "logos-nix_232",
+        "logos-nix": "logos-nix_237",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -1648,12 +2035,15 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_25": {
+    "logos-cpp-sdk_27": {
       "inputs": {
-        "logos-nix": "logos-nix_234",
+        "logos-nix": "logos-nix_239",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -1679,71 +2069,20 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_26": {
+    "logos-cpp-sdk_28": {
       "inputs": {
-        "logos-nix": "logos-nix_237",
+        "logos-nix": "logos-nix_242",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_27": {
-      "inputs": {
-        "logos-nix": "logos-nix_265",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_28": {
-      "inputs": {
-        "logos-nix": "logos-nix_274",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -1765,25 +2104,25 @@
     },
     "logos-cpp-sdk_29": {
       "inputs": {
-        "logos-nix": "logos-nix_283",
+        "logos-nix": "logos-nix_270",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "lastModified": 1779716125,
+        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
         "type": "github"
       },
       "original": {
@@ -1822,27 +2161,33 @@
     },
     "logos-cpp-sdk_30": {
       "inputs": {
-        "logos-nix": "logos-nix_285",
-        "nixpkgs": [
+        "logos-nix": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773956385,
-        "narHash": "sha256-CV0Lo1FrosBt/MSP+GWQGWXnYobxRGXGOREylNuwZ58=",
+        "lastModified": 1781027175,
+        "narHash": "sha256-NjODUctwKSIi3vMUSMgk6bxfW4fJM9vX5jndk8CfZJ4=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "4b66dac015e4b977d33cfae80a4c8e1d518679f3",
+        "rev": "bb6d87b6ec7a64814df48fbdb10cf5290ce4b724",
         "type": "github"
       },
       "original": {
@@ -1853,14 +2198,15 @@
     },
     "logos-cpp-sdk_31": {
       "inputs": {
-        "logos-nix": "logos-nix_288",
+        "logos-lidl": "logos-lidl_6",
+        "logos-nix": "logos-nix_299",
+        "logos-protocol": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
@@ -1868,11 +2214,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "lastModified": 1781663756,
+        "narHash": "sha256-q1Q2MCax3L1RLfcS40sDStVipK6dhfiPHYk31YeGyUI=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "rev": "182d850e722c820b3640a09541d7c469ef79f0e6",
         "type": "github"
       },
       "original": {
@@ -1883,11 +2229,13 @@
     },
     "logos-cpp-sdk_32": {
       "inputs": {
-        "logos-nix": "logos-nix_316",
+        "logos-nix": "logos-nix_315",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -1909,14 +2257,14 @@
     },
     "logos-cpp-sdk_33": {
       "inputs": {
-        "logos-nix": "logos-nix_317",
+        "logos-nix": "logos-nix_324",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -1942,37 +2290,6 @@
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_35": {
-      "inputs": {
-        "logos-nix": "logos-nix_328",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -1998,13 +2315,12 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_36": {
+    "logos-cpp-sdk_35": {
       "inputs": {
-        "logos-nix": "logos-nix_331",
+        "logos-nix": "logos-nix_329",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -2029,14 +2345,41 @@
         "type": "github"
       }
     },
+    "logos-cpp-sdk_36": {
+      "inputs": {
+        "logos-nix": "logos-nix_357",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
     "logos-cpp-sdk_37": {
       "inputs": {
-        "logos-nix": "logos-nix_359",
+        "logos-nix": "logos-nix_366",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2058,12 +2401,14 @@
     },
     "logos-cpp-sdk_38": {
       "inputs": {
-        "logos-nix": "logos-nix_368",
+        "logos-nix": "logos-nix_375",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-module-client",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2085,26 +2430,27 @@
     },
     "logos-cpp-sdk_39": {
       "inputs": {
-        "logos-nix": "logos-nix_371",
+        "logos-nix": "logos-nix_377",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "lastModified": 1773956385,
+        "narHash": "sha256-CV0Lo1FrosBt/MSP+GWQGWXnYobxRGXGOREylNuwZ58=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "rev": "4b66dac015e4b977d33cfae80a4c8e1d518679f3",
         "type": "github"
       },
       "original": {
@@ -2150,11 +2496,10 @@
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2176,29 +2521,22 @@
     },
     "logos-cpp-sdk_41": {
       "inputs": {
-        "logos-nix": "logos-nix_382",
+        "logos-nix": "logos-nix_408",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773956385,
-        "narHash": "sha256-CV0Lo1FrosBt/MSP+GWQGWXnYobxRGXGOREylNuwZ58=",
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "4b66dac015e4b977d33cfae80a4c8e1d518679f3",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
         "type": "github"
       },
       "original": {
@@ -2209,17 +2547,14 @@
     },
     "logos-cpp-sdk_42": {
       "inputs": {
-        "logos-nix": "logos-nix_385",
+        "logos-nix": "logos-nix_409",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2241,71 +2576,12 @@
     },
     "logos-cpp-sdk_43": {
       "inputs": {
-        "logos-nix": "logos-nix_413",
+        "logos-nix": "logos-nix_418",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_44": {
-      "inputs": {
-        "logos-nix": "logos-nix_422",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_45": {
-      "inputs": {
-        "logos-nix": "logos-nix_431",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -2328,15 +2604,14 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_46": {
+    "logos-cpp-sdk_44": {
       "inputs": {
-        "logos-nix": "logos-nix_433",
+        "logos-nix": "logos-nix_420",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -2361,15 +2636,14 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_47": {
+    "logos-cpp-sdk_45": {
       "inputs": {
-        "logos-nix": "logos-nix_436",
+        "logos-nix": "logos-nix_423",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -2393,15 +2667,71 @@
         "type": "github"
       }
     },
+    "logos-cpp-sdk_46": {
+      "inputs": {
+        "logos-nix": "logos-nix_451",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_47": {
+      "inputs": {
+        "logos-nix": "logos-nix_460",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-module-client",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
     "logos-cpp-sdk_48": {
       "inputs": {
-        "logos-nix": "logos-nix_464",
+        "logos-nix": "logos-nix_463",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2423,16 +2753,16 @@
     },
     "logos-cpp-sdk_49": {
       "inputs": {
-        "logos-nix": "logos-nix_465",
+        "logos-nix": "logos-nix_472",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2489,39 +2819,6 @@
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_51": {
-      "inputs": {
-        "logos-nix": "logos-nix_476",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -2547,19 +2844,46 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_52": {
+    "logos-cpp-sdk_51": {
       "inputs": {
-        "logos-nix": "logos-nix_479",
+        "logos-nix": "logos-nix_477",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_52": {
+      "inputs": {
+        "logos-nix": "logos-nix_505",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
@@ -2582,14 +2906,15 @@
     },
     "logos-cpp-sdk_53": {
       "inputs": {
-        "logos-nix": "logos-nix_507",
+        "logos-nix": "logos-nix_514",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2611,69 +2936,14 @@
     },
     "logos-cpp-sdk_54": {
       "inputs": {
-        "logos-nix": "logos-nix_516",
+        "logos-nix": "logos-nix_523",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-module-client",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_55": {
-      "inputs": {
-        "logos-nix": "logos-nix_531",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_56": {
-      "inputs": {
-        "logos-nix": "logos-nix_540",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -2695,14 +2965,16 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_57": {
+    "logos-cpp-sdk_55": {
       "inputs": {
-        "logos-nix": "logos-nix_542",
+        "logos-nix": "logos-nix_525",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2726,14 +2998,16 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_58": {
+    "logos-cpp-sdk_56": {
       "inputs": {
-        "logos-nix": "logos-nix_545",
+        "logos-nix": "logos-nix_528",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2756,12 +3030,45 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_59": {
+    "logos-cpp-sdk_57": {
       "inputs": {
-        "logos-nix": "logos-nix_586",
+        "logos-nix": "logos-nix_556",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_58": {
+      "inputs": {
+        "logos-nix": "logos-nix_557",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
@@ -2769,11 +3076,43 @@
         ]
       },
       "locked": {
-        "lastModified": 1780703083,
-        "narHash": "sha256-Z0nOivZhmNWprngIAxx1ZwpZPKH3EvZRTPzr3nTrMgs=",
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "eb71a1aa90e05a98814138779680de2ea60a9ff2",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_59": {
+      "inputs": {
+        "logos-nix": "logos-nix_566",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
         "type": "github"
       },
       "original": {
@@ -2809,25 +3148,30 @@
     },
     "logos-cpp-sdk_60": {
       "inputs": {
-        "logos-nix": "logos-nix_593",
+        "logos-nix": "logos-nix_568",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "lastModified": 1773956385,
+        "narHash": "sha256-CV0Lo1FrosBt/MSP+GWQGWXnYobxRGXGOREylNuwZ58=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "rev": "4b66dac015e4b977d33cfae80a4c8e1d518679f3",
         "type": "github"
       },
       "original": {
@@ -2838,15 +3182,18 @@
     },
     "logos-cpp-sdk_61": {
       "inputs": {
-        "logos-nix": "logos-nix_602",
+        "logos-nix": "logos-nix_571",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2868,28 +3215,25 @@
     },
     "logos-cpp-sdk_62": {
       "inputs": {
-        "logos-nix": "logos-nix_604",
+        "logos-nix": "logos-nix_599",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
           "logos-liblogos",
-          "logos-capability-module",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773956385,
-        "narHash": "sha256-CV0Lo1FrosBt/MSP+GWQGWXnYobxRGXGOREylNuwZ58=",
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "4b66dac015e4b977d33cfae80a4c8e1d518679f3",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
         "type": "github"
       },
       "original": {
@@ -2900,16 +3244,14 @@
     },
     "logos-cpp-sdk_63": {
       "inputs": {
-        "logos-nix": "logos-nix_607",
+        "logos-nix": "logos-nix_608",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-module-client",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2931,23 +3273,24 @@
     },
     "logos-cpp-sdk_64": {
       "inputs": {
-        "logos-nix": "logos-nix_635",
+        "logos-nix": "logos-nix_623",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
-          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
         "type": "github"
       },
       "original": {
@@ -2958,15 +3301,14 @@
     },
     "logos-cpp-sdk_65": {
       "inputs": {
-        "logos-nix": "logos-nix_637",
+        "logos-nix": "logos-nix_632",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2988,45 +3330,12 @@
     },
     "logos-cpp-sdk_66": {
       "inputs": {
-        "logos-nix": "logos-nix_646",
+        "logos-nix": "logos-nix_634",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_67": {
-      "inputs": {
-        "logos-nix": "logos-nix_648",
-        "nixpkgs": [
-          "logoscore-cli",
+          "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3050,16 +3359,14 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_68": {
+    "logos-cpp-sdk_67": {
       "inputs": {
-        "logos-nix": "logos-nix_651",
+        "logos-nix": "logos-nix_637",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3082,26 +3389,53 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_69": {
+    "logos-cpp-sdk_68": {
       "inputs": {
-        "logos-nix": "logos-nix_679",
+        "logos-nix": "logos-nix_678",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "lastModified": 1780703083,
+        "narHash": "sha256-Z0nOivZhmNWprngIAxx1ZwpZPKH3EvZRTPzr3nTrMgs=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "rev": "eb71a1aa90e05a98814138779680de2ea60a9ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_69": {
+      "inputs": {
+        "logos-nix": "logos-nix_685",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
         "type": "github"
       },
       "original": {
@@ -3139,6 +3473,280 @@
       }
     },
     "logos-cpp-sdk_70": {
+      "inputs": {
+        "logos-nix": "logos-nix_694",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_71": {
+      "inputs": {
+        "logos-nix": "logos-nix_696",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773956385,
+        "narHash": "sha256-CV0Lo1FrosBt/MSP+GWQGWXnYobxRGXGOREylNuwZ58=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "4b66dac015e4b977d33cfae80a4c8e1d518679f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_72": {
+      "inputs": {
+        "logos-nix": "logos-nix_699",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_73": {
+      "inputs": {
+        "logos-nix": "logos-nix_727",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779716125,
+        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_74": {
+      "inputs": {
+        "logos-nix": "logos-nix_729",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_75": {
+      "inputs": {
+        "logos-nix": "logos-nix_738",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_76": {
+      "inputs": {
+        "logos-nix": "logos-nix_740",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773956385,
+        "narHash": "sha256-CV0Lo1FrosBt/MSP+GWQGWXnYobxRGXGOREylNuwZ58=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "4b66dac015e4b977d33cfae80a4c8e1d518679f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_77": {
+      "inputs": {
+        "logos-nix": "logos-nix_743",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_78": {
+      "inputs": {
+        "logos-nix": "logos-nix_771",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779716125,
+        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_79": {
       "inputs": {
         "logos-nix": [
           "logoscore-cli",
@@ -3263,7 +3871,68 @@
     },
     "logos-design-system_10": {
       "inputs": {
-        "logos-nix": "logos-nix_432",
+        "logos-nix": "logos-nix_419",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-design-system",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777999983,
+        "narHash": "sha256-D6W7oC80cT7pg95kSpxO0jtoVj1hG9A151CciCSZaBc=",
+        "owner": "logos-co",
+        "repo": "logos-design-system",
+        "rev": "f6e95ae24ede3871c380f8250feffd17d173f5a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-design-system",
+        "type": "github"
+      }
+    },
+    "logos-design-system_11": {
+      "inputs": {
+        "logos-nix": "logos-nix_473",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-design-system",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777999983,
+        "narHash": "sha256-D6W7oC80cT7pg95kSpxO0jtoVj1hG9A151CciCSZaBc=",
+        "owner": "logos-co",
+        "repo": "logos-design-system",
+        "rev": "f6e95ae24ede3871c380f8250feffd17d173f5a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-design-system",
+        "type": "github"
+      }
+    },
+    "logos-design-system_12": {
+      "inputs": {
+        "logos-nix": "logos-nix_524",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3292,9 +3961,9 @@
         "type": "github"
       }
     },
-    "logos-design-system_11": {
+    "logos-design-system_13": {
       "inputs": {
-        "logos-nix": "logos-nix_475",
+        "logos-nix": "logos-nix_567",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3324,9 +3993,9 @@
         "type": "github"
       }
     },
-    "logos-design-system_12": {
+    "logos-design-system_14": {
       "inputs": {
-        "logos-nix": "logos-nix_541",
+        "logos-nix": "logos-nix_633",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3353,9 +4022,9 @@
         "type": "github"
       }
     },
-    "logos-design-system_13": {
+    "logos-design-system_15": {
       "inputs": {
-        "logos-nix": "logos-nix_603",
+        "logos-nix": "logos-nix_695",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3383,9 +4052,9 @@
         "type": "github"
       }
     },
-    "logos-design-system_14": {
+    "logos-design-system_16": {
       "inputs": {
-        "logos-nix": "logos-nix_636",
+        "logos-nix": "logos-nix_728",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3410,9 +4079,9 @@
         "type": "github"
       }
     },
-    "logos-design-system_15": {
+    "logos-design-system_17": {
       "inputs": {
-        "logos-nix": "logos-nix_647",
+        "logos-nix": "logos-nix_739",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3524,10 +4193,13 @@
     },
     "logos-design-system_5": {
       "inputs": {
-        "logos-nix": "logos-nix_177",
+        "logos-nix": "logos-nix_194",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -3552,10 +4224,9 @@
     },
     "logos-design-system_6": {
       "inputs": {
-        "logos-nix": "logos-nix_233",
+        "logos-nix": "logos-nix_227",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -3566,11 +4237,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777999983,
-        "narHash": "sha256-D6W7oC80cT7pg95kSpxO0jtoVj1hG9A151CciCSZaBc=",
+        "lastModified": 1780947586,
+        "narHash": "sha256-0l5Xjbx9bLRc6LF0FU3LZ15RmEYK9oOPy/EaOxQYHkc=",
         "owner": "logos-co",
         "repo": "logos-design-system",
-        "rev": "f6e95ae24ede3871c380f8250feffd17d173f5a4",
+        "rev": "4a37b34446ef4e55b16a5aeb011ffc5e8cbcbbb8",
         "type": "github"
       },
       "original": {
@@ -3581,11 +4252,14 @@
     },
     "logos-design-system_7": {
       "inputs": {
-        "logos-nix": "logos-nix_284",
+        "logos-nix": "logos-nix_238",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -3610,11 +4284,10 @@
     },
     "logos-design-system_8": {
       "inputs": {
-        "logos-nix": "logos-nix_327",
+        "logos-nix": "logos-nix_325",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -3640,13 +4313,11 @@
     },
     "logos-design-system_9": {
       "inputs": {
-        "logos-nix": "logos-nix_381",
+        "logos-nix": "logos-nix_376",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -3704,26 +4375,28 @@
     "logos-liblogos_10": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_19",
-        "logos-cpp-sdk": "logos-cpp-sdk_37",
-        "logos-module": "logos-module_49",
-        "logos-nix": "logos-nix_361",
-        "logos-package-manager": "logos-package-manager_19",
+        "logos-cpp-sdk": "logos-cpp-sdk_35",
+        "logos-module": "logos-module_46",
+        "logos-nix": "logos-nix_331",
+        "logos-package-manager": "logos-package-manager_16",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-nix",
           "nixpkgs"
         ],
-        "process-stats": "process-stats_11"
+        "process-stats": "process-stats_9"
       },
       "locked": {
-        "lastModified": 1778188958,
-        "narHash": "sha256-BU6lNRaWyyyPdw5M4yF9P0tsX8tLISmB9EIemw6rSSQ=",
+        "lastModified": 1778168472,
+        "narHash": "sha256-Td7Um8HOx4hG6k8ky3+bTsmgA9bgspI3eDs9LzVWv2s=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "03ffaa379ed22999dafa07ef8da905ef519bfb29",
+        "rev": "94af58c819038e0eb5c2003f69d3260d964aa8f3",
         "type": "github"
       },
       "original": {
@@ -3734,23 +4407,22 @@
     },
     "logos-liblogos_11": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_21",
-        "logos-cpp-sdk": "logos-cpp-sdk_36",
-        "logos-module": "logos-module_48",
-        "logos-nix": "logos-nix_333",
-        "logos-package-manager": "logos-package-manager_17",
+        "logos-capability-module": "logos-capability-module_22",
+        "logos-cpp-sdk": "logos-cpp-sdk_40",
+        "logos-module": "logos-module_53",
+        "logos-nix": "logos-nix_382",
+        "logos-package-manager": "logos-package-manager_19",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix",
           "nixpkgs"
         ],
-        "process-stats": "process-stats_10"
+        "process-stats": "process-stats_11"
       },
       "locked": {
         "lastModified": 1778168472,
@@ -3768,16 +4440,15 @@
     },
     "logos-liblogos_12": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_22",
-        "logos-cpp-sdk": "logos-cpp-sdk_43",
-        "logos-module": "logos-module_56",
-        "logos-nix": "logos-nix_415",
-        "logos-package-manager": "logos-package-manager_22",
+        "logos-capability-module": "logos-capability-module_23",
+        "logos-cpp-sdk": "logos-cpp-sdk_46",
+        "logos-module": "logos-module_60",
+        "logos-nix": "logos-nix_453",
+        "logos-package-manager": "logos-package-manager_23",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-nix",
           "nixpkgs"
@@ -3800,16 +4471,15 @@
     },
     "logos-liblogos_13": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_24",
-        "logos-cpp-sdk": "logos-cpp-sdk_42",
-        "logos-module": "logos-module_55",
-        "logos-nix": "logos-nix_387",
-        "logos-package-manager": "logos-package-manager_20",
+        "logos-capability-module": "logos-capability-module_25",
+        "logos-cpp-sdk": "logos-cpp-sdk_45",
+        "logos-module": "logos-module_59",
+        "logos-nix": "logos-nix_425",
+        "logos-package-manager": "logos-package-manager_21",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -3835,17 +4505,49 @@
     },
     "logos-liblogos_14": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_27",
-        "logos-cpp-sdk": "logos-cpp-sdk_47",
-        "logos-module": "logos-module_62",
-        "logos-nix": "logos-nix_438",
-        "logos-package-manager": "logos-package-manager_23",
+        "logos-capability-module": "logos-capability-module_26",
+        "logos-cpp-sdk": "logos-cpp-sdk_52",
+        "logos-module": "logos-module_67",
+        "logos-nix": "logos-nix_507",
+        "logos-package-manager": "logos-package-manager_26",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-liblogos",
+          "logos-nix",
+          "nixpkgs"
+        ],
+        "process-stats": "process-stats_15"
+      },
+      "locked": {
+        "lastModified": 1778188958,
+        "narHash": "sha256-BU6lNRaWyyyPdw5M4yF9P0tsX8tLISmB9EIemw6rSSQ=",
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "rev": "03ffaa379ed22999dafa07ef8da905ef519bfb29",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "type": "github"
+      }
+    },
+    "logos-liblogos_15": {
+      "inputs": {
+        "logos-capability-module": "logos-capability-module_28",
+        "logos-cpp-sdk": "logos-cpp-sdk_51",
+        "logos-module": "logos-module_66",
+        "logos-nix": "logos-nix_479",
+        "logos-package-manager": "logos-package-manager_24",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -3868,12 +4570,12 @@
         "type": "github"
       }
     },
-    "logos-liblogos_15": {
+    "logos-liblogos_16": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_28",
-        "logos-cpp-sdk": "logos-cpp-sdk_53",
-        "logos-module": "logos-module_69",
-        "logos-nix": "logos-nix_509",
+        "logos-capability-module": "logos-capability-module_31",
+        "logos-cpp-sdk": "logos-cpp-sdk_56",
+        "logos-module": "logos-module_73",
+        "logos-nix": "logos-nix_530",
         "logos-package-manager": "logos-package-manager_27",
         "nixpkgs": [
           "logoscore-cli",
@@ -3881,47 +4583,13 @@
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-nix",
-          "nixpkgs"
-        ],
-        "process-stats": "process-stats_16"
-      },
-      "locked": {
-        "lastModified": 1778188958,
-        "narHash": "sha256-BU6lNRaWyyyPdw5M4yF9P0tsX8tLISmB9EIemw6rSSQ=",
-        "owner": "logos-co",
-        "repo": "logos-liblogos",
-        "rev": "03ffaa379ed22999dafa07ef8da905ef519bfb29",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-liblogos",
-        "type": "github"
-      }
-    },
-    "logos-liblogos_16": {
-      "inputs": {
-        "logos-capability-module": "logos-capability-module_30",
-        "logos-cpp-sdk": "logos-cpp-sdk_52",
-        "logos-module": "logos-module_68",
-        "logos-nix": "logos-nix_481",
-        "logos-package-manager": "logos-package-manager_25",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix",
           "nixpkgs"
         ],
-        "process-stats": "process-stats_15"
+        "process-stats": "process-stats_16"
       },
       "locked": {
         "lastModified": 1778168472,
@@ -3940,15 +4608,51 @@
     "logos-liblogos_17": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_32",
-        "logos-cpp-sdk": "logos-cpp-sdk_58",
-        "logos-module": "logos-module_75",
-        "logos-nix": "logos-nix_547",
+        "logos-cpp-sdk": "logos-cpp-sdk_62",
+        "logos-module": "logos-module_80",
+        "logos-nix": "logos-nix_601",
+        "logos-package-manager": "logos-package-manager_31",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-nix",
+          "nixpkgs"
+        ],
+        "process-stats": "process-stats_18"
+      },
+      "locked": {
+        "lastModified": 1778188958,
+        "narHash": "sha256-BU6lNRaWyyyPdw5M4yF9P0tsX8tLISmB9EIemw6rSSQ=",
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "rev": "03ffaa379ed22999dafa07ef8da905ef519bfb29",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "type": "github"
+      }
+    },
+    "logos-liblogos_18": {
+      "inputs": {
+        "logos-capability-module": "logos-capability-module_34",
+        "logos-cpp-sdk": "logos-cpp-sdk_61",
+        "logos-module": "logos-module_79",
+        "logos-nix": "logos-nix_573",
         "logos-package-manager": "logos-package-manager_29",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix",
@@ -3970,25 +4674,24 @@
         "type": "github"
       }
     },
-    "logos-liblogos_18": {
+    "logos-liblogos_19": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_35",
-        "logos-cpp-sdk": "logos-cpp-sdk_63",
-        "logos-module": "logos-module_84",
-        "logos-nix": "logos-nix_609",
-        "logos-package-manager": "logos-package-manager_32",
+        "logos-capability-module": "logos-capability-module_36",
+        "logos-cpp-sdk": "logos-cpp-sdk_67",
+        "logos-module": "logos-module_86",
+        "logos-nix": "logos-nix_639",
+        "logos-package-manager": "logos-package-manager_33",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix",
           "nixpkgs"
         ],
-        "process-stats": "process-stats_18"
+        "process-stats": "process-stats_19"
       },
       "locked": {
         "lastModified": 1778168472,
@@ -3996,38 +4699,6 @@
         "owner": "logos-co",
         "repo": "logos-liblogos",
         "rev": "94af58c819038e0eb5c2003f69d3260d964aa8f3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-liblogos",
-        "type": "github"
-      }
-    },
-    "logos-liblogos_19": {
-      "inputs": {
-        "logos-capability-module": "logos-capability-module_36",
-        "logos-cpp-sdk": "logos-cpp-sdk_69",
-        "logos-module": "logos-module_91",
-        "logos-nix": "logos-nix_681",
-        "logos-package-manager": "logos-package-manager_36",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-nix",
-          "nixpkgs"
-        ],
-        "process-stats": "process-stats_20"
-      },
-      "locked": {
-        "lastModified": 1779724404,
-        "narHash": "sha256-HKgY1cbcm1BgFau0KBJba0pKGNZ/7oJMcqJMhPDQ20Q=",
-        "owner": "logos-co",
-        "repo": "logos-liblogos",
-        "rev": "be7c8fd8e89e9c7506421735e18dc85bde0c1cb2",
         "type": "github"
       },
       "original": {
@@ -4068,11 +4739,77 @@
     },
     "logos-liblogos_20": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_38",
-        "logos-cpp-sdk": "logos-cpp-sdk_68",
-        "logos-module": "logos-module_90",
-        "logos-nix": "logos-nix_653",
-        "logos-package-manager": "logos-package-manager_34",
+        "logos-capability-module": "logos-capability-module_39",
+        "logos-cpp-sdk": "logos-cpp-sdk_72",
+        "logos-module": "logos-module_95",
+        "logos-nix": "logos-nix_701",
+        "logos-package-manager": "logos-package-manager_36",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix",
+          "nixpkgs"
+        ],
+        "process-stats": "process-stats_20"
+      },
+      "locked": {
+        "lastModified": 1778168472,
+        "narHash": "sha256-Td7Um8HOx4hG6k8ky3+bTsmgA9bgspI3eDs9LzVWv2s=",
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "rev": "94af58c819038e0eb5c2003f69d3260d964aa8f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "type": "github"
+      }
+    },
+    "logos-liblogos_21": {
+      "inputs": {
+        "logos-capability-module": "logos-capability-module_40",
+        "logos-cpp-sdk": "logos-cpp-sdk_78",
+        "logos-module": "logos-module_102",
+        "logos-nix": "logos-nix_773",
+        "logos-package-manager": "logos-package-manager_40",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-nix",
+          "nixpkgs"
+        ],
+        "process-stats": "process-stats_22"
+      },
+      "locked": {
+        "lastModified": 1779724404,
+        "narHash": "sha256-HKgY1cbcm1BgFau0KBJba0pKGNZ/7oJMcqJMhPDQ20Q=",
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "rev": "be7c8fd8e89e9c7506421735e18dc85bde0c1cb2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "type": "github"
+      }
+    },
+    "logos-liblogos_22": {
+      "inputs": {
+        "logos-capability-module": "logos-capability-module_42",
+        "logos-cpp-sdk": "logos-cpp-sdk_77",
+        "logos-module": "logos-module_101",
+        "logos-nix": "logos-nix_745",
+        "logos-package-manager": "logos-package-manager_38",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -4085,7 +4822,7 @@
           "logos-nix",
           "nixpkgs"
         ],
-        "process-stats": "process-stats_19"
+        "process-stats": "process-stats_21"
       },
       "locked": {
         "lastModified": 1778168472,
@@ -4167,27 +4904,31 @@
     },
     "logos-liblogos_5": {
       "inputs": {
+        "default-container": "default-container",
+        "default-module-loader": "default-module-loader",
         "logos-capability-module": "logos-capability-module_10",
-        "logos-cpp-sdk": "logos-cpp-sdk_22",
-        "logos-module": "logos-module_29",
-        "logos-nix": "logos-nix_211",
-        "logos-package-manager": "logos-package-manager_11",
-        "logos-protocol": "logos-protocol_3",
-        "logos-qt-sdk": "logos-qt-sdk_3",
+        "logos-container": "logos-container_4",
+        "logos-cpp-sdk": "logos-cpp-sdk_31",
+        "logos-module": "logos-module_40",
+        "logos-module-loader": "logos-module-loader_2",
+        "logos-nix": "logos-nix_303",
+        "logos-package-manager": "logos-package-manager_15",
+        "logos-protocol": "logos-protocol_4",
+        "logos-qt-sdk": "logos-qt-sdk_4",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
           "logos-nix",
           "nixpkgs"
         ],
-        "process-stats": "process-stats_6"
+        "process-stats": "process-stats_8"
       },
       "locked": {
-        "lastModified": 1781311549,
-        "narHash": "sha256-1laKvOevI1RrXQxllvlXFJnFmRQWLbvWfmbUZ02O7NY=",
+        "lastModified": 1781906377,
+        "narHash": "sha256-EoVyFkgOnikgxw2kJK6s09Ys2xmTZvEAcDyyDC6vXfk=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "050f2d36284d29e0660a4086b5a8af49fd70f4ff",
+        "rev": "0c0a23db48e7b816ebf356457d9da5f84510072d",
         "type": "github"
       },
       "original": {
@@ -4198,14 +4939,17 @@
     },
     "logos-liblogos_6": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_12",
-        "logos-cpp-sdk": "logos-cpp-sdk_21",
-        "logos-module": "logos-module_28",
-        "logos-nix": "logos-nix_183",
+        "logos-capability-module": "logos-capability-module_13",
+        "logos-cpp-sdk": "logos-cpp-sdk_23",
+        "logos-module": "logos-module_32",
+        "logos-nix": "logos-nix_200",
         "logos-package-manager": "logos-package-manager_9",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -4230,26 +4974,29 @@
     },
     "logos-liblogos_7": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_13",
-        "logos-cpp-sdk": "logos-cpp-sdk_27",
-        "logos-module": "logos-module_36",
-        "logos-nix": "logos-nix_267",
-        "logos-package-manager": "logos-package-manager_14",
+        "logos-capability-module": "logos-capability-module_14",
+        "logos-cpp-sdk": "logos-cpp-sdk_29",
+        "logos-module": "logos-module_39",
+        "logos-nix": "logos-nix_272",
+        "logos-package-manager": "logos-package-manager_13",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-nix",
           "nixpkgs"
         ],
-        "process-stats": "process-stats_8"
+        "process-stats": "process-stats_7"
       },
       "locked": {
-        "lastModified": 1778263223,
-        "narHash": "sha256-LvenATy+0mzX2jKp+4KxB5Uuky3KXnHYy8FX18qSLHs=",
+        "lastModified": 1781104104,
+        "narHash": "sha256-RzYek00R1a+nTOejMKXER3WZLfO30A+3mCqvM6m7PfQ=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "2321de0365249e7223cac9ea2ac321fa0a2495c7",
+        "rev": "68e408a5de5a21948684485582a5d03d7bfc5d78",
         "type": "github"
       },
       "original": {
@@ -4260,14 +5007,17 @@
     },
     "logos-liblogos_8": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_15",
-        "logos-cpp-sdk": "logos-cpp-sdk_26",
-        "logos-module": "logos-module_35",
-        "logos-nix": "logos-nix_239",
-        "logos-package-manager": "logos-package-manager_12",
+        "logos-capability-module": "logos-capability-module_16",
+        "logos-cpp-sdk": "logos-cpp-sdk_28",
+        "logos-module": "logos-module_38",
+        "logos-nix": "logos-nix_244",
+        "logos-package-manager": "logos-package-manager_11",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -4275,7 +5025,7 @@
           "logos-nix",
           "nixpkgs"
         ],
-        "process-stats": "process-stats_7"
+        "process-stats": "process-stats_6"
       },
       "locked": {
         "lastModified": 1778168472,
@@ -4293,29 +5043,26 @@
     },
     "logos-liblogos_9": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_18",
-        "logos-cpp-sdk": "logos-cpp-sdk_31",
-        "logos-module": "logos-module_42",
-        "logos-nix": "logos-nix_290",
-        "logos-package-manager": "logos-package-manager_15",
+        "logos-capability-module": "logos-capability-module_17",
+        "logos-cpp-sdk": "logos-cpp-sdk_36",
+        "logos-module": "logos-module_47",
+        "logos-nix": "logos-nix_359",
+        "logos-package-manager": "logos-package-manager_18",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
+          "logos-liblogos",
           "logos-nix",
           "nixpkgs"
         ],
-        "process-stats": "process-stats_9"
+        "process-stats": "process-stats_10"
       },
       "locked": {
-        "lastModified": 1778168472,
-        "narHash": "sha256-Td7Um8HOx4hG6k8ky3+bTsmgA9bgspI3eDs9LzVWv2s=",
+        "lastModified": 1778263223,
+        "narHash": "sha256-LvenATy+0mzX2jKp+4KxB5Uuky3KXnHYy8FX18qSLHs=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "94af58c819038e0eb5c2003f69d3260d964aa8f3",
+        "rev": "2321de0365249e7223cac9ea2ac321fa0a2495c7",
         "type": "github"
       },
       "original": {
@@ -4382,17 +5129,174 @@
         "type": "github"
       }
     },
+    "logos-lidl_3": {
+      "inputs": {
+        "logos-nix": [
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781653473,
+        "narHash": "sha256-8l2tE2K5nY1grcFROQHC1By1jVI0NrfkS3k2v2y6R2I=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "8c95d4f0cc6a10195c70ed71e85b7a4cddca02f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_4": {
+      "inputs": {
+        "logos-nix": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781653473,
+        "narHash": "sha256-8l2tE2K5nY1grcFROQHC1By1jVI0NrfkS3k2v2y6R2I=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "8c95d4f0cc6a10195c70ed71e85b7a4cddca02f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_5": {
+      "inputs": {
+        "logos-nix": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781653473,
+        "narHash": "sha256-8l2tE2K5nY1grcFROQHC1By1jVI0NrfkS3k2v2y6R2I=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "8c95d4f0cc6a10195c70ed71e85b7a4cddca02f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_6": {
+      "inputs": {
+        "logos-nix": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781653473,
+        "narHash": "sha256-8l2tE2K5nY1grcFROQHC1By1jVI0NrfkS3k2v2y6R2I=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "8c95d4f0cc6a10195c70ed71e85b7a4cddca02f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_7": {
+      "inputs": {
+        "logos-nix": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781653473,
+        "narHash": "sha256-8l2tE2K5nY1grcFROQHC1By1jVI0NrfkS3k2v2y6R2I=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "8c95d4f0cc6a10195c70ed71e85b7a4cddca02f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
     "logos-logoscore-cli": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_16",
-        "logos-cpp-sdk": "logos-cpp-sdk_32",
-        "logos-liblogos": "logos-liblogos_10",
+        "logos-capability-module": "logos-capability-module_20",
+        "logos-cpp-sdk": "logos-cpp-sdk_41",
+        "logos-liblogos": "logos-liblogos_12",
         "logos-module-client": "logos-module-client",
-        "logos-nix": "logos-nix_370",
+        "logos-nix": "logos-nix_462",
         "logos-test-modules": "logos-test-modules_2",
-        "nix-bundle-appimage": "nix-bundle-appimage_32",
-        "nix-bundle-dir": "nix-bundle-dir_101",
-        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_14",
+        "nix-bundle-appimage": "nix-bundle-appimage_36",
+        "nix-bundle-dir": "nix-bundle-dir_115",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_16",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -4417,14 +5321,14 @@
     },
     "logos-logoscore-cli_2": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_25",
-        "logos-cpp-sdk": "logos-cpp-sdk_48",
-        "logos-liblogos": "logos-liblogos_15",
+        "logos-capability-module": "logos-capability-module_29",
+        "logos-cpp-sdk": "logos-cpp-sdk_57",
+        "logos-liblogos": "logos-liblogos_17",
         "logos-module-client": "logos-module-client_2",
-        "logos-nix": "logos-nix_518",
-        "nix-bundle-appimage": "nix-bundle-appimage_28",
-        "nix-bundle-dir": "nix-bundle-dir_89",
-        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_12",
+        "logos-nix": "logos-nix_610",
+        "nix-bundle-appimage": "nix-bundle-appimage_32",
+        "nix-bundle-dir": "nix-bundle-dir_103",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_14",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -4491,14 +5395,15 @@
           "logos-module-builder",
           "logos-nix",
           "nixpkgs"
-        ]
+        ],
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1781874578,
-        "narHash": "sha256-aTONNb+9toeNY8NwkkRJaZkcdpTXPuZWKd1+RIADaxU=",
+        "lastModified": 1782146416,
+        "narHash": "sha256-WkkDTc8p0YkZ5H1w9KmYih0WFT1+k/yjPKXtM3Mt6+E=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "205619cb450182df14163a932e3e45d798eac8ea",
+        "rev": "f4942648c28127d4ef4d4b467b22bd33873ab4fa",
         "type": "github"
       },
       "original": {
@@ -4509,15 +5414,88 @@
     },
     "logos-module-builder_10": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_44",
-        "logos-module": "logos-module_57",
-        "logos-nix": "logos-nix_424",
+        "logos-cpp-sdk": "logos-cpp-sdk_42",
+        "logos-module": "logos-module_54",
+        "logos-nix": "logos-nix_411",
         "logos-plugin-core": "logos-plugin-core_10",
         "logos-plugin-qt": "logos-plugin-qt_10",
         "logos-standalone-app": "logos-standalone-app_10",
         "logos-test-framework": "logos-test-framework_10",
         "nix-bundle-lgx": "nix-bundle-lgx_29",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_10",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778177522,
+        "narHash": "sha256-sUGiatEU51cyZeATc3P/8b0myrAkCKavePpFwtkKxAI=",
+        "owner": "logos-co",
+        "repo": "logos-module-builder",
+        "rev": "b0e41abf3e14c0534b41933c5f8e3fc697319037",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module-builder",
+        "type": "github"
+      }
+    },
+    "logos-module-builder_11": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_48",
+        "logos-module": "logos-module_61",
+        "logos-nix": "logos-nix_465",
+        "logos-plugin-core": "logos-plugin-core_11",
+        "logos-plugin-qt": "logos-plugin-qt_11",
+        "logos-standalone-app": "logos-standalone-app_11",
+        "logos-test-framework": "logos-test-framework_11",
+        "nix-bundle-lgx": "nix-bundle-lgx_32",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_11",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778177522,
+        "narHash": "sha256-sUGiatEU51cyZeATc3P/8b0myrAkCKavePpFwtkKxAI=",
+        "owner": "logos-co",
+        "repo": "logos-module-builder",
+        "rev": "b0e41abf3e14c0534b41933c5f8e3fc697319037",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module-builder",
+        "type": "github"
+      }
+    },
+    "logos-module-builder_12": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_53",
+        "logos-module": "logos-module_68",
+        "logos-nix": "logos-nix_516",
+        "logos-plugin-core": "logos-plugin-core_12",
+        "logos-plugin-qt": "logos-plugin-qt_12",
+        "logos-standalone-app": "logos-standalone-app_12",
+        "logos-test-framework": "logos-test-framework_12",
+        "nix-bundle-lgx": "nix-bundle-lgx_35",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_12",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -4544,17 +5522,17 @@
         "type": "github"
       }
     },
-    "logos-module-builder_11": {
+    "logos-module-builder_13": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_49",
-        "logos-module": "logos-module_63",
-        "logos-nix": "logos-nix_467",
-        "logos-plugin-core": "logos-plugin-core_11",
-        "logos-plugin-qt": "logos-plugin-qt_11",
-        "logos-standalone-app": "logos-standalone-app_11",
-        "logos-test-framework": "logos-test-framework_11",
-        "nix-bundle-lgx": "nix-bundle-lgx_32",
-        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_11",
+        "logos-cpp-sdk": "logos-cpp-sdk_58",
+        "logos-module": "logos-module_74",
+        "logos-nix": "logos-nix_559",
+        "logos-plugin-core": "logos-plugin-core_13",
+        "logos-plugin-qt": "logos-plugin-qt_13",
+        "logos-standalone-app": "logos-standalone-app_13",
+        "logos-test-framework": "logos-test-framework_13",
+        "nix-bundle-lgx": "nix-bundle-lgx_38",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_13",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -4582,17 +5560,17 @@
         "type": "github"
       }
     },
-    "logos-module-builder_12": {
+    "logos-module-builder_14": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_55",
-        "logos-module": "logos-module_70",
-        "logos-nix": "logos-nix_533",
-        "logos-plugin-core": "logos-plugin-core_12",
-        "logos-plugin-qt": "logos-plugin-qt_12",
-        "logos-standalone-app": "logos-standalone-app_12",
-        "logos-test-framework": "logos-test-framework_12",
-        "nix-bundle-lgx": "nix-bundle-lgx_36",
-        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_13",
+        "logos-cpp-sdk": "logos-cpp-sdk_64",
+        "logos-module": "logos-module_81",
+        "logos-nix": "logos-nix_625",
+        "logos-plugin-core": "logos-plugin-core_14",
+        "logos-plugin-qt": "logos-plugin-qt_14",
+        "logos-standalone-app": "logos-standalone-app_14",
+        "logos-test-framework": "logos-test-framework_14",
+        "nix-bundle-lgx": "nix-bundle-lgx_42",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_15",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -4617,17 +5595,17 @@
         "type": "github"
       }
     },
-    "logos-module-builder_13": {
+    "logos-module-builder_15": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_59",
-        "logos-module": "logos-module_76",
-        "logos-nix": "logos-nix_588",
-        "logos-plugin-core": "logos-plugin-core_13",
-        "logos-plugin-qt": "logos-plugin-qt_13",
-        "logos-standalone-app": "logos-standalone-app_13",
-        "logos-test-framework": "logos-test-framework_15",
-        "nix-bundle-lgx": "nix-bundle-lgx_46",
-        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_17",
+        "logos-cpp-sdk": "logos-cpp-sdk_68",
+        "logos-module": "logos-module_87",
+        "logos-nix": "logos-nix_680",
+        "logos-plugin-core": "logos-plugin-core_15",
+        "logos-plugin-qt": "logos-plugin-qt_15",
+        "logos-standalone-app": "logos-standalone-app_15",
+        "logos-test-framework": "logos-test-framework_17",
+        "nix-bundle-lgx": "nix-bundle-lgx_52",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_19",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -4650,17 +5628,17 @@
         "type": "github"
       }
     },
-    "logos-module-builder_14": {
+    "logos-module-builder_16": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_60",
-        "logos-module": "logos-module_79",
-        "logos-nix": "logos-nix_595",
-        "logos-plugin-core": "logos-plugin-core_14",
-        "logos-plugin-qt": "logos-plugin-qt_14",
-        "logos-standalone-app": "logos-standalone-app_14",
-        "logos-test-framework": "logos-test-framework_13",
-        "nix-bundle-lgx": "nix-bundle-lgx_40",
-        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_15",
+        "logos-cpp-sdk": "logos-cpp-sdk_69",
+        "logos-module": "logos-module_90",
+        "logos-nix": "logos-nix_687",
+        "logos-plugin-core": "logos-plugin-core_16",
+        "logos-plugin-qt": "logos-plugin-qt_16",
+        "logos-standalone-app": "logos-standalone-app_16",
+        "logos-test-framework": "logos-test-framework_15",
+        "nix-bundle-lgx": "nix-bundle-lgx_46",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_17",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -4686,17 +5664,17 @@
         "type": "github"
       }
     },
-    "logos-module-builder_15": {
+    "logos-module-builder_17": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_65",
-        "logos-module": "logos-module_85",
-        "logos-nix": "logos-nix_639",
-        "logos-plugin-core": "logos-plugin-core_15",
-        "logos-plugin-qt": "logos-plugin-qt_15",
-        "logos-standalone-app": "logos-standalone-app_15",
-        "logos-test-framework": "logos-test-framework_14",
-        "nix-bundle-lgx": "nix-bundle-lgx_43",
-        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_16",
+        "logos-cpp-sdk": "logos-cpp-sdk_74",
+        "logos-module": "logos-module_96",
+        "logos-nix": "logos-nix_731",
+        "logos-plugin-core": "logos-plugin-core_17",
+        "logos-plugin-qt": "logos-plugin-qt_17",
+        "logos-standalone-app": "logos-standalone-app_17",
+        "logos-test-framework": "logos-test-framework_16",
+        "nix-bundle-lgx": "nix-bundle-lgx_49",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_18",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -4827,15 +5805,15 @@
     },
     "logos-module-builder_5": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_18",
-        "logos-module": "logos-module_23",
-        "logos-nix": "logos-nix_169",
+        "logos-cpp-sdk": "logos-cpp-sdk_19",
+        "logos-module": "logos-module_24",
+        "logos-nix": "logos-nix_179",
         "logos-plugin-core": "logos-plugin-core_5",
         "logos-plugin-qt": "logos-plugin-qt_5",
         "logos-standalone-app": "logos-standalone-app_5",
-        "logos-test-framework": "logos-test-framework_5",
-        "nix-bundle-lgx": "nix-bundle-lgx_14",
-        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_5",
+        "logos-test-framework": "logos-test-framework_7",
+        "nix-bundle-lgx": "nix-bundle-lgx_20",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_7",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -4846,11 +5824,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778177522,
-        "narHash": "sha256-sUGiatEU51cyZeATc3P/8b0myrAkCKavePpFwtkKxAI=",
+        "lastModified": 1781208169,
+        "narHash": "sha256-u+GUBX0Evswa2tRwuUybsiUU+7O0wnNh33GJDBwk9ps=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "b0e41abf3e14c0534b41933c5f8e3fc697319037",
+        "rev": "fd07679ecfa1b2d8cfdd06799f3e03ed385b57f6",
         "type": "github"
       },
       "original": {
@@ -4861,19 +5839,21 @@
     },
     "logos-module-builder_6": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_23",
-        "logos-module": "logos-module_30",
-        "logos-nix": "logos-nix_225",
+        "logos-cpp-sdk": "logos-cpp-sdk_20",
+        "logos-module": "logos-module_27",
+        "logos-nix": "logos-nix_186",
         "logos-plugin-core": "logos-plugin-core_6",
         "logos-plugin-qt": "logos-plugin-qt_6",
         "logos-standalone-app": "logos-standalone-app_6",
-        "logos-test-framework": "logos-test-framework_6",
-        "nix-bundle-lgx": "nix-bundle-lgx_17",
-        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_6",
+        "logos-test-framework": "logos-test-framework_5",
+        "nix-bundle-lgx": "nix-bundle-lgx_14",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_5",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-nix",
@@ -4896,19 +5876,22 @@
     },
     "logos-module-builder_7": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_28",
-        "logos-module": "logos-module_37",
-        "logos-nix": "logos-nix_276",
+        "logos-cpp-sdk": "logos-cpp-sdk_25",
+        "logos-module": "logos-module_33",
+        "logos-nix": "logos-nix_230",
         "logos-plugin-core": "logos-plugin-core_7",
         "logos-plugin-qt": "logos-plugin-qt_7",
         "logos-standalone-app": "logos-standalone-app_7",
-        "logos-test-framework": "logos-test-framework_7",
-        "nix-bundle-lgx": "nix-bundle-lgx_20",
-        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_7",
+        "logos-test-framework": "logos-test-framework_6",
+        "nix-bundle-lgx": "nix-bundle-lgx_17",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_6",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-nix",
@@ -4931,9 +5914,9 @@
     },
     "logos-module-builder_8": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_33",
-        "logos-module": "logos-module_43",
-        "logos-nix": "logos-nix_319",
+        "logos-cpp-sdk": "logos-cpp-sdk_32",
+        "logos-module": "logos-module_41",
+        "logos-nix": "logos-nix_317",
         "logos-plugin-core": "logos-plugin-core_8",
         "logos-plugin-qt": "logos-plugin-qt_8",
         "logos-standalone-app": "logos-standalone-app_8",
@@ -4943,7 +5926,6 @@
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -4967,9 +5949,9 @@
     },
     "logos-module-builder_9": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_39",
-        "logos-module": "logos-module_50",
-        "logos-nix": "logos-nix_373",
+        "logos-cpp-sdk": "logos-cpp-sdk_37",
+        "logos-module": "logos-module_48",
+        "logos-nix": "logos-nix_368",
         "logos-plugin-core": "logos-plugin-core_9",
         "logos-plugin-qt": "logos-plugin-qt_9",
         "logos-standalone-app": "logos-standalone-app_9",
@@ -4980,8 +5962,6 @@
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-nix",
@@ -5004,8 +5984,8 @@
     },
     "logos-module-client": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_38",
-        "logos-nix": "logos-nix_369",
+        "logos-cpp-sdk": "logos-cpp-sdk_47",
+        "logos-nix": "logos-nix_461",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -5031,8 +6011,8 @@
     },
     "logos-module-client_2": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_54",
-        "logos-nix": "logos-nix_517",
+        "logos-cpp-sdk": "logos-cpp-sdk_63",
+        "logos-nix": "logos-nix_609",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -5058,6 +6038,59 @@
         "type": "github"
       }
     },
+    "logos-module-loader": {
+      "inputs": {
+        "logos-container": "logos-container_3",
+        "logos-nix": "logos-nix_173",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-module-loader",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781732584,
+        "narHash": "sha256-v1eIGPXTnW0oCwEvEjEoBLeoidUh3ZomDGQY9m/ucNw=",
+        "owner": "logos-co",
+        "repo": "logos-module-loader",
+        "rev": "7ed7a5a97e1ad9142187d755c4ce56ed17d69f18",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module-loader",
+        "type": "github"
+      }
+    },
+    "logos-module-loader_2": {
+      "inputs": {
+        "logos-container": "logos-container_5",
+        "logos-nix": "logos-nix_302",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-module-loader",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781732584,
+        "narHash": "sha256-v1eIGPXTnW0oCwEvEjEoBLeoidUh3ZomDGQY9m/ucNw=",
+        "owner": "logos-co",
+        "repo": "logos-module-loader",
+        "rev": "7ed7a5a97e1ad9142187d755c4ce56ed17d69f18",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module-loader",
+        "type": "github"
+      }
+    },
     "logos-module_10": {
       "inputs": {
         "logos-nix": "logos-nix_55",
@@ -5067,6 +6100,99 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_100": {
+      "inputs": {
+        "logos-nix": "logos-nix_741",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_101": {
+      "inputs": {
+        "logos-nix": "logos-nix_744",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_102": {
+      "inputs": {
+        "logos-nix": "logos-nix_772",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -5453,7 +6579,33 @@
     },
     "logos-module_23": {
       "inputs": {
-        "logos-nix": "logos-nix_168",
+        "logos-nix": "logos-nix_171",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781311603,
+        "narHash": "sha256-Ym3i52f5MWuZy8Qas3+zfoxz+mxQUsyW+Qol1no6kDs=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "a3e288a71d6f79445db598b0ffcca2ee435596b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_24": {
+      "inputs": {
+        "logos-nix": "logos-nix_178",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -5465,11 +6617,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "lastModified": 1780603603,
+        "narHash": "sha256-CV7R+lwNIP0baXZtE9uNjqu7qDLiANwyGfMkHfTjcl0=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "rev": "780894dd40ebc8eded0fa97b1729286f31571cfb",
         "type": "github"
       },
       "original": {
@@ -5478,9 +6630,9 @@
         "type": "github"
       }
     },
-    "logos-module_24": {
+    "logos-module_25": {
       "inputs": {
-        "logos-nix": "logos-nix_170",
+        "logos-nix": "logos-nix_180",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -5506,9 +6658,9 @@
         "type": "github"
       }
     },
-    "logos-module_25": {
+    "logos-module_26": {
       "inputs": {
-        "logos-nix": "logos-nix_172",
+        "logos-nix": "logos-nix_182",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -5534,57 +6686,28 @@
         "type": "github"
       }
     },
-    "logos-module_26": {
-      "inputs": {
-        "logos-nix": "logos-nix_174",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
     "logos-module_27": {
       "inputs": {
-        "logos-nix": "logos-nix_179",
+        "logos-nix": "logos-nix_185",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
         "type": "github"
       },
       "original": {
@@ -5595,14 +6718,16 @@
     },
     "logos-module_28": {
       "inputs": {
-        "logos-nix": "logos-nix_182",
+        "logos-nix": "logos-nix_187",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -5624,21 +6749,27 @@
     },
     "logos-module_29": {
       "inputs": {
-        "logos-nix": "logos-nix_210",
+        "logos-nix": "logos-nix_189",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781310867,
-        "narHash": "sha256-Ym3i52f5MWuZy8Qas3+zfoxz+mxQUsyW+Qol1no6kDs=",
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "b42805dac2874d8f72e1c12f7ac6a92ca7e5452c",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
         "type": "github"
       },
       "original": {
@@ -5674,24 +6805,28 @@
     },
     "logos-module_30": {
       "inputs": {
-        "logos-nix": "logos-nix_224",
+        "logos-nix": "logos-nix_191",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
         "type": "github"
       },
       "original": {
@@ -5702,25 +6837,29 @@
     },
     "logos-module_31": {
       "inputs": {
-        "logos-nix": "logos-nix_226",
+        "logos-nix": "logos-nix_196",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
         "type": "github"
       },
       "original": {
@@ -5731,14 +6870,17 @@
     },
     "logos-module_32": {
       "inputs": {
-        "logos-nix": "logos-nix_228",
+        "logos-nix": "logos-nix_199",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -5760,26 +6902,27 @@
     },
     "logos-module_33": {
       "inputs": {
-        "logos-nix": "logos-nix_230",
+        "logos-nix": "logos-nix_229",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
           "logos-capability-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
         "type": "github"
       },
       "original": {
@@ -5790,126 +6933,14 @@
     },
     "logos-module_34": {
       "inputs": {
-        "logos-nix": "logos-nix_235",
+        "logos-nix": "logos-nix_231",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_35": {
-      "inputs": {
-        "logos-nix": "logos-nix_238",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_36": {
-      "inputs": {
-        "logos-nix": "logos-nix_266",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_37": {
-      "inputs": {
-        "logos-nix": "logos-nix_275",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_38": {
-      "inputs": {
-        "logos-nix": "logos-nix_277",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
@@ -5932,16 +6963,148 @@
         "type": "github"
       }
     },
-    "logos-module_39": {
+    "logos-module_35": {
       "inputs": {
-        "logos-nix": "logos-nix_279",
+        "logos-nix": "logos-nix_233",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_36": {
+      "inputs": {
+        "logos-nix": "logos-nix_235",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_37": {
+      "inputs": {
+        "logos-nix": "logos-nix_240",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_38": {
+      "inputs": {
+        "logos-nix": "logos-nix_243",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_39": {
+      "inputs": {
+        "logos-nix": "logos-nix_271",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -5990,26 +7153,21 @@
     },
     "logos-module_40": {
       "inputs": {
-        "logos-nix": "logos-nix_281",
+        "logos-nix": "logos-nix_300",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
+          "logos-liblogos",
           "logos-module",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "lastModified": 1781311603,
+        "narHash": "sha256-Ym3i52f5MWuZy8Qas3+zfoxz+mxQUsyW+Qol1no6kDs=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "rev": "a3e288a71d6f79445db598b0ffcca2ee435596b9",
         "type": "github"
       },
       "original": {
@@ -6020,27 +7178,24 @@
     },
     "logos-module_41": {
       "inputs": {
-        "logos-nix": "logos-nix_286",
+        "logos-nix": "logos-nix_316",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
         "type": "github"
       },
       "original": {
@@ -6051,70 +7206,10 @@
     },
     "logos-module_42": {
       "inputs": {
-        "logos-nix": "logos-nix_289",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_43": {
-      "inputs": {
         "logos-nix": "logos-nix_318",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_44": {
-      "inputs": {
-        "logos-nix": "logos-nix_320",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -6138,13 +7233,12 @@
         "type": "github"
       }
     },
-    "logos-module_45": {
+    "logos-module_43": {
       "inputs": {
-        "logos-nix": "logos-nix_322",
+        "logos-nix": "logos-nix_320",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -6168,76 +7262,73 @@
         "type": "github"
       }
     },
+    "logos-module_44": {
+      "inputs": {
+        "logos-nix": "logos-nix_322",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_45": {
+      "inputs": {
+        "logos-nix": "logos-nix_327",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
     "logos-module_46": {
       "inputs": {
-        "logos-nix": "logos-nix_324",
+        "logos-nix": "logos-nix_330",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_47": {
-      "inputs": {
-        "logos-nix": "logos-nix_329",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_48": {
-      "inputs": {
-        "logos-nix": "logos-nix_332",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -6262,14 +7353,70 @@
         "type": "github"
       }
     },
-    "logos-module_49": {
+    "logos-module_47": {
       "inputs": {
-        "logos-nix": "logos-nix_360",
+        "logos-nix": "logos-nix_358",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_48": {
+      "inputs": {
+        "logos-nix": "logos-nix_367",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_49": {
+      "inputs": {
+        "logos-nix": "logos-nix_369",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -6319,74 +7466,11 @@
     },
     "logos-module_50": {
       "inputs": {
-        "logos-nix": "logos-nix_372",
+        "logos-nix": "logos-nix_371",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_51": {
-      "inputs": {
-        "logos-nix": "logos-nix_374",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_52": {
-      "inputs": {
-        "logos-nix": "logos-nix_376",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
@@ -6409,15 +7493,13 @@
         "type": "github"
       }
     },
-    "logos-module_53": {
+    "logos-module_51": {
       "inputs": {
-        "logos-nix": "logos-nix_378",
+        "logos-nix": "logos-nix_373",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -6433,6 +7515,67 @@
         "owner": "logos-co",
         "repo": "logos-module",
         "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_52": {
+      "inputs": {
+        "logos-nix": "logos-nix_378",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_53": {
+      "inputs": {
+        "logos-nix": "logos-nix_381",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
         "type": "github"
       },
       "original": {
@@ -6443,29 +7586,25 @@
     },
     "logos-module_54": {
       "inputs": {
-        "logos-nix": "logos-nix_383",
+        "logos-nix": "logos-nix_410",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
         "type": "github"
       },
       "original": {
@@ -6476,17 +7615,15 @@
     },
     "logos-module_55": {
       "inputs": {
-        "logos-nix": "logos-nix_386",
+        "logos-nix": "logos-nix_412",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -6513,8 +7650,10 @@
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -6536,26 +7675,27 @@
     },
     "logos-module_57": {
       "inputs": {
-        "logos-nix": "logos-nix_423",
+        "logos-nix": "logos-nix_416",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
         "type": "github"
       },
       "original": {
@@ -6566,27 +7706,28 @@
     },
     "logos-module_58": {
       "inputs": {
-        "logos-nix": "logos-nix_425",
+        "logos-nix": "logos-nix_421",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
         "type": "github"
       },
       "original": {
@@ -6597,16 +7738,16 @@
     },
     "logos-module_59": {
       "inputs": {
-        "logos-nix": "logos-nix_427",
+        "logos-nix": "logos-nix_424",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -6656,28 +7797,23 @@
     },
     "logos-module_60": {
       "inputs": {
-        "logos-nix": "logos-nix_429",
+        "logos-nix": "logos-nix_452",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
+          "logos-liblogos",
           "logos-module",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
         "type": "github"
       },
       "original": {
@@ -6688,29 +7824,26 @@
     },
     "logos-module_61": {
       "inputs": {
-        "logos-nix": "logos-nix_434",
+        "logos-nix": "logos-nix_464",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
         "type": "github"
       },
       "original": {
@@ -6721,76 +7854,12 @@
     },
     "logos-module_62": {
       "inputs": {
-        "logos-nix": "logos-nix_437",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_63": {
-      "inputs": {
         "logos-nix": "logos-nix_466",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_64": {
-      "inputs": {
-        "logos-nix": "logos-nix_468",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -6814,15 +7883,14 @@
         "type": "github"
       }
     },
-    "logos-module_65": {
+    "logos-module_63": {
       "inputs": {
-        "logos-nix": "logos-nix_470",
+        "logos-nix": "logos-nix_468",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -6846,82 +7914,79 @@
         "type": "github"
       }
     },
+    "logos-module_64": {
+      "inputs": {
+        "logos-nix": "logos-nix_470",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_65": {
+      "inputs": {
+        "logos-nix": "logos-nix_475",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
     "logos-module_66": {
       "inputs": {
-        "logos-nix": "logos-nix_472",
+        "logos-nix": "logos-nix_478",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_67": {
-      "inputs": {
-        "logos-nix": "logos-nix_477",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_68": {
-      "inputs": {
-        "logos-nix": "logos-nix_480",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -6946,16 +8011,76 @@
         "type": "github"
       }
     },
-    "logos-module_69": {
+    "logos-module_67": {
       "inputs": {
-        "logos-nix": "logos-nix_508",
+        "logos-nix": "logos-nix_506",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_68": {
+      "inputs": {
+        "logos-nix": "logos-nix_515",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_69": {
+      "inputs": {
+        "logos-nix": "logos-nix_517",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -7006,13 +8131,16 @@
     },
     "logos-module_70": {
       "inputs": {
-        "logos-nix": "logos-nix_532",
+        "logos-nix": "logos-nix_519",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
           "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -7034,25 +8162,28 @@
     },
     "logos-module_71": {
       "inputs": {
-        "logos-nix": "logos-nix_534",
+        "logos-nix": "logos-nix_521",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
         "type": "github"
       },
       "original": {
@@ -7063,14 +8194,50 @@
     },
     "logos-module_72": {
       "inputs": {
-        "logos-nix": "logos-nix_536",
+        "logos-nix": "logos-nix_526",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_73": {
+      "inputs": {
+        "logos-nix": "logos-nix_529",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -7090,59 +8257,29 @@
         "type": "github"
       }
     },
-    "logos-module_73": {
-      "inputs": {
-        "logos-nix": "logos-nix_538",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
     "logos-module_74": {
       "inputs": {
-        "logos-nix": "logos-nix_543",
+        "logos-nix": "logos-nix_558",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
+          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
         "type": "github"
       },
       "original": {
@@ -7153,15 +8290,17 @@
     },
     "logos-module_75": {
       "inputs": {
-        "logos-nix": "logos-nix_546",
+        "logos-nix": "logos-nix_560",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
+          "logos-logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -7183,63 +8322,15 @@
     },
     "logos-module_76": {
       "inputs": {
-        "logos-nix": "logos-nix_587",
+        "logos-nix": "logos-nix_562",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1780603603,
-        "narHash": "sha256-CV7R+lwNIP0baXZtE9uNjqu7qDLiANwyGfMkHfTjcl0=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "780894dd40ebc8eded0fa97b1729286f31571cfb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_77": {
-      "inputs": {
-        "logos-nix": "logos-nix_589",
-        "nixpkgs": [
-          "logoscore-cli",
+          "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_78": {
-      "inputs": {
-        "logos-nix": "logos-nix_591",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-module",
@@ -7261,16 +8352,87 @@
         "type": "github"
       }
     },
-    "logos-module_79": {
+    "logos-module_77": {
       "inputs": {
-        "logos-nix": "logos-nix_594",
+        "logos-nix": "logos-nix_564",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-capability-module",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_78": {
+      "inputs": {
+        "logos-nix": "logos-nix_569",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_79": {
+      "inputs": {
+        "logos-nix": "logos-nix_572",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -7322,15 +8484,14 @@
     },
     "logos-module_80": {
       "inputs": {
-        "logos-nix": "logos-nix_596",
+        "logos-nix": "logos-nix_600",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -7352,15 +8513,13 @@
     },
     "logos-module_81": {
       "inputs": {
-        "logos-nix": "logos-nix_598",
+        "logos-nix": "logos-nix_624",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -7382,138 +8541,12 @@
     },
     "logos-module_82": {
       "inputs": {
-        "logos-nix": "logos-nix_600",
+        "logos-nix": "logos-nix_626",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_83": {
-      "inputs": {
-        "logos-nix": "logos-nix_605",
-        "nixpkgs": [
-          "logoscore-cli",
+          "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773963329,
-        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_84": {
-      "inputs": {
-        "logos-nix": "logos-nix_608",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_85": {
-      "inputs": {
-        "logos-nix": "logos-nix_638",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_86": {
-      "inputs": {
-        "logos-nix": "logos-nix_640",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-module",
@@ -7535,16 +8568,14 @@
         "type": "github"
       }
     },
-    "logos-module_87": {
+    "logos-module_83": {
       "inputs": {
-        "logos-nix": "logos-nix_642",
+        "logos-nix": "logos-nix_628",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-module",
@@ -7566,16 +8597,14 @@
         "type": "github"
       }
     },
-    "logos-module_88": {
+    "logos-module_84": {
       "inputs": {
-        "logos-nix": "logos-nix_644",
+        "logos-nix": "logos-nix_630",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-capability-module",
@@ -7598,16 +8627,14 @@
         "type": "github"
       }
     },
-    "logos-module_89": {
+    "logos-module_85": {
       "inputs": {
-        "logos-nix": "logos-nix_649",
+        "logos-nix": "logos-nix_635",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7623,6 +8650,116 @@
         "owner": "logos-co",
         "repo": "logos-module",
         "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_86": {
+      "inputs": {
+        "logos-nix": "logos-nix_638",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_87": {
+      "inputs": {
+        "logos-nix": "logos-nix_679",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780603603,
+        "narHash": "sha256-CV7R+lwNIP0baXZtE9uNjqu7qDLiANwyGfMkHfTjcl0=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "780894dd40ebc8eded0fa97b1729286f31571cfb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_88": {
+      "inputs": {
+        "logos-nix": "logos-nix_681",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_89": {
+      "inputs": {
+        "logos-nix": "logos-nix_683",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
         "type": "github"
       },
       "original": {
@@ -7662,13 +8799,164 @@
     },
     "logos-module_90": {
       "inputs": {
-        "logos-nix": "logos-nix_652",
+        "logos-nix": "logos-nix_686",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_91": {
+      "inputs": {
+        "logos-nix": "logos-nix_688",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_92": {
+      "inputs": {
+        "logos-nix": "logos-nix_690",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_93": {
+      "inputs": {
+        "logos-nix": "logos-nix_692",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_94": {
+      "inputs": {
+        "logos-nix": "logos-nix_697",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_95": {
+      "inputs": {
+        "logos-nix": "logos-nix_700",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -7692,15 +8980,17 @@
         "type": "github"
       }
     },
-    "logos-module_91": {
+    "logos-module_96": {
       "inputs": {
-        "logos-nix": "logos-nix_680",
+        "logos-nix": "logos-nix_730",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -7712,6 +9002,100 @@
         "owner": "logos-co",
         "repo": "logos-module",
         "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_97": {
+      "inputs": {
+        "logos-nix": "logos-nix_732",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_98": {
+      "inputs": {
+        "logos-nix": "logos-nix_734",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776369033,
+        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_99": {
+      "inputs": {
+        "logos-nix": "logos-nix_736",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773963329,
+        "narHash": "sha256-zdvDHoYWQDse0eJ/UCKIJcfuYJ8NMgl6QfxRcyDEovI=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "ac5a4f06ea94b01dd9c5fbb9ed4f20620beab88d",
         "type": "github"
       },
       "original": {
@@ -9093,11 +10477,11 @@
         "nixpkgs": "nixpkgs_169"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9147,24 +10531,6 @@
         "nixpkgs": "nixpkgs_171"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_171": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_172"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -9178,9 +10544,9 @@
         "type": "github"
       }
     },
-    "logos-nix_172": {
+    "logos-nix_171": {
       "inputs": {
-        "nixpkgs": "nixpkgs_173"
+        "nixpkgs": "nixpkgs_172"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -9188,6 +10554,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_172": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_173"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9219,11 +10603,11 @@
         "nixpkgs": "nixpkgs_175"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9237,11 +10621,11 @@
         "nixpkgs": "nixpkgs_176"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9273,11 +10657,11 @@
         "nixpkgs": "nixpkgs_178"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9309,11 +10693,11 @@
         "nixpkgs": "nixpkgs_180"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9453,11 +10837,11 @@
         "nixpkgs": "nixpkgs_187"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9489,11 +10873,11 @@
         "nixpkgs": "nixpkgs_189"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9579,11 +10963,11 @@
         "nixpkgs": "nixpkgs_193"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -9651,11 +11035,11 @@
         "nixpkgs": "nixpkgs_197"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -9669,11 +11053,11 @@
         "nixpkgs": "nixpkgs_198"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -9687,11 +11071,11 @@
         "nixpkgs": "nixpkgs_199"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9867,11 +11251,11 @@
         "nixpkgs": "nixpkgs_207"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -9885,11 +11269,11 @@
         "nixpkgs": "nixpkgs_208"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9957,11 +11341,11 @@
         "nixpkgs": "nixpkgs_211"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9975,11 +11359,11 @@
         "nixpkgs": "nixpkgs_212"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -9993,11 +11377,11 @@
         "nixpkgs": "nixpkgs_213"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10011,11 +11395,11 @@
         "nixpkgs": "nixpkgs_214"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10029,11 +11413,11 @@
         "nixpkgs": "nixpkgs_215"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10155,11 +11539,11 @@
         "nixpkgs": "nixpkgs_221"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10173,11 +11557,11 @@
         "nixpkgs": "nixpkgs_222"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10191,11 +11575,11 @@
         "nixpkgs": "nixpkgs_223"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10245,11 +11629,11 @@
         "nixpkgs": "nixpkgs_226"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10263,11 +11647,11 @@
         "nixpkgs": "nixpkgs_227"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10281,24 +11665,6 @@
         "nixpkgs": "nixpkgs_228"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_228": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_229"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -10312,9 +11678,9 @@
         "type": "github"
       }
     },
-    "logos-nix_229": {
+    "logos-nix_228": {
       "inputs": {
-        "nixpkgs": "nixpkgs_230"
+        "nixpkgs": "nixpkgs_229"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -10322,6 +11688,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_229": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_230"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10353,11 +11737,11 @@
         "nixpkgs": "nixpkgs_231"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10425,11 +11809,11 @@
         "nixpkgs": "nixpkgs_235"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10515,11 +11899,11 @@
         "nixpkgs": "nixpkgs_240"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10551,11 +11935,11 @@
         "nixpkgs": "nixpkgs_241"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10587,11 +11971,11 @@
         "nixpkgs": "nixpkgs_243"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10623,11 +12007,11 @@
         "nixpkgs": "nixpkgs_245"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10641,11 +12025,11 @@
         "nixpkgs": "nixpkgs_246"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10659,11 +12043,11 @@
         "nixpkgs": "nixpkgs_247"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10695,11 +12079,11 @@
         "nixpkgs": "nixpkgs_249"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10713,11 +12097,11 @@
         "nixpkgs": "nixpkgs_250"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10767,11 +12151,11 @@
         "nixpkgs": "nixpkgs_252"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10785,11 +12169,11 @@
         "nixpkgs": "nixpkgs_253"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10821,11 +12205,11 @@
         "nixpkgs": "nixpkgs_255"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10857,11 +12241,11 @@
         "nixpkgs": "nixpkgs_257"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10893,11 +12277,11 @@
         "nixpkgs": "nixpkgs_259"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10965,11 +12349,11 @@
         "nixpkgs": "nixpkgs_262"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11037,11 +12421,11 @@
         "nixpkgs": "nixpkgs_266"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11091,11 +12475,11 @@
         "nixpkgs": "nixpkgs_269"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11145,11 +12529,11 @@
         "nixpkgs": "nixpkgs_271"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11181,11 +12565,11 @@
         "nixpkgs": "nixpkgs_273"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11199,11 +12583,11 @@
         "nixpkgs": "nixpkgs_274"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11217,11 +12601,11 @@
         "nixpkgs": "nixpkgs_275"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11253,11 +12637,11 @@
         "nixpkgs": "nixpkgs_277"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11289,11 +12673,11 @@
         "nixpkgs": "nixpkgs_279"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11307,11 +12691,11 @@
         "nixpkgs": "nixpkgs_280"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11343,11 +12727,11 @@
         "nixpkgs": "nixpkgs_281"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11361,11 +12745,11 @@
         "nixpkgs": "nixpkgs_282"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11379,11 +12763,11 @@
         "nixpkgs": "nixpkgs_283"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11397,11 +12781,11 @@
         "nixpkgs": "nixpkgs_284"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11433,11 +12817,11 @@
         "nixpkgs": "nixpkgs_286"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11451,11 +12835,11 @@
         "nixpkgs": "nixpkgs_287"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11487,11 +12871,11 @@
         "nixpkgs": "nixpkgs_289"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11505,11 +12889,11 @@
         "nixpkgs": "nixpkgs_290"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11559,11 +12943,11 @@
         "nixpkgs": "nixpkgs_292"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11631,11 +13015,11 @@
         "nixpkgs": "nixpkgs_296"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11667,11 +13051,11 @@
         "nixpkgs": "nixpkgs_298"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11685,11 +13069,11 @@
         "nixpkgs": "nixpkgs_299"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11757,11 +13141,11 @@
         "nixpkgs": "nixpkgs_301"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11775,11 +13159,11 @@
         "nixpkgs": "nixpkgs_302"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11793,11 +13177,11 @@
         "nixpkgs": "nixpkgs_303"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11883,11 +13267,11 @@
         "nixpkgs": "nixpkgs_308"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11901,11 +13285,11 @@
         "nixpkgs": "nixpkgs_309"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11919,11 +13303,11 @@
         "nixpkgs": "nixpkgs_310"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11955,11 +13339,11 @@
         "nixpkgs": "nixpkgs_311"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11991,11 +13375,11 @@
         "nixpkgs": "nixpkgs_313"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12027,11 +13411,11 @@
         "nixpkgs": "nixpkgs_315"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12045,11 +13429,11 @@
         "nixpkgs": "nixpkgs_316"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12063,11 +13447,11 @@
         "nixpkgs": "nixpkgs_317"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12207,11 +13591,11 @@
         "nixpkgs": "nixpkgs_324"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12225,11 +13609,11 @@
         "nixpkgs": "nixpkgs_325"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12261,11 +13645,11 @@
         "nixpkgs": "nixpkgs_327"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12315,11 +13699,11 @@
         "nixpkgs": "nixpkgs_330"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12387,11 +13771,11 @@
         "nixpkgs": "nixpkgs_333"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12405,11 +13789,11 @@
         "nixpkgs": "nixpkgs_334"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12423,11 +13807,11 @@
         "nixpkgs": "nixpkgs_335"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12495,11 +13879,11 @@
         "nixpkgs": "nixpkgs_339"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12567,11 +13951,11 @@
         "nixpkgs": "nixpkgs_342"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12585,11 +13969,11 @@
         "nixpkgs": "nixpkgs_343"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12603,11 +13987,11 @@
         "nixpkgs": "nixpkgs_344"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12621,11 +14005,11 @@
         "nixpkgs": "nixpkgs_345"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12639,11 +14023,11 @@
         "nixpkgs": "nixpkgs_346"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12657,11 +14041,11 @@
         "nixpkgs": "nixpkgs_347"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12675,11 +14059,11 @@
         "nixpkgs": "nixpkgs_348"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12693,11 +14077,11 @@
         "nixpkgs": "nixpkgs_349"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12711,11 +14095,11 @@
         "nixpkgs": "nixpkgs_350"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12747,11 +14131,11 @@
         "nixpkgs": "nixpkgs_351"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12765,11 +14149,11 @@
         "nixpkgs": "nixpkgs_352"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12819,11 +14203,11 @@
         "nixpkgs": "nixpkgs_355"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12855,11 +14239,11 @@
         "nixpkgs": "nixpkgs_357"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12873,11 +14257,11 @@
         "nixpkgs": "nixpkgs_358"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12945,11 +14329,11 @@
         "nixpkgs": "nixpkgs_361"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12963,11 +14347,11 @@
         "nixpkgs": "nixpkgs_362"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12981,11 +14365,11 @@
         "nixpkgs": "nixpkgs_363"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13053,11 +14437,11 @@
         "nixpkgs": "nixpkgs_367"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13107,11 +14491,11 @@
         "nixpkgs": "nixpkgs_370"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13161,24 +14545,6 @@
         "nixpkgs": "nixpkgs_372"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_372": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_373"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -13192,9 +14558,9 @@
         "type": "github"
       }
     },
-    "logos-nix_373": {
+    "logos-nix_372": {
       "inputs": {
-        "nixpkgs": "nixpkgs_374"
+        "nixpkgs": "nixpkgs_373"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -13202,6 +14568,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_373": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_374"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13269,11 +14653,11 @@
         "nixpkgs": "nixpkgs_378"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13377,11 +14761,11 @@
         "nixpkgs": "nixpkgs_383"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13395,11 +14779,11 @@
         "nixpkgs": "nixpkgs_384"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13431,11 +14815,11 @@
         "nixpkgs": "nixpkgs_386"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13467,11 +14851,11 @@
         "nixpkgs": "nixpkgs_388"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13485,11 +14869,11 @@
         "nixpkgs": "nixpkgs_389"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13503,11 +14887,11 @@
         "nixpkgs": "nixpkgs_390"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13557,11 +14941,11 @@
         "nixpkgs": "nixpkgs_392"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13575,11 +14959,11 @@
         "nixpkgs": "nixpkgs_393"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13611,11 +14995,11 @@
         "nixpkgs": "nixpkgs_395"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13629,11 +15013,11 @@
         "nixpkgs": "nixpkgs_396"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13665,11 +15049,11 @@
         "nixpkgs": "nixpkgs_398"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13701,11 +15085,11 @@
         "nixpkgs": "nixpkgs_400"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13773,11 +15157,11 @@
         "nixpkgs": "nixpkgs_402"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13827,11 +15211,11 @@
         "nixpkgs": "nixpkgs_405"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13899,11 +15283,11 @@
         "nixpkgs": "nixpkgs_409"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13917,11 +15301,11 @@
         "nixpkgs": "nixpkgs_410"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13953,11 +15337,11 @@
         "nixpkgs": "nixpkgs_411"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13971,11 +15355,11 @@
         "nixpkgs": "nixpkgs_412"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14061,11 +15445,11 @@
         "nixpkgs": "nixpkgs_417"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14097,11 +15481,11 @@
         "nixpkgs": "nixpkgs_419"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14187,11 +15571,11 @@
         "nixpkgs": "nixpkgs_423"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14205,24 +15589,6 @@
         "nixpkgs": "nixpkgs_424"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_424": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_425"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -14236,9 +15602,9 @@
         "type": "github"
       }
     },
-    "logos-nix_425": {
+    "logos-nix_424": {
       "inputs": {
-        "nixpkgs": "nixpkgs_426"
+        "nixpkgs": "nixpkgs_425"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -14246,6 +15612,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_425": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_426"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14295,11 +15679,11 @@
         "nixpkgs": "nixpkgs_429"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14367,11 +15751,11 @@
         "nixpkgs": "nixpkgs_432"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14385,11 +15769,11 @@
         "nixpkgs": "nixpkgs_433"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14421,11 +15805,11 @@
         "nixpkgs": "nixpkgs_435"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14439,11 +15823,11 @@
         "nixpkgs": "nixpkgs_436"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14457,11 +15841,11 @@
         "nixpkgs": "nixpkgs_437"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14583,11 +15967,11 @@
         "nixpkgs": "nixpkgs_443"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14601,11 +15985,11 @@
         "nixpkgs": "nixpkgs_444"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14637,11 +16021,11 @@
         "nixpkgs": "nixpkgs_446"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14673,11 +16057,11 @@
         "nixpkgs": "nixpkgs_448"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14781,11 +16165,11 @@
         "nixpkgs": "nixpkgs_453"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14799,11 +16183,11 @@
         "nixpkgs": "nixpkgs_454"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14817,11 +16201,11 @@
         "nixpkgs": "nixpkgs_455"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14835,11 +16219,11 @@
         "nixpkgs": "nixpkgs_456"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14853,11 +16237,11 @@
         "nixpkgs": "nixpkgs_457"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14943,11 +16327,11 @@
         "nixpkgs": "nixpkgs_461"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14979,11 +16363,11 @@
         "nixpkgs": "nixpkgs_463"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14997,11 +16381,11 @@
         "nixpkgs": "nixpkgs_464"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15015,11 +16399,11 @@
         "nixpkgs": "nixpkgs_465"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15159,11 +16543,11 @@
         "nixpkgs": "nixpkgs_472"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15177,11 +16561,11 @@
         "nixpkgs": "nixpkgs_473"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15213,11 +16597,11 @@
         "nixpkgs": "nixpkgs_475"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15267,11 +16651,11 @@
         "nixpkgs": "nixpkgs_478"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15339,11 +16723,11 @@
         "nixpkgs": "nixpkgs_481"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15357,11 +16741,11 @@
         "nixpkgs": "nixpkgs_482"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15375,11 +16759,11 @@
         "nixpkgs": "nixpkgs_483"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15447,11 +16831,11 @@
         "nixpkgs": "nixpkgs_487"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15501,11 +16885,11 @@
         "nixpkgs": "nixpkgs_490"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15537,11 +16921,11 @@
         "nixpkgs": "nixpkgs_491"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15555,11 +16939,11 @@
         "nixpkgs": "nixpkgs_492"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15573,11 +16957,11 @@
         "nixpkgs": "nixpkgs_493"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15591,11 +16975,11 @@
         "nixpkgs": "nixpkgs_494"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15609,11 +16993,11 @@
         "nixpkgs": "nixpkgs_495"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15627,11 +17011,11 @@
         "nixpkgs": "nixpkgs_496"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15645,11 +17029,11 @@
         "nixpkgs": "nixpkgs_497"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15663,11 +17047,11 @@
         "nixpkgs": "nixpkgs_498"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15681,11 +17065,11 @@
         "nixpkgs": "nixpkgs_499"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15699,11 +17083,11 @@
         "nixpkgs": "nixpkgs_500"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15789,11 +17173,11 @@
         "nixpkgs": "nixpkgs_503"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15825,11 +17209,11 @@
         "nixpkgs": "nixpkgs_505"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15843,11 +17227,11 @@
         "nixpkgs": "nixpkgs_506"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15897,11 +17281,11 @@
         "nixpkgs": "nixpkgs_509"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15915,11 +17299,11 @@
         "nixpkgs": "nixpkgs_510"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15951,11 +17335,11 @@
         "nixpkgs": "nixpkgs_511"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16023,11 +17407,11 @@
         "nixpkgs": "nixpkgs_515"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16077,11 +17461,11 @@
         "nixpkgs": "nixpkgs_518"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16113,11 +17497,11 @@
         "nixpkgs": "nixpkgs_520"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16149,11 +17533,11 @@
         "nixpkgs": "nixpkgs_521"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16185,11 +17569,11 @@
         "nixpkgs": "nixpkgs_523"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16347,11 +17731,11 @@
         "nixpkgs": "nixpkgs_531"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16401,11 +17785,11 @@
         "nixpkgs": "nixpkgs_534"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16437,11 +17821,11 @@
         "nixpkgs": "nixpkgs_536"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16509,11 +17893,11 @@
         "nixpkgs": "nixpkgs_540"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16599,11 +17983,11 @@
         "nixpkgs": "nixpkgs_544"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16617,11 +18001,11 @@
         "nixpkgs": "nixpkgs_545"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16635,11 +18019,11 @@
         "nixpkgs": "nixpkgs_546"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16797,11 +18181,11 @@
         "nixpkgs": "nixpkgs_554"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16815,11 +18199,11 @@
         "nixpkgs": "nixpkgs_555"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16905,11 +18289,11 @@
         "nixpkgs": "nixpkgs_560"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16941,11 +18325,11 @@
         "nixpkgs": "nixpkgs_561"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16995,11 +18379,11 @@
         "nixpkgs": "nixpkgs_564"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17013,11 +18397,11 @@
         "nixpkgs": "nixpkgs_565"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17031,11 +18415,11 @@
         "nixpkgs": "nixpkgs_566"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17049,11 +18433,11 @@
         "nixpkgs": "nixpkgs_567"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17139,11 +18523,11 @@
         "nixpkgs": "nixpkgs_571"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17157,11 +18541,11 @@
         "nixpkgs": "nixpkgs_572"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17265,11 +18649,11 @@
         "nixpkgs": "nixpkgs_578"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17283,11 +18667,11 @@
         "nixpkgs": "nixpkgs_579"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17337,11 +18721,11 @@
         "nixpkgs": "nixpkgs_581"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17373,11 +18757,11 @@
         "nixpkgs": "nixpkgs_583"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17463,11 +18847,11 @@
         "nixpkgs": "nixpkgs_588"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17481,11 +18865,11 @@
         "nixpkgs": "nixpkgs_589"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17553,11 +18937,11 @@
         "nixpkgs": "nixpkgs_592"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17571,11 +18955,11 @@
         "nixpkgs": "nixpkgs_593"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17589,11 +18973,11 @@
         "nixpkgs": "nixpkgs_594"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17625,24 +19009,6 @@
         "nixpkgs": "nixpkgs_596"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_596": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_597"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -17656,9 +19022,9 @@
         "type": "github"
       }
     },
-    "logos-nix_597": {
+    "logos-nix_596": {
       "inputs": {
-        "nixpkgs": "nixpkgs_598"
+        "nixpkgs": "nixpkgs_597"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -17666,6 +19032,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_597": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_598"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17769,11 +19153,11 @@
         "nixpkgs": "nixpkgs_602"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17877,11 +19261,11 @@
         "nixpkgs": "nixpkgs_608"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17895,11 +19279,11 @@
         "nixpkgs": "nixpkgs_609"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17967,11 +19351,11 @@
         "nixpkgs": "nixpkgs_612"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18021,11 +19405,11 @@
         "nixpkgs": "nixpkgs_615"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18039,11 +19423,11 @@
         "nixpkgs": "nixpkgs_616"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18057,11 +19441,11 @@
         "nixpkgs": "nixpkgs_617"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18093,11 +19477,11 @@
         "nixpkgs": "nixpkgs_619"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18111,11 +19495,11 @@
         "nixpkgs": "nixpkgs_620"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18147,11 +19531,11 @@
         "nixpkgs": "nixpkgs_621"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18183,11 +19567,11 @@
         "nixpkgs": "nixpkgs_623"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18237,11 +19621,11 @@
         "nixpkgs": "nixpkgs_626"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18255,11 +19639,11 @@
         "nixpkgs": "nixpkgs_627"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18309,11 +19693,11 @@
         "nixpkgs": "nixpkgs_630"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18435,11 +19819,11 @@
         "nixpkgs": "nixpkgs_636"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18543,11 +19927,11 @@
         "nixpkgs": "nixpkgs_641"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18561,11 +19945,11 @@
         "nixpkgs": "nixpkgs_642"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18597,11 +19981,11 @@
         "nixpkgs": "nixpkgs_644"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18687,11 +20071,11 @@
         "nixpkgs": "nixpkgs_649"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18705,11 +20089,11 @@
         "nixpkgs": "nixpkgs_650"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18759,11 +20143,11 @@
         "nixpkgs": "nixpkgs_652"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18777,11 +20161,11 @@
         "nixpkgs": "nixpkgs_653"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18813,11 +20197,11 @@
         "nixpkgs": "nixpkgs_655"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18849,11 +20233,11 @@
         "nixpkgs": "nixpkgs_657"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18867,11 +20251,11 @@
         "nixpkgs": "nixpkgs_658"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18939,11 +20323,11 @@
         "nixpkgs": "nixpkgs_661"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18993,11 +20377,11 @@
         "nixpkgs": "nixpkgs_664"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19029,11 +20413,11 @@
         "nixpkgs": "nixpkgs_666"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19065,11 +20449,11 @@
         "nixpkgs": "nixpkgs_668"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19101,11 +20485,11 @@
         "nixpkgs": "nixpkgs_670"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19155,11 +20539,11 @@
         "nixpkgs": "nixpkgs_672"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19227,11 +20611,11 @@
         "nixpkgs": "nixpkgs_676"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19245,11 +20629,11 @@
         "nixpkgs": "nixpkgs_677"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19281,11 +20665,11 @@
         "nixpkgs": "nixpkgs_679"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19299,11 +20683,11 @@
         "nixpkgs": "nixpkgs_680"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19335,11 +20719,11 @@
         "nixpkgs": "nixpkgs_681"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19353,11 +20737,11 @@
         "nixpkgs": "nixpkgs_682"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19407,11 +20791,11 @@
         "nixpkgs": "nixpkgs_685"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19425,11 +20809,11 @@
         "nixpkgs": "nixpkgs_686"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19461,24 +20845,6 @@
         "nixpkgs": "nixpkgs_688"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_688": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_689"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -19492,9 +20858,9 @@
         "type": "github"
       }
     },
-    "logos-nix_689": {
+    "logos-nix_688": {
       "inputs": {
-        "nixpkgs": "nixpkgs_690"
+        "nixpkgs": "nixpkgs_689"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -19502,6 +20868,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_689": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_690"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19533,11 +20917,11 @@
         "nixpkgs": "nixpkgs_691"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19623,11 +21007,11 @@
         "nixpkgs": "nixpkgs_696"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19677,11 +21061,11 @@
         "nixpkgs": "nixpkgs_699"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19767,11 +21151,11 @@
         "nixpkgs": "nixpkgs_702"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19785,11 +21169,11 @@
         "nixpkgs": "nixpkgs_703"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19821,11 +21205,11 @@
         "nixpkgs": "nixpkgs_705"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19875,11 +21259,11 @@
         "nixpkgs": "nixpkgs_708"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19947,11 +21331,11 @@
         "nixpkgs": "nixpkgs_711"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19983,11 +21367,11 @@
         "nixpkgs": "nixpkgs_713"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20019,11 +21403,11 @@
         "nixpkgs": "nixpkgs_715"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20037,11 +21421,11 @@
         "nixpkgs": "nixpkgs_716"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20073,11 +21457,11 @@
         "nixpkgs": "nixpkgs_718"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20091,11 +21475,11 @@
         "nixpkgs": "nixpkgs_719"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20109,11 +21493,11 @@
         "nixpkgs": "nixpkgs_720"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20145,11 +21529,11 @@
         "nixpkgs": "nixpkgs_721"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20217,6 +21601,24 @@
         "nixpkgs": "nixpkgs_725"
       },
       "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_725": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_726"
+      },
+      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -20230,9 +21632,261 @@
         "type": "github"
       }
     },
+    "logos-nix_726": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_727"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_727": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_728"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_728": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_729"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_729": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_730"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_73": {
       "inputs": {
         "nixpkgs": "nixpkgs_74"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_730": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_731"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_731": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_732"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_732": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_733"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_733": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_734"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_734": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_735"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_735": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_736"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_736": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_737"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_737": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_738"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_738": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_739"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_739": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_740"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -20266,6 +21920,186 @@
         "type": "github"
       }
     },
+    "logos-nix_740": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_741"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_741": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_742"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_742": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_743"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_743": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_744"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_744": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_745"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_745": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_746"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_746": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_747"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_747": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_748"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_748": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_749"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_749": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_750"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_75": {
       "inputs": {
         "nixpkgs": "nixpkgs_76"
@@ -20284,9 +22118,369 @@
         "type": "github"
       }
     },
+    "logos-nix_750": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_751"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_751": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_752"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_752": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_753"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_753": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_754"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_754": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_755"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_755": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_756"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_756": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_757"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_757": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_758"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_758": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_759"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_759": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_760"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_76": {
       "inputs": {
         "nixpkgs": "nixpkgs_77"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_760": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_761"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_761": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_762"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_762": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_763"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_763": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_764"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_764": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_765"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_765": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_766"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_766": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_767"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_767": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_768"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_768": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_769"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_769": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_770"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -20320,6 +22514,186 @@
         "type": "github"
       }
     },
+    "logos-nix_770": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_771"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_771": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_772"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_772": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_773"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_773": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_774"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_774": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_775"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_775": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_776"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_776": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_777"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_777": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_778"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_778": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_779"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_779": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_780"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_78": {
       "inputs": {
         "nixpkgs": "nixpkgs_79"
@@ -20338,9 +22712,369 @@
         "type": "github"
       }
     },
+    "logos-nix_780": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_781"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_781": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_782"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_782": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_783"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_783": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_784"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_784": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_785"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_785": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_786"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_786": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_787"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_787": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_788"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_788": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_789"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_789": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_790"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_79": {
       "inputs": {
         "nixpkgs": "nixpkgs_80"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_790": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_791"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_791": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_792"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_792": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_793"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_793": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_794"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_794": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_795"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_795": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_796"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_796": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_797"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_797": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_798"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_798": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_799"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_799": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_800"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -20392,9 +23126,315 @@
         "type": "github"
       }
     },
+    "logos-nix_800": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_801"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_801": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_802"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_802": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_803"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_803": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_804"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_804": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_805"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_805": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_806"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_806": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_807"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_807": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_808"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_808": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_809"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_809": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_810"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_81": {
       "inputs": {
         "nixpkgs": "nixpkgs_82"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_810": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_811"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_811": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_812"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_812": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_813"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_813": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_814"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_814": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_815"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_815": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_816"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_816": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_817"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -20816,13 +23856,16 @@
     },
     "logos-package-manager_10": {
       "inputs": {
-        "logos-nix": "logos-nix_201",
+        "logos-nix": "logos-nix_218",
         "logos-package": "logos-package_24",
         "nix-bundle-appimage": "nix-bundle-appimage_10",
         "nix-bundle-dir": "nix-bundle-dir_34",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -20847,12 +23890,20 @@
     },
     "logos-package-manager_11": {
       "inputs": {
-        "logos-nix": "logos-nix_212",
+        "logos-nix": "logos-nix_245",
         "logos-package": "logos-package_26",
         "nix-bundle-appimage": "nix-bundle-appimage_11",
         "nix-bundle-dir": "nix-bundle-dir_37",
         "nixpkgs": [
           "logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "logos-nix",
@@ -20875,29 +23926,31 @@
     },
     "logos-package-manager_12": {
       "inputs": {
-        "logos-nix": "logos-nix_240",
-        "logos-package": "logos-package_27",
+        "logos-nix": "logos-nix_262",
+        "logos-package": "logos-package_29",
         "nix-bundle-appimage": "nix-bundle-appimage_12",
-        "nix-bundle-dir": "nix-bundle-dir_39",
+        "nix-bundle-dir": "nix-bundle-dir_41",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776374462,
-        "narHash": "sha256-HMkuqSLdScAWTwXEWjhqx9Yk82GiPzPIfRaHTvjG730=",
+        "lastModified": 1775836847,
+        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "9101875bc103214855bc6217834e22e66802ed86",
+        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
         "type": "github"
       },
       "original": {
@@ -20908,28 +23961,28 @@
     },
     "logos-package-manager_13": {
       "inputs": {
-        "logos-nix": "logos-nix_257",
-        "logos-package": "logos-package_30",
+        "logos-nix": "logos-nix_273",
+        "logos-package": "logos-package_31",
         "nix-bundle-appimage": "nix-bundle-appimage_13",
-        "nix-bundle-dir": "nix-bundle-dir_43",
+        "nix-bundle-dir": "nix-bundle-dir_44",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775836847,
-        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
+        "lastModified": 1776374462,
+        "narHash": "sha256-HMkuqSLdScAWTwXEWjhqx9Yk82GiPzPIfRaHTvjG730=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
+        "rev": "9101875bc103214855bc6217834e22e66802ed86",
         "type": "github"
       },
       "original": {
@@ -20940,25 +23993,27 @@
     },
     "logos-package-manager_14": {
       "inputs": {
-        "logos-nix": "logos-nix_268",
-        "logos-package": "logos-package_32",
+        "logos-nix": "logos-nix_290",
+        "logos-package": "logos-package_34",
         "nix-bundle-appimage": "nix-bundle-appimage_14",
-        "nix-bundle-dir": "nix-bundle-dir_46",
+        "nix-bundle-dir": "nix-bundle-dir_48",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776374462,
-        "narHash": "sha256-HMkuqSLdScAWTwXEWjhqx9Yk82GiPzPIfRaHTvjG730=",
+        "lastModified": 1775836847,
+        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "9101875bc103214855bc6217834e22e66802ed86",
+        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
         "type": "github"
       },
       "original": {
@@ -20969,17 +24024,12 @@
     },
     "logos-package-manager_15": {
       "inputs": {
-        "logos-nix": "logos-nix_291",
-        "logos-package": "logos-package_33",
+        "logos-nix": "logos-nix_304",
+        "logos-package": "logos-package_36",
         "nix-bundle-appimage": "nix-bundle-appimage_15",
-        "nix-bundle-dir": "nix-bundle-dir_48",
+        "nix-bundle-dir": "nix-bundle-dir_51",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "logos-nix",
@@ -20987,11 +24037,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776374462,
-        "narHash": "sha256-HMkuqSLdScAWTwXEWjhqx9Yk82GiPzPIfRaHTvjG730=",
+        "lastModified": 1781106836,
+        "narHash": "sha256-vHxdyGdW3Ai3/Omspw5drtJXzXyN0TWuCYet95A5h6E=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "9101875bc103214855bc6217834e22e66802ed86",
+        "rev": "8a6b72f28b1e73b6d753eaabe7eba13bf425f04e",
         "type": "github"
       },
       "original": {
@@ -21002,46 +24052,13 @@
     },
     "logos-package-manager_16": {
       "inputs": {
-        "logos-nix": "logos-nix_308",
-        "logos-package": "logos-package_36",
+        "logos-nix": "logos-nix_332",
+        "logos-package": "logos-package_37",
         "nix-bundle-appimage": "nix-bundle-appimage_16",
-        "nix-bundle-dir": "nix-bundle-dir_52",
+        "nix-bundle-dir": "nix-bundle-dir_53",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775836847,
-        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "type": "github"
-      }
-    },
-    "logos-package-manager_17": {
-      "inputs": {
-        "logos-nix": "logos-nix_334",
-        "logos-package": "logos-package_38",
-        "nix-bundle-appimage": "nix-bundle-appimage_17",
-        "nix-bundle-dir": "nix-bundle-dir_55",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -21066,16 +24083,15 @@
         "type": "github"
       }
     },
-    "logos-package-manager_18": {
+    "logos-package-manager_17": {
       "inputs": {
-        "logos-nix": "logos-nix_351",
-        "logos-package": "logos-package_41",
-        "nix-bundle-appimage": "nix-bundle-appimage_18",
-        "nix-bundle-dir": "nix-bundle-dir_59",
+        "logos-nix": "logos-nix_349",
+        "logos-package": "logos-package_40",
+        "nix-bundle-appimage": "nix-bundle-appimage_17",
+        "nix-bundle-dir": "nix-bundle-dir_57",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -21099,9 +24115,38 @@
         "type": "github"
       }
     },
+    "logos-package-manager_18": {
+      "inputs": {
+        "logos-nix": "logos-nix_360",
+        "logos-package": "logos-package_42",
+        "nix-bundle-appimage": "nix-bundle-appimage_18",
+        "nix-bundle-dir": "nix-bundle-dir_60",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776374462,
+        "narHash": "sha256-HMkuqSLdScAWTwXEWjhqx9Yk82GiPzPIfRaHTvjG730=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "9101875bc103214855bc6217834e22e66802ed86",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
     "logos-package-manager_19": {
       "inputs": {
-        "logos-nix": "logos-nix_362",
+        "logos-nix": "logos-nix_383",
         "logos-package": "logos-package_43",
         "nix-bundle-appimage": "nix-bundle-appimage_19",
         "nix-bundle-dir": "nix-bundle-dir_62",
@@ -21109,6 +24154,9 @@
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "logos-nix",
@@ -21162,15 +24210,46 @@
     },
     "logos-package-manager_20": {
       "inputs": {
-        "logos-nix": "logos-nix_388",
-        "logos-package": "logos-package_44",
+        "logos-nix": "logos-nix_400",
+        "logos-package": "logos-package_46",
         "nix-bundle-appimage": "nix-bundle-appimage_20",
-        "nix-bundle-dir": "nix-bundle-dir_64",
+        "nix-bundle-dir": "nix-bundle-dir_66",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775836847,
+        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
+    "logos-package-manager_21": {
+      "inputs": {
+        "logos-nix": "logos-nix_426",
+        "logos-package": "logos-package_48",
+        "nix-bundle-appimage": "nix-bundle-appimage_21",
+        "nix-bundle-dir": "nix-bundle-dir_69",
+        "nixpkgs": [
+          "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -21195,17 +24274,16 @@
         "type": "github"
       }
     },
-    "logos-package-manager_21": {
+    "logos-package-manager_22": {
       "inputs": {
-        "logos-nix": "logos-nix_405",
-        "logos-package": "logos-package_47",
-        "nix-bundle-appimage": "nix-bundle-appimage_21",
-        "nix-bundle-dir": "nix-bundle-dir_68",
+        "logos-nix": "logos-nix_443",
+        "logos-package": "logos-package_51",
+        "nix-bundle-appimage": "nix-bundle-appimage_22",
+        "nix-bundle-dir": "nix-bundle-dir_73",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -21229,52 +24307,16 @@
         "type": "github"
       }
     },
-    "logos-package-manager_22": {
-      "inputs": {
-        "logos-nix": "logos-nix_416",
-        "logos-package": "logos-package_49",
-        "nix-bundle-appimage": "nix-bundle-appimage_22",
-        "nix-bundle-dir": "nix-bundle-dir_71",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
-          "logos-package-manager",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776374462,
-        "narHash": "sha256-HMkuqSLdScAWTwXEWjhqx9Yk82GiPzPIfRaHTvjG730=",
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "rev": "9101875bc103214855bc6217834e22e66802ed86",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "type": "github"
-      }
-    },
     "logos-package-manager_23": {
       "inputs": {
-        "logos-nix": "logos-nix_439",
-        "logos-package": "logos-package_50",
+        "logos-nix": "logos-nix_454",
+        "logos-package": "logos-package_53",
         "nix-bundle-appimage": "nix-bundle-appimage_23",
-        "nix-bundle-dir": "nix-bundle-dir_73",
+        "nix-bundle-dir": "nix-bundle-dir_76",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "logos-nix",
@@ -21297,50 +24339,15 @@
     },
     "logos-package-manager_24": {
       "inputs": {
-        "logos-nix": "logos-nix_456",
-        "logos-package": "logos-package_53",
+        "logos-nix": "logos-nix_480",
+        "logos-package": "logos-package_54",
         "nix-bundle-appimage": "nix-bundle-appimage_24",
-        "nix-bundle-dir": "nix-bundle-dir_77",
+        "nix-bundle-dir": "nix-bundle-dir_78",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775836847,
-        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "type": "github"
-      }
-    },
-    "logos-package-manager_25": {
-      "inputs": {
-        "logos-nix": "logos-nix_482",
-        "logos-package": "logos-package_55",
-        "nix-bundle-appimage": "nix-bundle-appimage_25",
-        "nix-bundle-dir": "nix-bundle-dir_80",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -21365,18 +24372,17 @@
         "type": "github"
       }
     },
-    "logos-package-manager_26": {
+    "logos-package-manager_25": {
       "inputs": {
-        "logos-nix": "logos-nix_499",
-        "logos-package": "logos-package_58",
-        "nix-bundle-appimage": "nix-bundle-appimage_26",
-        "nix-bundle-dir": "nix-bundle-dir_84",
+        "logos-nix": "logos-nix_497",
+        "logos-package": "logos-package_57",
+        "nix-bundle-appimage": "nix-bundle-appimage_25",
+        "nix-bundle-dir": "nix-bundle-dir_82",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -21400,9 +24406,40 @@
         "type": "github"
       }
     },
+    "logos-package-manager_26": {
+      "inputs": {
+        "logos-nix": "logos-nix_508",
+        "logos-package": "logos-package_59",
+        "nix-bundle-appimage": "nix-bundle-appimage_26",
+        "nix-bundle-dir": "nix-bundle-dir_85",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776374462,
+        "narHash": "sha256-HMkuqSLdScAWTwXEWjhqx9Yk82GiPzPIfRaHTvjG730=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "9101875bc103214855bc6217834e22e66802ed86",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
     "logos-package-manager_27": {
       "inputs": {
-        "logos-nix": "logos-nix_510",
+        "logos-nix": "logos-nix_531",
         "logos-package": "logos-package_60",
         "nix-bundle-appimage": "nix-bundle-appimage_27",
         "nix-bundle-dir": "nix-bundle-dir_87",
@@ -21412,6 +24449,9 @@
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "logos-nix",
@@ -21434,9 +24474,9 @@
     },
     "logos-package-manager_28": {
       "inputs": {
-        "logos-nix": "logos-nix_523",
-        "logos-package": "logos-package_61",
-        "nix-bundle-appimage": "nix-bundle-appimage_29",
+        "logos-nix": "logos-nix_548",
+        "logos-package": "logos-package_63",
+        "nix-bundle-appimage": "nix-bundle-appimage_28",
         "nix-bundle-dir": "nix-bundle-dir_91",
         "nixpkgs": [
           "logoscore-cli",
@@ -21444,6 +24484,8 @@
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-nix",
@@ -21466,15 +24508,18 @@
     },
     "logos-package-manager_29": {
       "inputs": {
-        "logos-nix": "logos-nix_548",
-        "logos-package": "logos-package_63",
-        "nix-bundle-appimage": "nix-bundle-appimage_30",
+        "logos-nix": "logos-nix_574",
+        "logos-package": "logos-package_65",
+        "nix-bundle-appimage": "nix-bundle-appimage_29",
         "nix-bundle-dir": "nix-bundle-dir_94",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -21532,15 +24577,18 @@
     },
     "logos-package-manager_30": {
       "inputs": {
-        "logos-nix": "logos-nix_565",
-        "logos-package": "logos-package_66",
-        "nix-bundle-appimage": "nix-bundle-appimage_31",
+        "logos-nix": "logos-nix_591",
+        "logos-package": "logos-package_68",
+        "nix-bundle-appimage": "nix-bundle-appimage_30",
         "nix-bundle-dir": "nix-bundle-dir_98",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -21564,10 +24612,139 @@
     },
     "logos-package-manager_31": {
       "inputs": {
-        "logos-nix": "logos-nix_578",
-        "logos-package": "logos-package_68",
+        "logos-nix": "logos-nix_602",
+        "logos-package": "logos-package_70",
+        "nix-bundle-appimage": "nix-bundle-appimage_31",
+        "nix-bundle-dir": "nix-bundle-dir_101",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776374462,
+        "narHash": "sha256-HMkuqSLdScAWTwXEWjhqx9Yk82GiPzPIfRaHTvjG730=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "9101875bc103214855bc6217834e22e66802ed86",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
+    "logos-package-manager_32": {
+      "inputs": {
+        "logos-nix": "logos-nix_615",
+        "logos-package": "logos-package_71",
         "nix-bundle-appimage": "nix-bundle-appimage_33",
-        "nix-bundle-dir": "nix-bundle-dir_103",
+        "nix-bundle-dir": "nix-bundle-dir_105",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775836847,
+        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
+    "logos-package-manager_33": {
+      "inputs": {
+        "logos-nix": "logos-nix_640",
+        "logos-package": "logos-package_73",
+        "nix-bundle-appimage": "nix-bundle-appimage_34",
+        "nix-bundle-dir": "nix-bundle-dir_108",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776374462,
+        "narHash": "sha256-HMkuqSLdScAWTwXEWjhqx9Yk82GiPzPIfRaHTvjG730=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "9101875bc103214855bc6217834e22e66802ed86",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
+    "logos-package-manager_34": {
+      "inputs": {
+        "logos-nix": "logos-nix_657",
+        "logos-package": "logos-package_76",
+        "nix-bundle-appimage": "nix-bundle-appimage_35",
+        "nix-bundle-dir": "nix-bundle-dir_112",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775836847,
+        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
+    "logos-package-manager_35": {
+      "inputs": {
+        "logos-nix": "logos-nix_670",
+        "logos-package": "logos-package_78",
+        "nix-bundle-appimage": "nix-bundle-appimage_37",
+        "nix-bundle-dir": "nix-bundle-dir_117",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -21592,151 +24769,18 @@
         "type": "github"
       }
     },
-    "logos-package-manager_32": {
-      "inputs": {
-        "logos-nix": "logos-nix_610",
-        "logos-package": "logos-package_70",
-        "nix-bundle-appimage": "nix-bundle-appimage_34",
-        "nix-bundle-dir": "nix-bundle-dir_106",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776374462,
-        "narHash": "sha256-HMkuqSLdScAWTwXEWjhqx9Yk82GiPzPIfRaHTvjG730=",
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "rev": "9101875bc103214855bc6217834e22e66802ed86",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "type": "github"
-      }
-    },
-    "logos-package-manager_33": {
-      "inputs": {
-        "logos-nix": "logos-nix_627",
-        "logos-package": "logos-package_73",
-        "nix-bundle-appimage": "nix-bundle-appimage_35",
-        "nix-bundle-dir": "nix-bundle-dir_110",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775836847,
-        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "type": "github"
-      }
-    },
-    "logos-package-manager_34": {
-      "inputs": {
-        "logos-nix": "logos-nix_654",
-        "logos-package": "logos-package_75",
-        "nix-bundle-appimage": "nix-bundle-appimage_36",
-        "nix-bundle-dir": "nix-bundle-dir_113",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776374462,
-        "narHash": "sha256-HMkuqSLdScAWTwXEWjhqx9Yk82GiPzPIfRaHTvjG730=",
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "rev": "9101875bc103214855bc6217834e22e66802ed86",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "type": "github"
-      }
-    },
-    "logos-package-manager_35": {
-      "inputs": {
-        "logos-nix": "logos-nix_671",
-        "logos-package": "logos-package_78",
-        "nix-bundle-appimage": "nix-bundle-appimage_37",
-        "nix-bundle-dir": "nix-bundle-dir_117",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775836847,
-        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "type": "github"
-      }
-    },
     "logos-package-manager_36": {
       "inputs": {
-        "logos-nix": "logos-nix_682",
+        "logos-nix": "logos-nix_702",
         "logos-package": "logos-package_80",
         "nix-bundle-appimage": "nix-bundle-appimage_38",
         "nix-bundle-dir": "nix-bundle-dir_120",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -21761,13 +24805,16 @@
     },
     "logos-package-manager_37": {
       "inputs": {
-        "logos-nix": "logos-nix_699",
+        "logos-nix": "logos-nix_719",
         "logos-package": "logos-package_83",
         "nix-bundle-appimage": "nix-bundle-appimage_39",
         "nix-bundle-dir": "nix-bundle-dir_124",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -21791,12 +24838,53 @@
     },
     "logos-package-manager_38": {
       "inputs": {
-        "logos-nix": "logos-nix_712",
+        "logos-nix": "logos-nix_746",
         "logos-package": "logos-package_85",
-        "nix-bundle-appimage": "nix-bundle-appimage_41",
-        "nix-bundle-dir": "nix-bundle-dir_129",
+        "nix-bundle-appimage": "nix-bundle-appimage_40",
+        "nix-bundle-dir": "nix-bundle-dir_127",
         "nixpkgs": [
           "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776374462,
+        "narHash": "sha256-HMkuqSLdScAWTwXEWjhqx9Yk82GiPzPIfRaHTvjG730=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "9101875bc103214855bc6217834e22e66802ed86",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
+    "logos-package-manager_39": {
+      "inputs": {
+        "logos-nix": "logos-nix_763",
+        "logos-package": "logos-package_88",
+        "nix-bundle-appimage": "nix-bundle-appimage_41",
+        "nix-bundle-dir": "nix-bundle-dir_131",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-nix",
@@ -21829,6 +24917,95 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775836847,
+        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
+    "logos-package-manager_40": {
+      "inputs": {
+        "logos-nix": "logos-nix_774",
+        "logos-package": "logos-package_90",
+        "nix-bundle-appimage": "nix-bundle-appimage_42",
+        "nix-bundle-dir": "nix-bundle-dir_134",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776374462,
+        "narHash": "sha256-HMkuqSLdScAWTwXEWjhqx9Yk82GiPzPIfRaHTvjG730=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "9101875bc103214855bc6217834e22e66802ed86",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
+    "logos-package-manager_41": {
+      "inputs": {
+        "logos-nix": "logos-nix_791",
+        "logos-package": "logos-package_93",
+        "nix-bundle-appimage": "nix-bundle-appimage_43",
+        "nix-bundle-dir": "nix-bundle-dir_138",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775836847,
+        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
+    "logos-package-manager_42": {
+      "inputs": {
+        "logos-nix": "logos-nix_804",
+        "logos-package": "logos-package_95",
+        "nix-bundle-appimage": "nix-bundle-appimage_45",
+        "nix-bundle-dir": "nix-bundle-dir_143",
+        "nixpkgs": [
+          "logoscore-cli",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-nix",
@@ -21969,13 +25146,16 @@
     },
     "logos-package-manager_9": {
       "inputs": {
-        "logos-nix": "logos-nix_184",
+        "logos-nix": "logos-nix_201",
         "logos-package": "logos-package_21",
         "nix-bundle-appimage": "nix-bundle-appimage_9",
         "nix-bundle-dir": "nix-bundle-dir_30",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -22094,11 +25274,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "lastModified": 1781872378,
+        "narHash": "sha256-ZHh+krtTbn6Qt7Hm3+shrhAAGCFa7FXt8ajYqx+Nt1o=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "rev": "ab885df3641e9adb61ff16e42d3e6f63b24db8f6",
         "type": "github"
       },
       "original": {
@@ -22330,10 +25510,13 @@
     },
     "logos-package_21": {
       "inputs": {
-        "logos-nix": "logos-nix_185",
+        "logos-nix": "logos-nix_202",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -22360,10 +25543,13 @@
     },
     "logos-package_22": {
       "inputs": {
-        "logos-nix": "logos-nix_194",
+        "logos-nix": "logos-nix_211",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -22389,10 +25575,13 @@
     },
     "logos-package_23": {
       "inputs": {
-        "logos-nix": "logos-nix_198",
+        "logos-nix": "logos-nix_215",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-lgx",
@@ -22417,10 +25606,13 @@
     },
     "logos-package_24": {
       "inputs": {
-        "logos-nix": "logos-nix_202",
+        "logos-nix": "logos-nix_219",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -22446,10 +25638,13 @@
     },
     "logos-package_25": {
       "inputs": {
-        "logos-nix": "logos-nix_207",
+        "logos-nix": "logos-nix_224",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -22475,9 +25670,17 @@
     },
     "logos-package_26": {
       "inputs": {
-        "logos-nix": "logos-nix_213",
+        "logos-nix": "logos-nix_246",
         "nixpkgs": [
           "logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "logos-package",
@@ -22501,27 +25704,29 @@
     },
     "logos-package_27": {
       "inputs": {
-        "logos-nix": "logos-nix_241",
+        "logos-nix": "logos-nix_255",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-package-manager",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
         "type": "github"
       },
       "original": {
@@ -22532,14 +25737,16 @@
     },
     "logos-package_28": {
       "inputs": {
-        "logos-nix": "logos-nix_250",
+        "logos-nix": "logos-nix_259",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -22562,25 +25769,29 @@
     },
     "logos-package_29": {
       "inputs": {
-        "logos-nix": "logos-nix_254",
+        "logos-nix": "logos-nix_263",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
         "type": "github"
       },
       "original": {
@@ -22619,15 +25830,18 @@
     },
     "logos-package_30": {
       "inputs": {
-        "logos-nix": "logos-nix_258",
+        "logos-nix": "logos-nix_268",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -22649,15 +25863,15 @@
     },
     "logos-package_31": {
       "inputs": {
-        "logos-nix": "logos-nix_263",
+        "logos-nix": "logos-nix_274",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -22679,23 +25893,25 @@
     },
     "logos-package_32": {
       "inputs": {
-        "logos-nix": "logos-nix_269",
+        "logos-nix": "logos-nix_283",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
-          "logos-package-manager",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
         "type": "github"
       },
       "original": {
@@ -22706,15 +25922,41 @@
     },
     "logos-package_33": {
       "inputs": {
-        "logos-nix": "logos-nix_292",
+        "logos-nix": "logos-nix_287",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_34": {
+      "inputs": {
+        "logos-nix": "logos-nix_291",
+        "nixpkgs": [
+          "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-package",
           "logos-nix",
@@ -22735,45 +25977,15 @@
         "type": "github"
       }
     },
-    "logos-package_34": {
-      "inputs": {
-        "logos-nix": "logos-nix_301",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_35": {
       "inputs": {
-        "logos-nix": "logos-nix_305",
+        "logos-nix": "logos-nix_296",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -22781,11 +25993,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
         "type": "github"
       },
       "original": {
@@ -22796,14 +26008,10 @@
     },
     "logos-package_36": {
       "inputs": {
-        "logos-nix": "logos-nix_309",
+        "logos-nix": "logos-nix_305",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-liblogos",
           "logos-package-manager",
           "logos-package",
           "logos-nix",
@@ -22826,41 +26034,10 @@
     },
     "logos-package_37": {
       "inputs": {
-        "logos-nix": "logos-nix_314",
+        "logos-nix": "logos-nix_333",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_38": {
-      "inputs": {
-        "logos-nix": "logos-nix_335",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -22886,17 +26063,45 @@
         "type": "github"
       }
     },
-    "logos-package_39": {
+    "logos-package_38": {
       "inputs": {
-        "logos-nix": "logos-nix_344",
+        "logos-nix": "logos-nix_342",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_39": {
+      "inputs": {
+        "logos-nix": "logos-nix_346",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -22948,41 +26153,10 @@
     },
     "logos-package_40": {
       "inputs": {
-        "logos-nix": "logos-nix_348",
+        "logos-nix": "logos-nix_350",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_41": {
-      "inputs": {
-        "logos-nix": "logos-nix_352",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -23007,13 +26181,12 @@
         "type": "github"
       }
     },
-    "logos-package_42": {
+    "logos-package_41": {
       "inputs": {
-        "logos-nix": "logos-nix_357",
+        "logos-nix": "logos-nix_355",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -23038,13 +26211,43 @@
         "type": "github"
       }
     },
+    "logos-package_42": {
+      "inputs": {
+        "logos-nix": "logos-nix_361",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
     "logos-package_43": {
       "inputs": {
-        "logos-nix": "logos-nix_363",
+        "logos-nix": "logos-nix_384",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "logos-package",
@@ -23068,29 +26271,26 @@
     },
     "logos-package_44": {
       "inputs": {
-        "logos-nix": "logos-nix_389",
+        "logos-nix": "logos-nix_393",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
         "type": "github"
       },
       "original": {
@@ -23101,16 +26301,13 @@
     },
     "logos-package_45": {
       "inputs": {
-        "logos-nix": "logos-nix_398",
+        "logos-nix": "logos-nix_397",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -23133,27 +26330,26 @@
     },
     "logos-package_46": {
       "inputs": {
-        "logos-nix": "logos-nix_402",
+        "logos-nix": "logos-nix_401",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
         "type": "github"
       },
       "original": {
@@ -23169,12 +26365,10 @@
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23196,17 +26390,17 @@
     },
     "logos-package_48": {
       "inputs": {
-        "logos-nix": "logos-nix_411",
+        "logos-nix": "logos-nix_427",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23228,25 +26422,27 @@
     },
     "logos-package_49": {
       "inputs": {
-        "logos-nix": "logos-nix_417",
+        "logos-nix": "logos-nix_436",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
-          "logos-package-manager",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
         "type": "github"
       },
       "original": {
@@ -23291,12 +26487,40 @@
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_51": {
+      "inputs": {
+        "logos-nix": "logos-nix_444",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-package",
           "logos-nix",
@@ -23317,18 +26541,17 @@
         "type": "github"
       }
     },
-    "logos-package_51": {
+    "logos-package_52": {
       "inputs": {
         "logos-nix": "logos-nix_449",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -23336,42 +26559,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_52": {
-      "inputs": {
-        "logos-nix": "logos-nix_453",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
         "type": "github"
       },
       "original": {
@@ -23382,16 +26574,12 @@
     },
     "logos-package_53": {
       "inputs": {
-        "logos-nix": "logos-nix_457",
+        "logos-nix": "logos-nix_455",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-liblogos",
           "logos-package-manager",
           "logos-package",
           "logos-nix",
@@ -23414,45 +26602,12 @@
     },
     "logos-package_54": {
       "inputs": {
-        "logos-nix": "logos-nix_462",
+        "logos-nix": "logos-nix_481",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_55": {
-      "inputs": {
-        "logos-nix": "logos-nix_483",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -23478,19 +26633,49 @@
         "type": "github"
       }
     },
-    "logos-package_56": {
+    "logos-package_55": {
       "inputs": {
-        "logos-nix": "logos-nix_492",
+        "logos-nix": "logos-nix_490",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_56": {
+      "inputs": {
+        "logos-nix": "logos-nix_494",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -23513,45 +26698,12 @@
     },
     "logos-package_57": {
       "inputs": {
-        "logos-nix": "logos-nix_496",
+        "logos-nix": "logos-nix_498",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_58": {
-      "inputs": {
-        "logos-nix": "logos-nix_500",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -23576,20 +26728,48 @@
         "type": "github"
       }
     },
-    "logos-package_59": {
+    "logos-package_58": {
       "inputs": {
-        "logos-nix": "logos-nix_505",
+        "logos-nix": "logos-nix_503",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_59": {
+      "inputs": {
+        "logos-nix": "logos-nix_509",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23642,13 +26822,16 @@
     },
     "logos-package_60": {
       "inputs": {
-        "logos-nix": "logos-nix_511",
+        "logos-nix": "logos-nix_532",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "logos-package",
@@ -23672,13 +26855,78 @@
     },
     "logos-package_61": {
       "inputs": {
-        "logos-nix": "logos-nix_524",
+        "logos-nix": "logos-nix_541",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_62": {
+      "inputs": {
+        "logos-nix": "logos-nix_545",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_63": {
+      "inputs": {
+        "logos-nix": "logos-nix_549",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-package",
@@ -23700,15 +26948,17 @@
         "type": "github"
       }
     },
-    "logos-package_62": {
+    "logos-package_64": {
       "inputs": {
-        "logos-nix": "logos-nix_529",
+        "logos-nix": "logos-nix_554",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "logos-package",
@@ -23730,14 +26980,17 @@
         "type": "github"
       }
     },
-    "logos-package_63": {
+    "logos-package_65": {
       "inputs": {
-        "logos-nix": "logos-nix_549",
+        "logos-nix": "logos-nix_575",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -23761,14 +27014,17 @@
         "type": "github"
       }
     },
-    "logos-package_64": {
+    "logos-package_66": {
       "inputs": {
-        "logos-nix": "logos-nix_558",
+        "logos-nix": "logos-nix_584",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "nix-bundle-lgx",
@@ -23791,14 +27047,17 @@
         "type": "github"
       }
     },
-    "logos-package_65": {
+    "logos-package_67": {
       "inputs": {
-        "logos-nix": "logos-nix_562",
+        "logos-nix": "logos-nix_588",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "logos-package",
@@ -23820,73 +27079,18 @@
         "type": "github"
       }
     },
-    "logos-package_66": {
-      "inputs": {
-        "logos-nix": "logos-nix_566",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_67": {
-      "inputs": {
-        "logos-nix": "logos-nix_571",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_68": {
       "inputs": {
-        "logos-nix": "logos-nix_579",
+        "logos-nix": "logos-nix_592",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-package",
@@ -23910,11 +27114,16 @@
     },
     "logos-package_69": {
       "inputs": {
-        "logos-nix": "logos-nix_584",
+        "logos-nix": "logos-nix_597",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "logos-package",
@@ -23968,15 +27177,13 @@
     },
     "logos-package_70": {
       "inputs": {
-        "logos-nix": "logos-nix_611",
+        "logos-nix": "logos-nix_603",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-package-manager",
           "logos-package",
@@ -24000,27 +27207,26 @@
     },
     "logos-package_71": {
       "inputs": {
-        "logos-nix": "logos-nix_620",
+        "logos-nix": "logos-nix_616",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
         "type": "github"
       },
       "original": {
@@ -24031,14 +27237,14 @@
     },
     "logos-package_72": {
       "inputs": {
-        "logos-nix": "logos-nix_624",
+        "logos-nix": "logos-nix_621",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -24046,11 +27252,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
         "type": "github"
       },
       "original": {
@@ -24061,15 +27267,15 @@
     },
     "logos-package_73": {
       "inputs": {
-        "logos-nix": "logos-nix_628",
+        "logos-nix": "logos-nix_641",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-liblogos",
           "logos-package-manager",
           "logos-package",
           "logos-nix",
@@ -24092,13 +27298,101 @@
     },
     "logos-package_74": {
       "inputs": {
-        "logos-nix": "logos-nix_633",
+        "logos-nix": "logos-nix_650",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-capability-module",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_75": {
+      "inputs": {
+        "logos-nix": "logos-nix_654",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_76": {
+      "inputs": {
+        "logos-nix": "logos-nix_658",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_77": {
+      "inputs": {
+        "logos-nix": "logos-nix_663",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -24121,113 +27415,13 @@
         "type": "github"
       }
     },
-    "logos-package_75": {
-      "inputs": {
-        "logos-nix": "logos-nix_655",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_76": {
-      "inputs": {
-        "logos-nix": "logos-nix_664",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_77": {
-      "inputs": {
-        "logos-nix": "logos-nix_668",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_78": {
       "inputs": {
-        "logos-nix": "logos-nix_672",
+        "logos-nix": "logos-nix_671",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "logos-logoscore-cli",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-package",
@@ -24251,15 +27445,11 @@
     },
     "logos-package_79": {
       "inputs": {
-        "logos-nix": "logos-nix_677",
+        "logos-nix": "logos-nix_676",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "logos-logoscore-cli",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "logos-package",
@@ -24312,10 +27502,13 @@
     },
     "logos-package_80": {
       "inputs": {
-        "logos-nix": "logos-nix_683",
+        "logos-nix": "logos-nix_703",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -24341,10 +27534,13 @@
     },
     "logos-package_81": {
       "inputs": {
-        "logos-nix": "logos-nix_692",
+        "logos-nix": "logos-nix_712",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "nix-bundle-lgx",
@@ -24369,10 +27565,13 @@
     },
     "logos-package_82": {
       "inputs": {
-        "logos-nix": "logos-nix_696",
+        "logos-nix": "logos-nix_716",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "logos-package",
@@ -24396,10 +27595,13 @@
     },
     "logos-package_83": {
       "inputs": {
-        "logos-nix": "logos-nix_700",
+        "logos-nix": "logos-nix_720",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -24424,10 +27626,13 @@
     },
     "logos-package_84": {
       "inputs": {
-        "logos-nix": "logos-nix_705",
+        "logos-nix": "logos-nix_725",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -24452,10 +27657,17 @@
     },
     "logos-package_85": {
       "inputs": {
-        "logos-nix": "logos-nix_713",
+        "logos-nix": "logos-nix_747",
         "nixpkgs": [
           "logoscore-cli",
-          "nix-bundle-logos-module-install",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "logos-package",
           "logos-nix",
@@ -24478,11 +27690,80 @@
     },
     "logos-package_86": {
       "inputs": {
-        "logos-nix": "logos-nix_718",
+        "logos-nix": "logos-nix_756",
         "nixpkgs": [
           "logoscore-cli",
-          "nix-bundle-logos-module-install",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_87": {
+      "inputs": {
+        "logos-nix": "logos-nix_760",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_88": {
+      "inputs": {
+        "logos-nix": "logos-nix_764",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -24502,11 +27783,19 @@
         "type": "github"
       }
     },
-    "logos-package_87": {
+    "logos-package_89": {
       "inputs": {
-        "logos-nix": "logos-nix_721",
+        "logos-nix": "logos-nix_769",
         "nixpkgs": [
-          "package-manager",
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -24556,6 +27845,222 @@
         "type": "github"
       }
     },
+    "logos-package_90": {
+      "inputs": {
+        "logos-nix": "logos-nix_775",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_91": {
+      "inputs": {
+        "logos-nix": "logos-nix_784",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_92": {
+      "inputs": {
+        "logos-nix": "logos-nix_788",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_93": {
+      "inputs": {
+        "logos-nix": "logos-nix_792",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_94": {
+      "inputs": {
+        "logos-nix": "logos-nix_797",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_95": {
+      "inputs": {
+        "logos-nix": "logos-nix_805",
+        "nixpkgs": [
+          "logoscore-cli",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_96": {
+      "inputs": {
+        "logos-nix": "logos-nix_810",
+        "nixpkgs": [
+          "logoscore-cli",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_97": {
+      "inputs": {
+        "logos-nix": "logos-nix_813",
+        "nixpkgs": [
+          "package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781873979,
+        "narHash": "sha256-Z5XUSB9wfdrmQhG/0fehJeBd9CjrlIEeO+mKDhE46H4=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "c207525d30f48620696668c38486884bad5384bc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
     "logos-plugin-core": {
       "inputs": {
         "logos-module": "logos-module_2",
@@ -24583,8 +28088,69 @@
     },
     "logos-plugin-core_10": {
       "inputs": {
-        "logos-module": "logos-module_58",
-        "logos-nix": "logos-nix_426",
+        "logos-module": "logos-module_55",
+        "logos-nix": "logos-nix_413",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778168218,
+        "narHash": "sha256-EGHUsyKaA7IjnBKNysFD62Qlqsd0GyxyhbuYNAS0+Tg=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "8c45eca86db8fba8689326c35d0ec8c2b3cdd9a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-core_11": {
+      "inputs": {
+        "logos-module": "logos-module_62",
+        "logos-nix": "logos-nix_467",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778168218,
+        "narHash": "sha256-EGHUsyKaA7IjnBKNysFD62Qlqsd0GyxyhbuYNAS0+Tg=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "8c45eca86db8fba8689326c35d0ec8c2b3cdd9a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-core_12": {
+      "inputs": {
+        "logos-module": "logos-module_69",
+        "logos-nix": "logos-nix_518",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -24612,10 +28178,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-core_11": {
+    "logos-plugin-core_13": {
       "inputs": {
-        "logos-module": "logos-module_64",
-        "logos-nix": "logos-nix_469",
+        "logos-module": "logos-module_75",
+        "logos-nix": "logos-nix_561",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -24644,10 +28210,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-core_12": {
+    "logos-plugin-core_14": {
       "inputs": {
-        "logos-module": "logos-module_71",
-        "logos-nix": "logos-nix_535",
+        "logos-module": "logos-module_82",
+        "logos-nix": "logos-nix_627",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -24673,10 +28239,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-core_13": {
+    "logos-plugin-core_15": {
       "inputs": {
-        "logos-module": "logos-module_77",
-        "logos-nix": "logos-nix_590",
+        "logos-module": "logos-module_88",
+        "logos-nix": "logos-nix_682",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -24700,10 +28266,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-core_14": {
+    "logos-plugin-core_16": {
       "inputs": {
-        "logos-module": "logos-module_80",
-        "logos-nix": "logos-nix_597",
+        "logos-module": "logos-module_91",
+        "logos-nix": "logos-nix_689",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -24730,10 +28296,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-core_15": {
+    "logos-plugin-core_17": {
       "inputs": {
-        "logos-module": "logos-module_86",
-        "logos-nix": "logos-nix_641",
+        "logos-module": "logos-module_97",
+        "logos-nix": "logos-nix_733",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -24847,8 +28413,8 @@
     },
     "logos-plugin-core_5": {
       "inputs": {
-        "logos-module": "logos-module_24",
-        "logos-nix": "logos-nix_171",
+        "logos-module": "logos-module_25",
+        "logos-nix": "logos-nix_181",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -24860,11 +28426,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778168218,
-        "narHash": "sha256-EGHUsyKaA7IjnBKNysFD62Qlqsd0GyxyhbuYNAS0+Tg=",
+        "lastModified": 1780929868,
+        "narHash": "sha256-yDxv9Cv5VEJDVqHz9qYCU3UXv+kCIjRoD90A7uGYuGU=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "8c45eca86db8fba8689326c35d0ec8c2b3cdd9a0",
+        "rev": "68090d0a976224ca1c3c606c486a9ac3dd7a4559",
         "type": "github"
       },
       "original": {
@@ -24875,12 +28441,14 @@
     },
     "logos-plugin-core_6": {
       "inputs": {
-        "logos-module": "logos-module_31",
-        "logos-nix": "logos-nix_227",
+        "logos-module": "logos-module_28",
+        "logos-nix": "logos-nix_188",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
@@ -24904,12 +28472,15 @@
     },
     "logos-plugin-core_7": {
       "inputs": {
-        "logos-module": "logos-module_38",
-        "logos-nix": "logos-nix_278",
+        "logos-module": "logos-module_34",
+        "logos-nix": "logos-nix_232",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
@@ -24933,12 +28504,11 @@
     },
     "logos-plugin-core_8": {
       "inputs": {
-        "logos-module": "logos-module_44",
-        "logos-nix": "logos-nix_321",
+        "logos-module": "logos-module_42",
+        "logos-nix": "logos-nix_319",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -24963,14 +28533,12 @@
     },
     "logos-plugin-core_9": {
       "inputs": {
-        "logos-module": "logos-module_51",
-        "logos-nix": "logos-nix_375",
+        "logos-module": "logos-module_49",
+        "logos-nix": "logos-nix_370",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
@@ -25019,8 +28587,69 @@
     },
     "logos-plugin-qt_10": {
       "inputs": {
-        "logos-module": "logos-module_59",
-        "logos-nix": "logos-nix_428",
+        "logos-module": "logos-module_56",
+        "logos-nix": "logos-nix_415",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778168218,
+        "narHash": "sha256-EGHUsyKaA7IjnBKNysFD62Qlqsd0GyxyhbuYNAS0+Tg=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "8c45eca86db8fba8689326c35d0ec8c2b3cdd9a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_11": {
+      "inputs": {
+        "logos-module": "logos-module_63",
+        "logos-nix": "logos-nix_469",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778168218,
+        "narHash": "sha256-EGHUsyKaA7IjnBKNysFD62Qlqsd0GyxyhbuYNAS0+Tg=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "8c45eca86db8fba8689326c35d0ec8c2b3cdd9a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_12": {
+      "inputs": {
+        "logos-module": "logos-module_70",
+        "logos-nix": "logos-nix_520",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -25048,10 +28677,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_11": {
+    "logos-plugin-qt_13": {
       "inputs": {
-        "logos-module": "logos-module_65",
-        "logos-nix": "logos-nix_471",
+        "logos-module": "logos-module_76",
+        "logos-nix": "logos-nix_563",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -25080,10 +28709,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_12": {
+    "logos-plugin-qt_14": {
       "inputs": {
-        "logos-module": "logos-module_72",
-        "logos-nix": "logos-nix_537",
+        "logos-module": "logos-module_83",
+        "logos-nix": "logos-nix_629",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -25109,10 +28738,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_13": {
+    "logos-plugin-qt_15": {
       "inputs": {
-        "logos-module": "logos-module_78",
-        "logos-nix": "logos-nix_592",
+        "logos-module": "logos-module_89",
+        "logos-nix": "logos-nix_684",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -25136,10 +28765,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_14": {
+    "logos-plugin-qt_16": {
       "inputs": {
-        "logos-module": "logos-module_81",
-        "logos-nix": "logos-nix_599",
+        "logos-module": "logos-module_92",
+        "logos-nix": "logos-nix_691",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -25166,10 +28795,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_15": {
+    "logos-plugin-qt_17": {
       "inputs": {
-        "logos-module": "logos-module_87",
-        "logos-nix": "logos-nix_643",
+        "logos-module": "logos-module_98",
+        "logos-nix": "logos-nix_735",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -25283,8 +28912,8 @@
     },
     "logos-plugin-qt_5": {
       "inputs": {
-        "logos-module": "logos-module_25",
-        "logos-nix": "logos-nix_173",
+        "logos-module": "logos-module_26",
+        "logos-nix": "logos-nix_183",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -25296,11 +28925,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778168218,
-        "narHash": "sha256-EGHUsyKaA7IjnBKNysFD62Qlqsd0GyxyhbuYNAS0+Tg=",
+        "lastModified": 1780929868,
+        "narHash": "sha256-yDxv9Cv5VEJDVqHz9qYCU3UXv+kCIjRoD90A7uGYuGU=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "8c45eca86db8fba8689326c35d0ec8c2b3cdd9a0",
+        "rev": "68090d0a976224ca1c3c606c486a9ac3dd7a4559",
         "type": "github"
       },
       "original": {
@@ -25311,12 +28940,14 @@
     },
     "logos-plugin-qt_6": {
       "inputs": {
-        "logos-module": "logos-module_32",
-        "logos-nix": "logos-nix_229",
+        "logos-module": "logos-module_29",
+        "logos-nix": "logos-nix_190",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
@@ -25340,12 +28971,15 @@
     },
     "logos-plugin-qt_7": {
       "inputs": {
-        "logos-module": "logos-module_39",
-        "logos-nix": "logos-nix_280",
+        "logos-module": "logos-module_35",
+        "logos-nix": "logos-nix_234",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
@@ -25369,12 +29003,11 @@
     },
     "logos-plugin-qt_8": {
       "inputs": {
-        "logos-module": "logos-module_45",
-        "logos-nix": "logos-nix_323",
+        "logos-module": "logos-module_43",
+        "logos-nix": "logos-nix_321",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -25399,14 +29032,12 @@
     },
     "logos-plugin-qt_9": {
       "inputs": {
-        "logos-module": "logos-module_52",
-        "logos-nix": "logos-nix_377",
+        "logos-module": "logos-module_50",
+        "logos-nix": "logos-nix_372",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
@@ -25439,11 +29070,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781303997,
-        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "lastModified": 1782082589,
+        "narHash": "sha256-Qeqxp0HYb3oTpmfD5YlFPJzpAJa7Ilb9o4sMeVvmHRI=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "rev": "315a3a2e0af61bc47aad5601ee44cd7689975820",
         "type": "github"
       },
       "original": {
@@ -25481,7 +29112,33 @@
     },
     "logos-protocol_3": {
       "inputs": {
-        "logos-nix": "logos-nix_217",
+        "logos-nix": "logos-nix_175",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_4": {
+      "inputs": {
+        "logos-nix": "logos-nix_309",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -25504,9 +29161,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_4": {
+    "logos-protocol_5": {
       "inputs": {
-        "logos-nix": "logos-nix_221",
+        "logos-nix": "logos-nix_313",
         "nixpkgs": [
           "logoscore-cli",
           "logos-protocol",
@@ -25557,13 +29214,12 @@
     },
     "logos-qt-mcp_10": {
       "inputs": {
-        "logos-nix": "logos-nix_446",
+        "logos-nix": "logos-nix_433",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -25587,13 +29243,12 @@
     },
     "logos-qt-mcp_11": {
       "inputs": {
-        "logos-nix": "logos-nix_489",
+        "logos-nix": "logos-nix_487",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -25618,7 +29273,68 @@
     },
     "logos-qt-mcp_12": {
       "inputs": {
-        "logos-nix": "logos-nix_555",
+        "logos-nix": "logos-nix_538",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455349,
+        "narHash": "sha256-rebrtH1UxC1hDuwQBwyYbGzNCrnuuqiVL7OvzUhk65k=",
+        "owner": "logos-co",
+        "repo": "logos-qt-mcp",
+        "rev": "c5223b4b640add09e461983b8fddbd12c8b31f4f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-mcp",
+        "type": "github"
+      }
+    },
+    "logos-qt-mcp_13": {
+      "inputs": {
+        "logos-nix": "logos-nix_581",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455349,
+        "narHash": "sha256-rebrtH1UxC1hDuwQBwyYbGzNCrnuuqiVL7OvzUhk65k=",
+        "owner": "logos-co",
+        "repo": "logos-qt-mcp",
+        "rev": "c5223b4b640add09e461983b8fddbd12c8b31f4f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-mcp",
+        "type": "github"
+      }
+    },
+    "logos-qt-mcp_14": {
+      "inputs": {
+        "logos-nix": "logos-nix_647",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -25644,9 +29360,9 @@
         "type": "github"
       }
     },
-    "logos-qt-mcp_13": {
+    "logos-qt-mcp_15": {
       "inputs": {
-        "logos-nix": "logos-nix_617",
+        "logos-nix": "logos-nix_709",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -25673,9 +29389,9 @@
         "type": "github"
       }
     },
-    "logos-qt-mcp_14": {
+    "logos-qt-mcp_16": {
       "inputs": {
-        "logos-nix": "logos-nix_661",
+        "logos-nix": "logos-nix_753",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -25703,9 +29419,9 @@
         "type": "github"
       }
     },
-    "logos-qt-mcp_15": {
+    "logos-qt-mcp_17": {
       "inputs": {
-        "logos-nix": "logos-nix_689",
+        "logos-nix": "logos-nix_781",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -25811,10 +29527,13 @@
     },
     "logos-qt-mcp_5": {
       "inputs": {
-        "logos-nix": "logos-nix_191",
+        "logos-nix": "logos-nix_208",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -25838,10 +29557,13 @@
     },
     "logos-qt-mcp_6": {
       "inputs": {
-        "logos-nix": "logos-nix_247",
+        "logos-nix": "logos-nix_252",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -25866,24 +29588,24 @@
     },
     "logos-qt-mcp_7": {
       "inputs": {
-        "logos-nix": "logos-nix_298",
+        "logos-nix": "logos-nix_280",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-qt-mcp",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1774455349,
-        "narHash": "sha256-rebrtH1UxC1hDuwQBwyYbGzNCrnuuqiVL7OvzUhk65k=",
+        "lastModified": 1781077555,
+        "narHash": "sha256-rkqva3DbhhxWrVp6KLyhVxbAK2MLIWfUcPG5HM7wnsQ=",
         "owner": "logos-co",
         "repo": "logos-qt-mcp",
-        "rev": "c5223b4b640add09e461983b8fddbd12c8b31f4f",
+        "rev": "c87f6bd985a07ec2809081c8d0830108aa895819",
         "type": "github"
       },
       "original": {
@@ -25894,11 +29616,10 @@
     },
     "logos-qt-mcp_8": {
       "inputs": {
-        "logos-nix": "logos-nix_341",
+        "logos-nix": "logos-nix_339",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -25923,13 +29644,11 @@
     },
     "logos-qt-mcp_9": {
       "inputs": {
-        "logos-nix": "logos-nix_395",
+        "logos-nix": "logos-nix_390",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -25971,11 +29690,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781655169,
-        "narHash": "sha256-wjbHmczSG8VUMlRkIp3pviVTLPTzReDbIRfBpqnlQr4=",
+        "lastModified": 1781962335,
+        "narHash": "sha256-TThOj0o115vPawAPJgv5zhDnV/hVfnDqjpga9Z2SlPU=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "812369213719773f6486755a30c476a699469b37",
+        "rev": "cdf077cdb296b39fe45d6f774a0b4ae71be48d45",
         "type": "github"
       },
       "original": {
@@ -26026,9 +29745,49 @@
         "logos-cpp-sdk": [
           "logoscore-cli",
           "logos-liblogos",
+          "default-module-loader",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_218",
+        "logos-lidl": "logos-lidl_5",
+        "logos-nix": "logos-nix_176",
+        "logos-protocol": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781655169,
+        "narHash": "sha256-wjbHmczSG8VUMlRkIp3pviVTLPTzReDbIRfBpqnlQr4=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "812369213719773f6486755a30c476a699469b37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_4": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_7",
+        "logos-nix": "logos-nix_310",
         "logos-protocol": [
           "logoscore-cli",
           "logos-liblogos",
@@ -26043,11 +29802,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781306785,
-        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
+        "lastModified": 1781655169,
+        "narHash": "sha256-wjbHmczSG8VUMlRkIp3pviVTLPTzReDbIRfBpqnlQr4=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
+        "rev": "812369213719773f6486755a30c476a699469b37",
         "type": "github"
       },
       "original": {
@@ -26056,13 +29815,13 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_4": {
+    "logos-qt-sdk_5": {
       "inputs": {
         "logos-cpp-sdk": [
           "logoscore-cli",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_222",
+        "logos-nix": "logos-nix_314",
         "logos-protocol": [
           "logoscore-cli",
           "logos-protocol"
@@ -26090,6 +29849,7 @@
     },
     "logos-rust-sdk": {
       "inputs": {
+        "logos-lidl": "logos-lidl_3",
         "logos-logoscore-cli": [
           "logos-module-builder",
           "logos-cpp-sdk"
@@ -26114,17 +29874,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1781550278,
-        "narHash": "sha256-j3CZSeGvvw+X5qRLlaHh1UfUNFc2hNs756hSN04J/XQ=",
+        "lastModified": 1782045655,
+        "narHash": "sha256-fprp1M+5opx3nfqAW+2HKcRUQyc+zqxsOxdNvpJFFv0=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "340f42d41008488d912257e7836789795adbaeb7",
+        "rev": "9957a9dd81c38c27e7021b623709129d3a4b7476",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "340f42d41008488d912257e7836789795adbaeb7",
+        "rev": "9957a9dd81c38c27e7021b623709129d3a4b7476",
         "type": "github"
       }
     },
@@ -26161,14 +29921,87 @@
     },
     "logos-standalone-app_10": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_26",
-        "logos-cpp-sdk": "logos-cpp-sdk_45",
+        "logos-capability-module": "logos-capability-module_24",
+        "logos-cpp-sdk": "logos-cpp-sdk_43",
         "logos-design-system": "logos-design-system_10",
-        "logos-liblogos": "logos-liblogos_14",
-        "logos-nix": "logos-nix_445",
+        "logos-liblogos": "logos-liblogos_13",
+        "logos-nix": "logos-nix_432",
         "logos-qt-mcp": "logos-qt-mcp_10",
         "logos-view-module-runtime": "logos-view-module-runtime_10",
         "nix-bundle-lgx": "nix-bundle-lgx_28",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778177364,
+        "narHash": "sha256-k05qvbRM2fR7SAEKaElXZNtneWJx/IN/yEx4JMnxv1A=",
+        "owner": "logos-co",
+        "repo": "logos-standalone-app",
+        "rev": "a749953e0e9f3d716856d2bd818cd5757aeb065d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-standalone-app",
+        "type": "github"
+      }
+    },
+    "logos-standalone-app_11": {
+      "inputs": {
+        "logos-capability-module": "logos-capability-module_27",
+        "logos-cpp-sdk": "logos-cpp-sdk_49",
+        "logos-design-system": "logos-design-system_11",
+        "logos-liblogos": "logos-liblogos_15",
+        "logos-nix": "logos-nix_486",
+        "logos-qt-mcp": "logos-qt-mcp_11",
+        "logos-view-module-runtime": "logos-view-module-runtime_11",
+        "nix-bundle-lgx": "nix-bundle-lgx_31",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778177364,
+        "narHash": "sha256-k05qvbRM2fR7SAEKaElXZNtneWJx/IN/yEx4JMnxv1A=",
+        "owner": "logos-co",
+        "repo": "logos-standalone-app",
+        "rev": "a749953e0e9f3d716856d2bd818cd5757aeb065d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-standalone-app",
+        "type": "github"
+      }
+    },
+    "logos-standalone-app_12": {
+      "inputs": {
+        "logos-capability-module": "logos-capability-module_30",
+        "logos-cpp-sdk": "logos-cpp-sdk_54",
+        "logos-design-system": "logos-design-system_12",
+        "logos-liblogos": "logos-liblogos_16",
+        "logos-nix": "logos-nix_537",
+        "logos-qt-mcp": "logos-qt-mcp_12",
+        "logos-view-module-runtime": "logos-view-module-runtime_12",
+        "nix-bundle-lgx": "nix-bundle-lgx_34",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26196,16 +30029,16 @@
         "type": "github"
       }
     },
-    "logos-standalone-app_11": {
+    "logos-standalone-app_13": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_29",
-        "logos-cpp-sdk": "logos-cpp-sdk_50",
-        "logos-design-system": "logos-design-system_11",
-        "logos-liblogos": "logos-liblogos_16",
-        "logos-nix": "logos-nix_488",
-        "logos-qt-mcp": "logos-qt-mcp_11",
-        "logos-view-module-runtime": "logos-view-module-runtime_11",
-        "nix-bundle-lgx": "nix-bundle-lgx_31",
+        "logos-capability-module": "logos-capability-module_33",
+        "logos-cpp-sdk": "logos-cpp-sdk_59",
+        "logos-design-system": "logos-design-system_13",
+        "logos-liblogos": "logos-liblogos_18",
+        "logos-nix": "logos-nix_580",
+        "logos-qt-mcp": "logos-qt-mcp_13",
+        "logos-view-module-runtime": "logos-view-module-runtime_13",
+        "nix-bundle-lgx": "nix-bundle-lgx_37",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26234,16 +30067,16 @@
         "type": "github"
       }
     },
-    "logos-standalone-app_12": {
+    "logos-standalone-app_14": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_31",
-        "logos-cpp-sdk": "logos-cpp-sdk_56",
-        "logos-design-system": "logos-design-system_12",
-        "logos-liblogos": "logos-liblogos_17",
-        "logos-nix": "logos-nix_554",
-        "logos-qt-mcp": "logos-qt-mcp_12",
-        "logos-view-module-runtime": "logos-view-module-runtime_12",
-        "nix-bundle-lgx": "nix-bundle-lgx_35",
+        "logos-capability-module": "logos-capability-module_35",
+        "logos-cpp-sdk": "logos-cpp-sdk_65",
+        "logos-design-system": "logos-design-system_14",
+        "logos-liblogos": "logos-liblogos_19",
+        "logos-nix": "logos-nix_646",
+        "logos-qt-mcp": "logos-qt-mcp_14",
+        "logos-view-module-runtime": "logos-view-module-runtime_14",
+        "nix-bundle-lgx": "nix-bundle-lgx_41",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26269,16 +30102,16 @@
         "type": "github"
       }
     },
-    "logos-standalone-app_13": {
+    "logos-standalone-app_15": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_33",
-        "logos-cpp-sdk": "logos-cpp-sdk_64",
-        "logos-design-system": "logos-design-system_14",
-        "logos-liblogos": "logos-liblogos_19",
-        "logos-nix": "logos-nix_688",
-        "logos-qt-mcp": "logos-qt-mcp_15",
-        "logos-view-module-runtime": "logos-view-module-runtime_15",
-        "nix-bundle-lgx": "nix-bundle-lgx_45",
+        "logos-capability-module": "logos-capability-module_37",
+        "logos-cpp-sdk": "logos-cpp-sdk_73",
+        "logos-design-system": "logos-design-system_16",
+        "logos-liblogos": "logos-liblogos_21",
+        "logos-nix": "logos-nix_780",
+        "logos-qt-mcp": "logos-qt-mcp_17",
+        "logos-view-module-runtime": "logos-view-module-runtime_17",
+        "nix-bundle-lgx": "nix-bundle-lgx_51",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26302,16 +30135,16 @@
         "type": "github"
       }
     },
-    "logos-standalone-app_14": {
+    "logos-standalone-app_16": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_34",
-        "logos-cpp-sdk": "logos-cpp-sdk_61",
-        "logos-design-system": "logos-design-system_13",
-        "logos-liblogos": "logos-liblogos_18",
-        "logos-nix": "logos-nix_616",
-        "logos-qt-mcp": "logos-qt-mcp_13",
-        "logos-view-module-runtime": "logos-view-module-runtime_13",
-        "nix-bundle-lgx": "nix-bundle-lgx_39",
+        "logos-capability-module": "logos-capability-module_38",
+        "logos-cpp-sdk": "logos-cpp-sdk_70",
+        "logos-design-system": "logos-design-system_15",
+        "logos-liblogos": "logos-liblogos_20",
+        "logos-nix": "logos-nix_708",
+        "logos-qt-mcp": "logos-qt-mcp_15",
+        "logos-view-module-runtime": "logos-view-module-runtime_15",
+        "nix-bundle-lgx": "nix-bundle-lgx_45",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26338,16 +30171,16 @@
         "type": "github"
       }
     },
-    "logos-standalone-app_15": {
+    "logos-standalone-app_17": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_37",
-        "logos-cpp-sdk": "logos-cpp-sdk_66",
-        "logos-design-system": "logos-design-system_15",
-        "logos-liblogos": "logos-liblogos_20",
-        "logos-nix": "logos-nix_660",
-        "logos-qt-mcp": "logos-qt-mcp_14",
-        "logos-view-module-runtime": "logos-view-module-runtime_14",
-        "nix-bundle-lgx": "nix-bundle-lgx_42",
+        "logos-capability-module": "logos-capability-module_41",
+        "logos-cpp-sdk": "logos-cpp-sdk_75",
+        "logos-design-system": "logos-design-system_17",
+        "logos-liblogos": "logos-liblogos_22",
+        "logos-nix": "logos-nix_752",
+        "logos-qt-mcp": "logos-qt-mcp_16",
+        "logos-view-module-runtime": "logos-view-module-runtime_16",
+        "nix-bundle-lgx": "nix-bundle-lgx_48",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26480,13 +30313,13 @@
     "logos-standalone-app_5": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_11",
-        "logos-cpp-sdk": "logos-cpp-sdk_19",
-        "logos-design-system": "logos-design-system_5",
-        "logos-liblogos": "logos-liblogos_6",
-        "logos-nix": "logos-nix_190",
-        "logos-qt-mcp": "logos-qt-mcp_5",
-        "logos-view-module-runtime": "logos-view-module-runtime_5",
-        "nix-bundle-lgx": "nix-bundle-lgx_13",
+        "logos-cpp-sdk": "logos-cpp-sdk_24",
+        "logos-design-system": "logos-design-system_6",
+        "logos-liblogos": "logos-liblogos_7",
+        "logos-nix": "logos-nix_279",
+        "logos-qt-mcp": "logos-qt-mcp_7",
+        "logos-view-module-runtime": "logos-view-module-runtime_7",
+        "nix-bundle-lgx": "nix-bundle-lgx_19",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -26498,11 +30331,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778177364,
-        "narHash": "sha256-k05qvbRM2fR7SAEKaElXZNtneWJx/IN/yEx4JMnxv1A=",
+        "lastModified": 1781127963,
+        "narHash": "sha256-Z7vO0bm1trVctlqsDc+p6lLYEC1K5qEJctgdSkVG2YI=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "a749953e0e9f3d716856d2bd818cd5757aeb065d",
+        "rev": "0206e2ea6c43d78d083ba7e4e002fe34a60b77ac",
         "type": "github"
       },
       "original": {
@@ -26513,18 +30346,20 @@
     },
     "logos-standalone-app_6": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_14",
-        "logos-cpp-sdk": "logos-cpp-sdk_24",
-        "logos-design-system": "logos-design-system_6",
-        "logos-liblogos": "logos-liblogos_8",
-        "logos-nix": "logos-nix_246",
-        "logos-qt-mcp": "logos-qt-mcp_6",
-        "logos-view-module-runtime": "logos-view-module-runtime_6",
-        "nix-bundle-lgx": "nix-bundle-lgx_16",
+        "logos-capability-module": "logos-capability-module_12",
+        "logos-cpp-sdk": "logos-cpp-sdk_21",
+        "logos-design-system": "logos-design-system_5",
+        "logos-liblogos": "logos-liblogos_6",
+        "logos-nix": "logos-nix_207",
+        "logos-qt-mcp": "logos-qt-mcp_5",
+        "logos-view-module-runtime": "logos-view-module-runtime_5",
+        "nix-bundle-lgx": "nix-bundle-lgx_13",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -26548,18 +30383,21 @@
     },
     "logos-standalone-app_7": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_17",
-        "logos-cpp-sdk": "logos-cpp-sdk_29",
+        "logos-capability-module": "logos-capability-module_15",
+        "logos-cpp-sdk": "logos-cpp-sdk_26",
         "logos-design-system": "logos-design-system_7",
-        "logos-liblogos": "logos-liblogos_9",
-        "logos-nix": "logos-nix_297",
-        "logos-qt-mcp": "logos-qt-mcp_7",
-        "logos-view-module-runtime": "logos-view-module-runtime_7",
-        "nix-bundle-lgx": "nix-bundle-lgx_19",
+        "logos-liblogos": "logos-liblogos_8",
+        "logos-nix": "logos-nix_251",
+        "logos-qt-mcp": "logos-qt-mcp_6",
+        "logos-view-module-runtime": "logos-view-module-runtime_6",
+        "nix-bundle-lgx": "nix-bundle-lgx_16",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -26583,18 +30421,17 @@
     },
     "logos-standalone-app_8": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_20",
-        "logos-cpp-sdk": "logos-cpp-sdk_34",
+        "logos-capability-module": "logos-capability-module_18",
+        "logos-cpp-sdk": "logos-cpp-sdk_33",
         "logos-design-system": "logos-design-system_8",
-        "logos-liblogos": "logos-liblogos_11",
-        "logos-nix": "logos-nix_340",
+        "logos-liblogos": "logos-liblogos_10",
+        "logos-nix": "logos-nix_338",
         "logos-qt-mcp": "logos-qt-mcp_8",
         "logos-view-module-runtime": "logos-view-module-runtime_8",
         "nix-bundle-lgx": "nix-bundle-lgx_22",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -26619,11 +30456,11 @@
     },
     "logos-standalone-app_9": {
       "inputs": {
-        "logos-capability-module": "logos-capability-module_23",
-        "logos-cpp-sdk": "logos-cpp-sdk_40",
+        "logos-capability-module": "logos-capability-module_21",
+        "logos-cpp-sdk": "logos-cpp-sdk_38",
         "logos-design-system": "logos-design-system_9",
-        "logos-liblogos": "logos-liblogos_13",
-        "logos-nix": "logos-nix_394",
+        "logos-liblogos": "logos-liblogos_11",
+        "logos-nix": "logos-nix_389",
         "logos-qt-mcp": "logos-qt-mcp_9",
         "logos-view-module-runtime": "logos-view-module-runtime_9",
         "nix-bundle-lgx": "nix-bundle-lgx_25",
@@ -26631,8 +30468,6 @@
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -26694,19 +30529,17 @@
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_451",
+        "logos-nix": "logos-nix_438",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
@@ -26735,19 +30568,17 @@
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_494",
+        "logos-nix": "logos-nix_492",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -26777,15 +30608,19 @@
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_560",
+        "logos-nix": "logos-nix_543",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix",
@@ -26811,18 +30646,22 @@
         "logos-cpp-sdk": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_622",
+        "logos-nix": "logos-nix_586",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
@@ -26849,6 +30688,80 @@
         "logos-cpp-sdk": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": "logos-nix_652",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778168561,
+        "narHash": "sha256-BINVw7hztdrDkoDSdmnKZes7A15g1SmXKjIHpjZv/3I=",
+        "owner": "logos-co",
+        "repo": "logos-test-framework",
+        "rev": "44816073a437fde4203e140b896e70a387c0678a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-test-framework",
+        "type": "github"
+      }
+    },
+    "logos-test-framework_15": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": "logos-nix_714",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778168561,
+        "narHash": "sha256-BINVw7hztdrDkoDSdmnKZes7A15g1SmXKjIHpjZv/3I=",
+        "owner": "logos-co",
+        "repo": "logos-test-framework",
+        "rev": "44816073a437fde4203e140b896e70a387c0678a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-test-framework",
+        "type": "github"
+      }
+    },
+    "logos-test-framework_16": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26856,7 +30769,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_666",
+        "logos-nix": "logos-nix_758",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26884,7 +30797,7 @@
         "type": "github"
       }
     },
-    "logos-test-framework_15": {
+    "logos-test-framework_17": {
       "inputs": {
         "logos-cpp-sdk": [
           "logoscore-cli",
@@ -26892,7 +30805,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_694",
+        "logos-nix": "logos-nix_786",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27021,12 +30934,18 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_196",
+        "logos-nix": "logos-nix_213",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
@@ -27052,16 +30971,22 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_252",
+        "logos-nix": "logos-nix_257",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -27088,17 +31013,15 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_303",
+        "logos-nix": "logos-nix_285",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
@@ -27107,11 +31030,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778168561,
-        "narHash": "sha256-BINVw7hztdrDkoDSdmnKZes7A15g1SmXKjIHpjZv/3I=",
+        "lastModified": 1780432542,
+        "narHash": "sha256-LcZnXuNTCyFQS7rhOHF3sy+oF6PNq/H1MLPHch08XrU=",
         "owner": "logos-co",
         "repo": "logos-test-framework",
-        "rev": "44816073a437fde4203e140b896e70a387c0678a",
+        "rev": "ee081954096f602b47308c6dc7d00fb71d5dcdc7",
         "type": "github"
       },
       "original": {
@@ -27125,17 +31048,15 @@
         "logos-cpp-sdk": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_346",
+        "logos-nix": "logos-nix_344",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -27164,19 +31085,15 @@
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_400",
+        "logos-nix": "logos-nix_395",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
@@ -27200,10 +31117,10 @@
     },
     "logos-test-modules": {
       "inputs": {
-        "logos-liblogos": "logos-liblogos_7",
+        "logos-liblogos": "logos-liblogos_9",
         "logos-logoscore-cli": "logos-logoscore-cli",
-        "logos-module-builder": "logos-module-builder_13",
-        "logos-nix": "logos-nix_707",
+        "logos-module-builder": "logos-module-builder_15",
+        "logos-nix": "logos-nix_799",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27227,10 +31144,10 @@
     },
     "logos-test-modules_2": {
       "inputs": {
-        "logos-liblogos": "logos-liblogos_12",
+        "logos-liblogos": "logos-liblogos_14",
         "logos-logoscore-cli": "logos-logoscore-cli_2",
-        "logos-module-builder": "logos-module-builder_12",
-        "logos-nix": "logos-nix_573",
+        "logos-module-builder": "logos-module-builder_14",
+        "logos-nix": "logos-nix_665",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27295,20 +31212,18 @@
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_447",
+        "logos-nix": "logos-nix_434",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -27337,20 +31252,18 @@
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_490",
+        "logos-nix": "logos-nix_488",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -27380,16 +31293,20 @@
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_556",
+        "logos-nix": "logos-nix_539",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix",
@@ -27415,19 +31332,23 @@
         "logos-cpp-sdk": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_618",
+        "logos-nix": "logos-nix_582",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -27454,6 +31375,82 @@
         "logos-cpp-sdk": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": "logos-nix_648",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778168591,
+        "narHash": "sha256-gHapkm3yh3YNuM8EaFvThrJ2qVjcKKr5KA6wFfE0M7Q=",
+        "owner": "logos-co",
+        "repo": "logos-view-module-runtime",
+        "rev": "3c3735c25c8d66cc713623420dc74e445442592a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-view-module-runtime",
+        "type": "github"
+      }
+    },
+    "logos-view-module-runtime_15": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": "logos-nix_710",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778168591,
+        "narHash": "sha256-gHapkm3yh3YNuM8EaFvThrJ2qVjcKKr5KA6wFfE0M7Q=",
+        "owner": "logos-co",
+        "repo": "logos-view-module-runtime",
+        "rev": "3c3735c25c8d66cc713623420dc74e445442592a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-view-module-runtime",
+        "type": "github"
+      }
+    },
+    "logos-view-module-runtime_16": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -27462,7 +31459,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_662",
+        "logos-nix": "logos-nix_754",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27490,10 +31487,10 @@
         "type": "github"
       }
     },
-    "logos-view-module-runtime_15": {
+    "logos-view-module-runtime_17": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_70",
-        "logos-nix": "logos-nix_690",
+        "logos-cpp-sdk": "logos-cpp-sdk_79",
+        "logos-nix": "logos-nix_782",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27622,12 +31619,18 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_192",
+        "logos-nix": "logos-nix_209",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -27653,17 +31656,23 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_248",
+        "logos-nix": "logos-nix_253",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -27688,33 +31697,25 @@
     },
     "logos-view-module-runtime_7": {
       "inputs": {
-        "logos-cpp-sdk": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk"
-        ],
-        "logos-nix": "logos-nix_299",
+        "logos-cpp-sdk": "logos-cpp-sdk_30",
+        "logos-nix": "logos-nix_281",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-view-module-runtime",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778168591,
-        "narHash": "sha256-gHapkm3yh3YNuM8EaFvThrJ2qVjcKKr5KA6wFfE0M7Q=",
+        "lastModified": 1781120903,
+        "narHash": "sha256-dPi2gaFPB0mfDLyFRO2xVo88GODYgs/akT5CNy1J2o0=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "3c3735c25c8d66cc713623420dc74e445442592a",
+        "rev": "bec7d3e6041c33109d6696276e634a5258ba788c",
         "type": "github"
       },
       "original": {
@@ -27728,18 +31729,16 @@
         "logos-cpp-sdk": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_342",
+        "logos-nix": "logos-nix_340",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -27768,20 +31767,16 @@
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_396",
+        "logos-nix": "logos-nix_391",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -27808,13 +31803,13 @@
         "logos-capability-module": "logos-capability-module_7",
         "logos-cpp-sdk": "logos-cpp-sdk_17",
         "logos-liblogos": "logos-liblogos_5",
-        "logos-nix": "logos-nix_220",
-        "logos-protocol": "logos-protocol_4",
-        "logos-qt-sdk": "logos-qt-sdk_4",
+        "logos-nix": "logos-nix_312",
+        "logos-protocol": "logos-protocol_5",
+        "logos-qt-sdk": "logos-qt-sdk_5",
         "logos-test-modules": "logos-test-modules",
-        "nix-bundle-appimage": "nix-bundle-appimage_40",
-        "nix-bundle-dir": "nix-bundle-dir_127",
-        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_18",
+        "nix-bundle-appimage": "nix-bundle-appimage_44",
+        "nix-bundle-dir": "nix-bundle-dir_141",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_20",
         "nixpkgs": [
           "logoscore-cli",
           "logos-nix",
@@ -27822,11 +31817,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781796080,
-        "narHash": "sha256-3WKsMCRYDDx/1X06gEQWghjfNhMiV8UgqIHn657T7F8=",
+        "lastModified": 1781907401,
+        "narHash": "sha256-7JIXkoI9DZLq59AhDH1ddvuKSLrySzefuKEHHU8H4so=",
         "owner": "logos-co",
         "repo": "logos-logoscore-cli",
-        "rev": "8002477a34e9afa2cbd7e9a795fbb2e982c7666b",
+        "rev": "859c365ea15acd27cc9acfcebbb092d26d491585",
         "type": "github"
       },
       "original": {
@@ -27868,11 +31863,14 @@
     },
     "nix-bundle-appimage_10": {
       "inputs": {
-        "logos-nix": "logos-nix_203",
+        "logos-nix": "logos-nix_220",
         "nix-bundle-dir": "nix-bundle-dir_33",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -27898,10 +31896,18 @@
     },
     "nix-bundle-appimage_11": {
       "inputs": {
-        "logos-nix": "logos-nix_214",
+        "logos-nix": "logos-nix_247",
         "nix-bundle-dir": "nix-bundle-dir_36",
         "nixpkgs": [
           "logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -27925,43 +31931,14 @@
     },
     "nix-bundle-appimage_12": {
       "inputs": {
-        "logos-nix": "logos-nix_242",
-        "nix-bundle-dir": "nix-bundle-dir_38",
+        "logos-nix": "logos-nix_264",
+        "nix-bundle-dir": "nix-bundle-dir_40",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_13": {
-      "inputs": {
-        "logos-nix": "logos-nix_259",
-        "nix-bundle-dir": "nix-bundle-dir_42",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -27986,14 +31963,47 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_14": {
+    "nix-bundle-appimage_13": {
       "inputs": {
-        "logos-nix": "logos-nix_270",
-        "nix-bundle-dir": "nix-bundle-dir_45",
+        "logos-nix": "logos-nix_275",
+        "nix-bundle-dir": "nix-bundle-dir_43",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_14": {
+      "inputs": {
+        "logos-nix": "logos-nix_292",
+        "nix-bundle-dir": "nix-bundle-dir_47",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -28016,15 +32026,10 @@
     },
     "nix-bundle-appimage_15": {
       "inputs": {
-        "logos-nix": "logos-nix_293",
-        "nix-bundle-dir": "nix-bundle-dir_47",
+        "logos-nix": "logos-nix_306",
+        "nix-bundle-dir": "nix-bundle-dir_50",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -28048,43 +32053,11 @@
     },
     "nix-bundle-appimage_16": {
       "inputs": {
-        "logos-nix": "logos-nix_310",
-        "nix-bundle-dir": "nix-bundle-dir_51",
+        "logos-nix": "logos-nix_334",
+        "nix-bundle-dir": "nix-bundle-dir_52",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_17": {
-      "inputs": {
-        "logos-nix": "logos-nix_336",
-        "nix-bundle-dir": "nix-bundle-dir_54",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -28110,14 +32083,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_18": {
+    "nix-bundle-appimage_17": {
       "inputs": {
-        "logos-nix": "logos-nix_353",
-        "nix-bundle-dir": "nix-bundle-dir_58",
+        "logos-nix": "logos-nix_351",
+        "nix-bundle-dir": "nix-bundle-dir_56",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -28142,14 +32114,45 @@
         "type": "github"
       }
     },
+    "nix-bundle-appimage_18": {
+      "inputs": {
+        "logos-nix": "logos-nix_362",
+        "nix-bundle-dir": "nix-bundle-dir_59",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
     "nix-bundle-appimage_19": {
       "inputs": {
-        "logos-nix": "logos-nix_364",
+        "logos-nix": "logos-nix_385",
         "nix-bundle-dir": "nix-bundle-dir_61",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -28203,13 +32206,43 @@
     },
     "nix-bundle-appimage_20": {
       "inputs": {
-        "logos-nix": "logos-nix_390",
-        "nix-bundle-dir": "nix-bundle-dir_63",
+        "logos-nix": "logos-nix_402",
+        "nix-bundle-dir": "nix-bundle-dir_65",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_21": {
+      "inputs": {
+        "logos-nix": "logos-nix_428",
+        "nix-bundle-dir": "nix-bundle-dir_68",
+        "nixpkgs": [
+          "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -28235,15 +32268,14 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_21": {
+    "nix-bundle-appimage_22": {
       "inputs": {
-        "logos-nix": "logos-nix_407",
-        "nix-bundle-dir": "nix-bundle-dir_67",
+        "logos-nix": "logos-nix_445",
+        "nix-bundle-dir": "nix-bundle-dir_72",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -28268,49 +32300,14 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_22": {
-      "inputs": {
-        "logos-nix": "logos-nix_418",
-        "nix-bundle-dir": "nix-bundle-dir_70",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
     "nix-bundle-appimage_23": {
       "inputs": {
-        "logos-nix": "logos-nix_441",
-        "nix-bundle-dir": "nix-bundle-dir_72",
+        "logos-nix": "logos-nix_456",
+        "nix-bundle-dir": "nix-bundle-dir_75",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -28334,47 +32331,13 @@
     },
     "nix-bundle-appimage_24": {
       "inputs": {
-        "logos-nix": "logos-nix_458",
-        "nix-bundle-dir": "nix-bundle-dir_76",
+        "logos-nix": "logos-nix_482",
+        "nix-bundle-dir": "nix-bundle-dir_77",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_25": {
-      "inputs": {
-        "logos-nix": "logos-nix_484",
-        "nix-bundle-dir": "nix-bundle-dir_79",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -28400,16 +32363,15 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_26": {
+    "nix-bundle-appimage_25": {
       "inputs": {
-        "logos-nix": "logos-nix_501",
-        "nix-bundle-dir": "nix-bundle-dir_83",
+        "logos-nix": "logos-nix_499",
+        "nix-bundle-dir": "nix-bundle-dir_81",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -28434,9 +32396,39 @@
         "type": "github"
       }
     },
+    "nix-bundle-appimage_26": {
+      "inputs": {
+        "logos-nix": "logos-nix_510",
+        "nix-bundle-dir": "nix-bundle-dir_84",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
     "nix-bundle-appimage_27": {
       "inputs": {
-        "logos-nix": "logos-nix_512",
+        "logos-nix": "logos-nix_533",
         "nix-bundle-dir": "nix-bundle-dir_86",
         "nixpkgs": [
           "logoscore-cli",
@@ -28444,6 +32436,9 @@
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -28467,25 +32462,29 @@
     },
     "nix-bundle-appimage_28": {
       "inputs": {
-        "logos-nix": "logos-nix_519",
-        "nix-bundle-dir": "nix-bundle-dir_88",
+        "logos-nix": "logos-nix_550",
+        "nix-bundle-dir": "nix-bundle-dir_90",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776974156,
-        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
-        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
         "type": "github"
       },
       "original": {
@@ -28496,15 +32495,19 @@
     },
     "nix-bundle-appimage_29": {
       "inputs": {
-        "logos-nix": "logos-nix_525",
-        "nix-bundle-dir": "nix-bundle-dir_90",
+        "logos-nix": "logos-nix_576",
+        "nix-bundle-dir": "nix-bundle-dir_93",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "nix-bundle-logos-module-install",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -28559,45 +32562,16 @@
     },
     "nix-bundle-appimage_30": {
       "inputs": {
-        "logos-nix": "logos-nix_550",
-        "nix-bundle-dir": "nix-bundle-dir_93",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_31": {
-      "inputs": {
-        "logos-nix": "logos-nix_567",
+        "logos-nix": "logos-nix_593",
         "nix-bundle-dir": "nix-bundle-dir_97",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -28620,12 +32594,45 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_32": {
+    "nix-bundle-appimage_31": {
       "inputs": {
-        "logos-nix": "logos-nix_574",
+        "logos-nix": "logos-nix_604",
         "nix-bundle-dir": "nix-bundle-dir_100",
         "nixpkgs": [
           "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_32": {
+      "inputs": {
+        "logos-nix": "logos-nix_611",
+        "nix-bundle-dir": "nix-bundle-dir_102",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "nix-bundle-appimage",
@@ -28649,10 +32656,12 @@
     },
     "nix-bundle-appimage_33": {
       "inputs": {
-        "logos-nix": "logos-nix_580",
-        "nix-bundle-dir": "nix-bundle-dir_102",
+        "logos-nix": "logos-nix_617",
+        "nix-bundle-dir": "nix-bundle-dir_104",
         "nixpkgs": [
           "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "nix-bundle-logos-module-install",
@@ -28678,14 +32687,13 @@
     },
     "nix-bundle-appimage_34": {
       "inputs": {
-        "logos-nix": "logos-nix_612",
-        "nix-bundle-dir": "nix-bundle-dir_105",
+        "logos-nix": "logos-nix_642",
+        "nix-bundle-dir": "nix-bundle-dir_107",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28711,14 +32719,13 @@
     },
     "nix-bundle-appimage_35": {
       "inputs": {
-        "logos-nix": "logos-nix_629",
-        "nix-bundle-dir": "nix-bundle-dir_109",
+        "logos-nix": "logos-nix_659",
+        "nix-bundle-dir": "nix-bundle-dir_111",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -28743,30 +32750,23 @@
     },
     "nix-bundle-appimage_36": {
       "inputs": {
-        "logos-nix": "logos-nix_656",
-        "nix-bundle-dir": "nix-bundle-dir_112",
+        "logos-nix": "logos-nix_666",
+        "nix-bundle-dir": "nix-bundle-dir_114",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "logos-logoscore-cli",
           "nix-bundle-appimage",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "lastModified": 1776974156,
+        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
         "type": "github"
       },
       "original": {
@@ -28777,16 +32777,12 @@
     },
     "nix-bundle-appimage_37": {
       "inputs": {
-        "logos-nix": "logos-nix_673",
+        "logos-nix": "logos-nix_672",
         "nix-bundle-dir": "nix-bundle-dir_116",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "logos-logoscore-cli",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -28810,11 +32806,14 @@
     },
     "nix-bundle-appimage_38": {
       "inputs": {
-        "logos-nix": "logos-nix_684",
+        "logos-nix": "logos-nix_704",
         "nix-bundle-dir": "nix-bundle-dir_119",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28840,11 +32839,14 @@
     },
     "nix-bundle-appimage_39": {
       "inputs": {
-        "logos-nix": "logos-nix_701",
+        "logos-nix": "logos-nix_721",
         "nix-bundle-dir": "nix-bundle-dir_123",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -28900,21 +32902,30 @@
     },
     "nix-bundle-appimage_40": {
       "inputs": {
-        "logos-nix": "logos-nix_708",
+        "logos-nix": "logos-nix_748",
         "nix-bundle-dir": "nix-bundle-dir_126",
         "nixpkgs": [
           "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776974156,
-        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
-        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
         "type": "github"
       },
       "original": {
@@ -28925,10 +32936,16 @@
     },
     "nix-bundle-appimage_41": {
       "inputs": {
-        "logos-nix": "logos-nix_714",
-        "nix-bundle-dir": "nix-bundle-dir_128",
+        "logos-nix": "logos-nix_765",
+        "nix-bundle-dir": "nix-bundle-dir_130",
         "nixpkgs": [
           "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -28952,8 +32969,119 @@
     },
     "nix-bundle-appimage_42": {
       "inputs": {
-        "logos-nix": "logos-nix_722",
-        "nix-bundle-dir": "nix-bundle-dir_131",
+        "logos-nix": "logos-nix_776",
+        "nix-bundle-dir": "nix-bundle-dir_133",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_43": {
+      "inputs": {
+        "logos-nix": "logos-nix_793",
+        "nix-bundle-dir": "nix-bundle-dir_137",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_44": {
+      "inputs": {
+        "logos-nix": "logos-nix_800",
+        "nix-bundle-dir": "nix-bundle-dir_140",
+        "nixpkgs": [
+          "logoscore-cli",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776974156,
+        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_45": {
+      "inputs": {
+        "logos-nix": "logos-nix_806",
+        "nix-bundle-dir": "nix-bundle-dir_142",
+        "nixpkgs": [
+          "logoscore-cli",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_46": {
+      "inputs": {
+        "logos-nix": "logos-nix_814",
+        "nix-bundle-dir": "nix-bundle-dir_145",
         "nixpkgs": [
           "package-manager",
           "nix-bundle-appimage",
@@ -29091,11 +33219,14 @@
     },
     "nix-bundle-appimage_9": {
       "inputs": {
-        "logos-nix": "logos-nix_186",
+        "logos-nix": "logos-nix_203",
         "nix-bundle-dir": "nix-bundle-dir_29",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -29181,21 +33312,25 @@
     },
     "nix-bundle-dir_100": {
       "inputs": {
-        "logos-nix": "logos-nix_575",
+        "logos-nix": "logos-nix_605",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-package-manager",
           "nix-bundle-appimage",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776974030,
-        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -29206,9 +33341,68 @@
     },
     "nix-bundle-dir_101": {
       "inputs": {
-        "logos-nix": "logos-nix_576",
+        "logos-nix": "logos-nix_606",
         "nixpkgs": [
           "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_102": {
+      "inputs": {
+        "logos-nix": "logos-nix_612",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776974030,
+        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_103": {
+      "inputs": {
+        "logos-nix": "logos-nix_613",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "nix-bundle-dir",
@@ -29230,11 +33424,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_102": {
+    "nix-bundle-dir_104": {
       "inputs": {
-        "logos-nix": "logos-nix_581",
+        "logos-nix": "logos-nix_618",
         "nixpkgs": [
           "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "nix-bundle-logos-module-install",
@@ -29249,62 +33445,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_103": {
-      "inputs": {
-        "logos-nix": "logos-nix_582",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_104": {
-      "inputs": {
-        "logos-nix": "logos-nix_585",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -29315,27 +33455,26 @@
     },
     "nix-bundle-dir_105": {
       "inputs": {
-        "logos-nix": "logos-nix_613",
+        "logos-nix": "logos-nix_619",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "nix-bundle-appimage",
+          "nix-bundle-dir",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -29346,17 +33485,15 @@
     },
     "nix-bundle-dir_106": {
       "inputs": {
-        "logos-nix": "logos-nix_614",
+        "logos-nix": "logos-nix_622",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -29378,27 +33515,26 @@
     },
     "nix-bundle-dir_107": {
       "inputs": {
-        "logos-nix": "logos-nix_621",
+        "logos-nix": "logos-nix_643",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -29409,15 +33545,16 @@
     },
     "nix-bundle-dir_108": {
       "inputs": {
-        "logos-nix": "logos-nix_625",
+        "logos-nix": "logos-nix_644",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
+          "logos-liblogos",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -29439,26 +33576,26 @@
     },
     "nix-bundle-dir_109": {
       "inputs": {
-        "logos-nix": "logos-nix_630",
+        "logos-nix": "logos-nix_651",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -29498,16 +33635,14 @@
     },
     "nix-bundle-dir_110": {
       "inputs": {
-        "logos-nix": "logos-nix_631",
+        "logos-nix": "logos-nix_655",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -29529,13 +33664,71 @@
     },
     "nix-bundle-dir_111": {
       "inputs": {
-        "logos-nix": "logos-nix_634",
+        "logos-nix": "logos-nix_660",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_112": {
+      "inputs": {
+        "logos-nix": "logos-nix_661",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_113": {
+      "inputs": {
+        "logos-nix": "logos-nix_664",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -29558,95 +33751,23 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_112": {
+    "nix-bundle-dir_114": {
       "inputs": {
-        "logos-nix": "logos-nix_657",
+        "logos-nix": "logos-nix_667",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "logos-logoscore-cli",
           "nix-bundle-appimage",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "lastModified": 1776974030,
+        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_113": {
-      "inputs": {
-        "logos-nix": "logos-nix_658",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_114": {
-      "inputs": {
-        "logos-nix": "logos-nix_665",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
         "type": "github"
       },
       "original": {
@@ -29657,27 +33778,22 @@
     },
     "nix-bundle-dir_115": {
       "inputs": {
-        "logos-nix": "logos-nix_669",
+        "logos-nix": "logos-nix_668",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
+          "logos-logoscore-cli",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "lastModified": 1776974030,
+        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
         "type": "github"
       },
       "original": {
@@ -29688,15 +33804,11 @@
     },
     "nix-bundle-dir_116": {
       "inputs": {
-        "logos-nix": "logos-nix_674",
+        "logos-nix": "logos-nix_673",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "logos-logoscore-cli",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -29719,15 +33831,11 @@
     },
     "nix-bundle-dir_117": {
       "inputs": {
-        "logos-nix": "logos-nix_675",
+        "logos-nix": "logos-nix_674",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "logos-logoscore-cli",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-dir",
@@ -29751,15 +33859,11 @@
     },
     "nix-bundle-dir_118": {
       "inputs": {
-        "logos-nix": "logos-nix_678",
+        "logos-nix": "logos-nix_677",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "logos-logoscore-cli",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "nix-bundle-dir",
@@ -29783,10 +33887,13 @@
     },
     "nix-bundle-dir_119": {
       "inputs": {
-        "logos-nix": "logos-nix_685",
+        "logos-nix": "logos-nix_705",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -29840,10 +33947,13 @@
     },
     "nix-bundle-dir_120": {
       "inputs": {
-        "logos-nix": "logos-nix_686",
+        "logos-nix": "logos-nix_706",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -29869,10 +33979,13 @@
     },
     "nix-bundle-dir_121": {
       "inputs": {
-        "logos-nix": "logos-nix_693",
+        "logos-nix": "logos-nix_713",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "nix-bundle-lgx",
@@ -29897,10 +34010,13 @@
     },
     "nix-bundle-dir_122": {
       "inputs": {
-        "logos-nix": "logos-nix_697",
+        "logos-nix": "logos-nix_717",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "nix-bundle-dir",
@@ -29924,10 +34040,13 @@
     },
     "nix-bundle-dir_123": {
       "inputs": {
-        "logos-nix": "logos-nix_702",
+        "logos-nix": "logos-nix_722",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -29951,10 +34070,13 @@
     },
     "nix-bundle-dir_124": {
       "inputs": {
-        "logos-nix": "logos-nix_703",
+        "logos-nix": "logos-nix_723",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -29979,10 +34101,13 @@
     },
     "nix-bundle-dir_125": {
       "inputs": {
-        "logos-nix": "logos-nix_706",
+        "logos-nix": "logos-nix_726",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -30007,57 +34132,17 @@
     },
     "nix-bundle-dir_126": {
       "inputs": {
-        "logos-nix": "logos-nix_709",
+        "logos-nix": "logos-nix_749",
         "nixpkgs": [
           "logoscore-cli",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776974030,
-        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_127": {
-      "inputs": {
-        "logos-nix": "logos-nix_710",
-        "nixpkgs": [
-          "logoscore-cli",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776974030,
-        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_128": {
-      "inputs": {
-        "logos-nix": "logos-nix_715",
-        "nixpkgs": [
-          "logoscore-cli",
-          "nix-bundle-logos-module-install",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "nixpkgs"
@@ -30077,13 +34162,83 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_129": {
+    "nix-bundle-dir_127": {
       "inputs": {
-        "logos-nix": "logos-nix_716",
+        "logos-nix": "logos-nix_750",
         "nixpkgs": [
           "logoscore-cli",
-          "nix-bundle-logos-module-install",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_128": {
+      "inputs": {
+        "logos-nix": "logos-nix_757",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_129": {
+      "inputs": {
+        "logos-nix": "logos-nix_761",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -30135,9 +34290,78 @@
     },
     "nix-bundle-dir_130": {
       "inputs": {
-        "logos-nix": "logos-nix_719",
+        "logos-nix": "logos-nix_766",
         "nixpkgs": [
           "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_131": {
+      "inputs": {
+        "logos-nix": "logos-nix_767",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_132": {
+      "inputs": {
+        "logos-nix": "logos-nix_770",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "nix-bundle-dir",
@@ -30159,11 +34383,16 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_131": {
+    "nix-bundle-dir_133": {
       "inputs": {
-        "logos-nix": "logos-nix_723",
+        "logos-nix": "logos-nix_777",
         "nixpkgs": [
-          "package-manager",
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
           "nix-bundle-appimage",
           "nixpkgs"
         ]
@@ -30182,11 +34411,154 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_132": {
+    "nix-bundle-dir_134": {
       "inputs": {
-        "logos-nix": "logos-nix_724",
+        "logos-nix": "logos-nix_778",
         "nixpkgs": [
-          "package-manager",
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_135": {
+      "inputs": {
+        "logos-nix": "logos-nix_785",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_136": {
+      "inputs": {
+        "logos-nix": "logos-nix_789",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_137": {
+      "inputs": {
+        "logos-nix": "logos-nix_794",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_138": {
+      "inputs": {
+        "logos-nix": "logos-nix_795",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_139": {
+      "inputs": {
+        "logos-nix": "logos-nix_798",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -30217,6 +34589,177 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_140": {
+      "inputs": {
+        "logos-nix": "logos-nix_801",
+        "nixpkgs": [
+          "logoscore-cli",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776974030,
+        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_141": {
+      "inputs": {
+        "logos-nix": "logos-nix_802",
+        "nixpkgs": [
+          "logoscore-cli",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776974030,
+        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_142": {
+      "inputs": {
+        "logos-nix": "logos-nix_807",
+        "nixpkgs": [
+          "logoscore-cli",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_143": {
+      "inputs": {
+        "logos-nix": "logos-nix_808",
+        "nixpkgs": [
+          "logoscore-cli",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_144": {
+      "inputs": {
+        "logos-nix": "logos-nix_811",
+        "nixpkgs": [
+          "logoscore-cli",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_145": {
+      "inputs": {
+        "logos-nix": "logos-nix_815",
+        "nixpkgs": [
+          "package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_146": {
+      "inputs": {
+        "logos-nix": "logos-nix_816",
+        "nixpkgs": [
+          "package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -30327,11 +34870,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "lastModified": 1776974030,
+        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
         "type": "github"
       },
       "original": {
@@ -30644,10 +35187,13 @@
     },
     "nix-bundle-dir_29": {
       "inputs": {
-        "logos-nix": "logos-nix_187",
+        "logos-nix": "logos-nix_204",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -30702,10 +35248,13 @@
     },
     "nix-bundle-dir_30": {
       "inputs": {
-        "logos-nix": "logos-nix_188",
+        "logos-nix": "logos-nix_205",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -30732,10 +35281,13 @@
     },
     "nix-bundle-dir_31": {
       "inputs": {
-        "logos-nix": "logos-nix_195",
+        "logos-nix": "logos-nix_212",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -30761,10 +35313,13 @@
     },
     "nix-bundle-dir_32": {
       "inputs": {
-        "logos-nix": "logos-nix_199",
+        "logos-nix": "logos-nix_216",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-lgx",
@@ -30789,10 +35344,13 @@
     },
     "nix-bundle-dir_33": {
       "inputs": {
-        "logos-nix": "logos-nix_204",
+        "logos-nix": "logos-nix_221",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -30817,10 +35375,13 @@
     },
     "nix-bundle-dir_34": {
       "inputs": {
-        "logos-nix": "logos-nix_205",
+        "logos-nix": "logos-nix_222",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -30846,10 +35407,13 @@
     },
     "nix-bundle-dir_35": {
       "inputs": {
-        "logos-nix": "logos-nix_208",
+        "logos-nix": "logos-nix_225",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -30875,9 +35439,17 @@
     },
     "nix-bundle-dir_36": {
       "inputs": {
-        "logos-nix": "logos-nix_215",
+        "logos-nix": "logos-nix_248",
         "nixpkgs": [
           "logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -30900,9 +35472,17 @@
     },
     "nix-bundle-dir_37": {
       "inputs": {
-        "logos-nix": "logos-nix_216",
+        "logos-nix": "logos-nix_249",
         "nixpkgs": [
           "logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-dir",
@@ -30926,26 +35506,29 @@
     },
     "nix-bundle-dir_38": {
       "inputs": {
-        "logos-nix": "logos-nix_243",
+        "logos-nix": "logos-nix_256",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -30956,16 +35539,17 @@
     },
     "nix-bundle-dir_39": {
       "inputs": {
-        "logos-nix": "logos-nix_244",
+        "logos-nix": "logos-nix_260",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-package-manager",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -31015,26 +35599,28 @@
     },
     "nix-bundle-dir_40": {
       "inputs": {
-        "logos-nix": "logos-nix_251",
+        "logos-nix": "logos-nix_265",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -31045,14 +35631,18 @@
     },
     "nix-bundle-dir_41": {
       "inputs": {
-        "logos-nix": "logos-nix_255",
+        "logos-nix": "logos-nix_266",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -31074,69 +35664,13 @@
     },
     "nix-bundle-dir_42": {
       "inputs": {
-        "logos-nix": "logos-nix_260",
+        "logos-nix": "logos-nix_269",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_43": {
-      "inputs": {
-        "logos-nix": "logos-nix_261",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_44": {
-      "inputs": {
-        "logos-nix": "logos-nix_264",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -31161,12 +35695,15 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_45": {
+    "nix-bundle-dir_43": {
       "inputs": {
-        "logos-nix": "logos-nix_271",
+        "logos-nix": "logos-nix_276",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -31187,12 +35724,15 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_46": {
+    "nix-bundle-dir_44": {
       "inputs": {
-        "logos-nix": "logos-nix_272",
+        "logos-nix": "logos-nix_277",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-dir",
@@ -31214,17 +35754,72 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_47": {
+    "nix-bundle-dir_45": {
       "inputs": {
-        "logos-nix": "logos-nix_294",
+        "logos-nix": "logos-nix_284",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_46": {
+      "inputs": {
+        "logos-nix": "logos-nix_288",
+        "nixpkgs": [
+          "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_47": {
+      "inputs": {
+        "logos-nix": "logos-nix_293",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "nixpkgs"
@@ -31246,15 +35841,13 @@
     },
     "nix-bundle-dir_48": {
       "inputs": {
-        "logos-nix": "logos-nix_295",
+        "logos-nix": "logos-nix_294",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
@@ -31277,14 +35870,13 @@
     },
     "nix-bundle-dir_49": {
       "inputs": {
-        "logos-nix": "logos-nix_302",
+        "logos-nix": "logos-nix_297",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
@@ -31335,43 +35927,10 @@
     },
     "nix-bundle-dir_50": {
       "inputs": {
-        "logos-nix": "logos-nix_306",
+        "logos-nix": "logos-nix_307",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_51": {
-      "inputs": {
-        "logos-nix": "logos-nix_311",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "nixpkgs"
@@ -31391,16 +35950,12 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_52": {
+    "nix-bundle-dir_51": {
       "inputs": {
-        "logos-nix": "logos-nix_312",
+        "logos-nix": "logos-nix_308",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
@@ -31421,17 +35976,48 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_53": {
+    "nix-bundle-dir_52": {
       "inputs": {
-        "logos-nix": "logos-nix_315",
+        "logos-nix": "logos-nix_335",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_53": {
+      "inputs": {
+        "logos-nix": "logos-nix_336",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -31453,27 +36039,26 @@
     },
     "nix-bundle-dir_54": {
       "inputs": {
-        "logos-nix": "logos-nix_337",
+        "logos-nix": "logos-nix_343",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -31484,17 +36069,14 @@
     },
     "nix-bundle-dir_55": {
       "inputs": {
-        "logos-nix": "logos-nix_338",
+        "logos-nix": "logos-nix_347",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -31516,72 +36098,10 @@
     },
     "nix-bundle-dir_56": {
       "inputs": {
-        "logos-nix": "logos-nix_345",
+        "logos-nix": "logos-nix_352",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_57": {
-      "inputs": {
-        "logos-nix": "logos-nix_349",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_58": {
-      "inputs": {
-        "logos-nix": "logos-nix_354",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -31605,13 +36125,12 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_59": {
+    "nix-bundle-dir_57": {
       "inputs": {
-        "logos-nix": "logos-nix_355",
+        "logos-nix": "logos-nix_353",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -31628,6 +36147,62 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_58": {
+      "inputs": {
+        "logos-nix": "logos-nix_356",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_59": {
+      "inputs": {
+        "logos-nix": "logos-nix_363",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -31667,16 +36242,12 @@
     },
     "nix-bundle-dir_60": {
       "inputs": {
-        "logos-nix": "logos-nix_358",
+        "logos-nix": "logos-nix_364",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -31698,11 +36269,14 @@
     },
     "nix-bundle-dir_61": {
       "inputs": {
-        "logos-nix": "logos-nix_365",
+        "logos-nix": "logos-nix_386",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -31725,11 +36299,14 @@
     },
     "nix-bundle-dir_62": {
       "inputs": {
-        "logos-nix": "logos-nix_366",
+        "logos-nix": "logos-nix_387",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-dir",
@@ -31753,28 +36330,26 @@
     },
     "nix-bundle-dir_63": {
       "inputs": {
-        "logos-nix": "logos-nix_391",
+        "logos-nix": "logos-nix_394",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -31785,18 +36360,14 @@
     },
     "nix-bundle-dir_64": {
       "inputs": {
-        "logos-nix": "logos-nix_392",
+        "logos-nix": "logos-nix_398",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -31818,76 +36389,11 @@
     },
     "nix-bundle-dir_65": {
       "inputs": {
-        "logos-nix": "logos-nix_399",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_66": {
-      "inputs": {
         "logos-nix": "logos-nix_403",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_67": {
-      "inputs": {
-        "logos-nix": "logos-nix_408",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -31910,15 +36416,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_68": {
+    "nix-bundle-dir_66": {
       "inputs": {
-        "logos-nix": "logos-nix_409",
+        "logos-nix": "logos-nix_404",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -31942,19 +36446,80 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_69": {
+    "nix-bundle-dir_67": {
       "inputs": {
-        "logos-nix": "logos-nix_412",
+        "logos-nix": "logos-nix_407",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_68": {
+      "inputs": {
+        "logos-nix": "logos-nix_429",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_69": {
+      "inputs": {
+        "logos-nix": "logos-nix_430",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -32005,24 +36570,27 @@
     },
     "nix-bundle-dir_70": {
       "inputs": {
-        "logos-nix": "logos-nix_419",
+        "logos-nix": "logos-nix_437",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -32033,14 +36601,15 @@
     },
     "nix-bundle-dir_71": {
       "inputs": {
-        "logos-nix": "logos-nix_420",
+        "logos-nix": "logos-nix_441",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
-          "logos-package-manager",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -32062,17 +36631,15 @@
     },
     "nix-bundle-dir_72": {
       "inputs": {
-        "logos-nix": "logos-nix_442",
+        "logos-nix": "logos-nix_446",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "nixpkgs"
@@ -32094,17 +36661,15 @@
     },
     "nix-bundle-dir_73": {
       "inputs": {
-        "logos-nix": "logos-nix_443",
+        "logos-nix": "logos-nix_447",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
@@ -32132,11 +36697,10 @@
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
@@ -32159,47 +36723,12 @@
     },
     "nix-bundle-dir_75": {
       "inputs": {
-        "logos-nix": "logos-nix_454",
+        "logos-nix": "logos-nix_457",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_76": {
-      "inputs": {
-        "logos-nix": "logos-nix_459",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "nixpkgs"
@@ -32219,18 +36748,14 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_77": {
+    "nix-bundle-dir_76": {
       "inputs": {
-        "logos-nix": "logos-nix_460",
+        "logos-nix": "logos-nix_458",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
@@ -32251,19 +36776,52 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_78": {
+    "nix-bundle-dir_77": {
       "inputs": {
-        "logos-nix": "logos-nix_463",
+        "logos-nix": "logos-nix_483",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_78": {
+      "inputs": {
+        "logos-nix": "logos-nix_484",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -32285,29 +36843,28 @@
     },
     "nix-bundle-dir_79": {
       "inputs": {
-        "logos-nix": "logos-nix_485",
+        "logos-nix": "logos-nix_491",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -32348,19 +36905,16 @@
     },
     "nix-bundle-dir_80": {
       "inputs": {
-        "logos-nix": "logos-nix_486",
+        "logos-nix": "logos-nix_495",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -32382,78 +36936,12 @@
     },
     "nix-bundle-dir_81": {
       "inputs": {
-        "logos-nix": "logos-nix_493",
+        "logos-nix": "logos-nix_500",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_82": {
-      "inputs": {
-        "logos-nix": "logos-nix_497",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_83": {
-      "inputs": {
-        "logos-nix": "logos-nix_502",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -32477,15 +36965,14 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_84": {
+    "nix-bundle-dir_82": {
       "inputs": {
-        "logos-nix": "logos-nix_503",
+        "logos-nix": "logos-nix_501",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -32510,15 +36997,14 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_85": {
+    "nix-bundle-dir_83": {
       "inputs": {
-        "logos-nix": "logos-nix_506",
+        "logos-nix": "logos-nix_504",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -32543,15 +37029,75 @@
         "type": "github"
       }
     },
+    "nix-bundle-dir_84": {
+      "inputs": {
+        "logos-nix": "logos-nix_511",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_85": {
+      "inputs": {
+        "logos-nix": "logos-nix_512",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
     "nix-bundle-dir_86": {
       "inputs": {
-        "logos-nix": "logos-nix_513",
+        "logos-nix": "logos-nix_534",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -32574,13 +37120,16 @@
     },
     "nix-bundle-dir_87": {
       "inputs": {
-        "logos-nix": "logos-nix_514",
+        "logos-nix": "logos-nix_535",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-dir",
@@ -32604,23 +37153,28 @@
     },
     "nix-bundle-dir_88": {
       "inputs": {
-        "logos-nix": "logos-nix_520",
+        "logos-nix": "logos-nix_542",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "nix-bundle-appimage",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776974030,
-        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -32631,24 +37185,27 @@
     },
     "nix-bundle-dir_89": {
       "inputs": {
-        "logos-nix": "logos-nix_521",
+        "logos-nix": "logos-nix_546",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776974030,
-        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -32690,13 +37247,15 @@
     },
     "nix-bundle-dir_90": {
       "inputs": {
-        "logos-nix": "logos-nix_526",
+        "logos-nix": "logos-nix_551",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -32719,13 +37278,15 @@
     },
     "nix-bundle-dir_91": {
       "inputs": {
-        "logos-nix": "logos-nix_527",
+        "logos-nix": "logos-nix_552",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-dir",
@@ -32749,13 +37310,15 @@
     },
     "nix-bundle-dir_92": {
       "inputs": {
-        "logos-nix": "logos-nix_530",
+        "logos-nix": "logos-nix_555",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "nix-bundle-dir",
@@ -32779,12 +37342,15 @@
     },
     "nix-bundle-dir_93": {
       "inputs": {
-        "logos-nix": "logos-nix_551",
+        "logos-nix": "logos-nix_577",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32809,12 +37375,15 @@
     },
     "nix-bundle-dir_94": {
       "inputs": {
-        "logos-nix": "logos-nix_552",
+        "logos-nix": "logos-nix_578",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32840,12 +37409,15 @@
     },
     "nix-bundle-dir_95": {
       "inputs": {
-        "logos-nix": "logos-nix_559",
+        "logos-nix": "logos-nix_585",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "nix-bundle-lgx",
@@ -32870,12 +37442,15 @@
     },
     "nix-bundle-dir_96": {
       "inputs": {
-        "logos-nix": "logos-nix_563",
+        "logos-nix": "logos-nix_589",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "nix-bundle-dir",
@@ -32899,12 +37474,15 @@
     },
     "nix-bundle-dir_97": {
       "inputs": {
-        "logos-nix": "logos-nix_568",
+        "logos-nix": "logos-nix_594",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -32928,12 +37506,15 @@
     },
     "nix-bundle-dir_98": {
       "inputs": {
-        "logos-nix": "logos-nix_569",
+        "logos-nix": "logos-nix_595",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -32958,12 +37539,15 @@
     },
     "nix-bundle-dir_99": {
       "inputs": {
-        "logos-nix": "logos-nix_572",
+        "logos-nix": "logos-nix_598",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -33102,12 +37686,15 @@
     },
     "nix-bundle-lgx_13": {
       "inputs": {
-        "logos-nix": "logos-nix_193",
+        "logos-nix": "logos-nix_210",
         "logos-package": "logos-package_22",
         "nix-bundle-dir": "nix-bundle-dir_31",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -33131,12 +37718,15 @@
     },
     "nix-bundle-lgx_14": {
       "inputs": {
-        "logos-nix": "logos-nix_197",
+        "logos-nix": "logos-nix_214",
         "logos-package": "logos-package_23",
         "nix-bundle-dir": "nix-bundle-dir_32",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-lgx",
@@ -33160,12 +37750,15 @@
     },
     "nix-bundle-lgx_15": {
       "inputs": {
-        "logos-nix": "logos-nix_206",
+        "logos-nix": "logos-nix_223",
         "logos-package": "logos-package_25",
         "nix-bundle-dir": "nix-bundle-dir_35",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -33190,12 +37783,15 @@
     },
     "nix-bundle-lgx_16": {
       "inputs": {
-        "logos-nix": "logos-nix_249",
-        "logos-package": "logos-package_28",
-        "nix-bundle-dir": "nix-bundle-dir_40",
+        "logos-nix": "logos-nix_254",
+        "logos-package": "logos-package_27",
+        "nix-bundle-dir": "nix-bundle-dir_38",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -33220,12 +37816,15 @@
     },
     "nix-bundle-lgx_17": {
       "inputs": {
-        "logos-nix": "logos-nix_253",
-        "logos-package": "logos-package_29",
-        "nix-bundle-dir": "nix-bundle-dir_41",
+        "logos-nix": "logos-nix_258",
+        "logos-package": "logos-package_28",
+        "nix-bundle-dir": "nix-bundle-dir_39",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -33250,12 +37849,15 @@
     },
     "nix-bundle-lgx_18": {
       "inputs": {
-        "logos-nix": "logos-nix_262",
-        "logos-package": "logos-package_31",
-        "nix-bundle-dir": "nix-bundle-dir_44",
+        "logos-nix": "logos-nix_267",
+        "logos-package": "logos-package_30",
+        "nix-bundle-dir": "nix-bundle-dir_42",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -33281,16 +37883,16 @@
     },
     "nix-bundle-lgx_19": {
       "inputs": {
-        "logos-nix": "logos-nix_300",
-        "logos-package": "logos-package_34",
-        "nix-bundle-dir": "nix-bundle-dir_49",
+        "logos-nix": "logos-nix_282",
+        "logos-package": "logos-package_32",
+        "nix-bundle-dir": "nix-bundle-dir_45",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "nix-bundle-lgx",
           "logos-nix",
           "nixpkgs"
         ]
@@ -33340,13 +37942,12 @@
     },
     "nix-bundle-lgx_20": {
       "inputs": {
-        "logos-nix": "logos-nix_304",
-        "logos-package": "logos-package_35",
-        "nix-bundle-dir": "nix-bundle-dir_50",
+        "logos-nix": "logos-nix_286",
+        "logos-package": "logos-package_33",
+        "nix-bundle-dir": "nix-bundle-dir_46",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-lgx",
@@ -33370,13 +37971,12 @@
     },
     "nix-bundle-lgx_21": {
       "inputs": {
-        "logos-nix": "logos-nix_313",
-        "logos-package": "logos-package_37",
-        "nix-bundle-dir": "nix-bundle-dir_53",
+        "logos-nix": "logos-nix_295",
+        "logos-package": "logos-package_35",
+        "nix-bundle-dir": "nix-bundle-dir_49",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -33401,13 +38001,12 @@
     },
     "nix-bundle-lgx_22": {
       "inputs": {
-        "logos-nix": "logos-nix_343",
-        "logos-package": "logos-package_39",
-        "nix-bundle-dir": "nix-bundle-dir_56",
+        "logos-nix": "logos-nix_341",
+        "logos-package": "logos-package_38",
+        "nix-bundle-dir": "nix-bundle-dir_54",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -33432,13 +38031,12 @@
     },
     "nix-bundle-lgx_23": {
       "inputs": {
-        "logos-nix": "logos-nix_347",
-        "logos-package": "logos-package_40",
-        "nix-bundle-dir": "nix-bundle-dir_57",
+        "logos-nix": "logos-nix_345",
+        "logos-package": "logos-package_39",
+        "nix-bundle-dir": "nix-bundle-dir_55",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -33463,13 +38061,12 @@
     },
     "nix-bundle-lgx_24": {
       "inputs": {
-        "logos-nix": "logos-nix_356",
-        "logos-package": "logos-package_42",
-        "nix-bundle-dir": "nix-bundle-dir_60",
+        "logos-nix": "logos-nix_354",
+        "logos-package": "logos-package_41",
+        "nix-bundle-dir": "nix-bundle-dir_58",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -33495,15 +38092,13 @@
     },
     "nix-bundle-lgx_25": {
       "inputs": {
-        "logos-nix": "logos-nix_397",
-        "logos-package": "logos-package_45",
-        "nix-bundle-dir": "nix-bundle-dir_65",
+        "logos-nix": "logos-nix_392",
+        "logos-package": "logos-package_44",
+        "nix-bundle-dir": "nix-bundle-dir_63",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -33527,15 +38122,13 @@
     },
     "nix-bundle-lgx_26": {
       "inputs": {
-        "logos-nix": "logos-nix_401",
-        "logos-package": "logos-package_46",
-        "nix-bundle-dir": "nix-bundle-dir_66",
+        "logos-nix": "logos-nix_396",
+        "logos-package": "logos-package_45",
+        "nix-bundle-dir": "nix-bundle-dir_64",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-lgx",
@@ -33559,15 +38152,13 @@
     },
     "nix-bundle-lgx_27": {
       "inputs": {
-        "logos-nix": "logos-nix_410",
-        "logos-package": "logos-package_48",
-        "nix-bundle-dir": "nix-bundle-dir_69",
+        "logos-nix": "logos-nix_405",
+        "logos-package": "logos-package_47",
+        "nix-bundle-dir": "nix-bundle-dir_67",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -33592,15 +38183,14 @@
     },
     "nix-bundle-lgx_28": {
       "inputs": {
-        "logos-nix": "logos-nix_448",
-        "logos-package": "logos-package_51",
-        "nix-bundle-dir": "nix-bundle-dir_74",
+        "logos-nix": "logos-nix_435",
+        "logos-package": "logos-package_49",
+        "nix-bundle-dir": "nix-bundle-dir_70",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -33624,15 +38214,14 @@
     },
     "nix-bundle-lgx_29": {
       "inputs": {
-        "logos-nix": "logos-nix_452",
-        "logos-package": "logos-package_52",
-        "nix-bundle-dir": "nix-bundle-dir_75",
+        "logos-nix": "logos-nix_439",
+        "logos-package": "logos-package_50",
+        "nix-bundle-dir": "nix-bundle-dir_71",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-lgx",
@@ -33686,15 +38275,14 @@
     },
     "nix-bundle-lgx_30": {
       "inputs": {
-        "logos-nix": "logos-nix_461",
-        "logos-package": "logos-package_54",
-        "nix-bundle-dir": "nix-bundle-dir_78",
+        "logos-nix": "logos-nix_448",
+        "logos-package": "logos-package_52",
+        "nix-bundle-dir": "nix-bundle-dir_74",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -33719,15 +38307,14 @@
     },
     "nix-bundle-lgx_31": {
       "inputs": {
-        "logos-nix": "logos-nix_491",
-        "logos-package": "logos-package_56",
-        "nix-bundle-dir": "nix-bundle-dir_81",
+        "logos-nix": "logos-nix_489",
+        "logos-package": "logos-package_55",
+        "nix-bundle-dir": "nix-bundle-dir_79",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -33752,15 +38339,14 @@
     },
     "nix-bundle-lgx_32": {
       "inputs": {
-        "logos-nix": "logos-nix_495",
-        "logos-package": "logos-package_57",
-        "nix-bundle-dir": "nix-bundle-dir_82",
+        "logos-nix": "logos-nix_493",
+        "logos-package": "logos-package_56",
+        "nix-bundle-dir": "nix-bundle-dir_80",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -33785,15 +38371,14 @@
     },
     "nix-bundle-lgx_33": {
       "inputs": {
-        "logos-nix": "logos-nix_504",
-        "logos-package": "logos-package_59",
-        "nix-bundle-dir": "nix-bundle-dir_85",
+        "logos-nix": "logos-nix_502",
+        "logos-package": "logos-package_58",
+        "nix-bundle-dir": "nix-bundle-dir_83",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -33819,27 +38404,28 @@
     },
     "nix-bundle-lgx_34": {
       "inputs": {
-        "logos-nix": "logos-nix_528",
-        "logos-package": "logos-package_62",
-        "nix-bundle-dir": "nix-bundle-dir_92",
+        "logos-nix": "logos-nix_540",
+        "logos-package": "logos-package_61",
+        "nix-bundle-dir": "nix-bundle-dir_88",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775836380,
-        "narHash": "sha256-XbBPcMuDFA/SxYVw9TIRQbhie5Vj5MqwdU+Gh1iR1LA=",
+        "lastModified": 1777575520,
+        "narHash": "sha256-HOwg1N4NfGYq579IppVPpVjPDZfYQGndXGlcl1VRXXo=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "9d8f8602b1574ec9ac4c9b31ae0c92570221c268",
+        "rev": "3c44d99b9d8dbd8a135b44b5b328e6175650305e",
         "type": "github"
       },
       "original": {
@@ -33850,16 +38436,18 @@
     },
     "nix-bundle-lgx_35": {
       "inputs": {
-        "logos-nix": "logos-nix_557",
-        "logos-package": "logos-package_64",
-        "nix-bundle-dir": "nix-bundle-dir_95",
+        "logos-nix": "logos-nix_544",
+        "logos-package": "logos-package_62",
+        "nix-bundle-dir": "nix-bundle-dir_89",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "nix-bundle-lgx",
           "logos-nix",
           "nixpkgs"
         ]
@@ -33880,26 +38468,29 @@
     },
     "nix-bundle-lgx_36": {
       "inputs": {
-        "logos-nix": "logos-nix_561",
-        "logos-package": "logos-package_65",
-        "nix-bundle-dir": "nix-bundle-dir_96",
+        "logos-nix": "logos-nix_553",
+        "logos-package": "logos-package_64",
+        "nix-bundle-dir": "nix-bundle-dir_92",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
           "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1777575520,
-        "narHash": "sha256-HOwg1N4NfGYq579IppVPpVjPDZfYQGndXGlcl1VRXXo=",
+        "lastModified": 1775836380,
+        "narHash": "sha256-XbBPcMuDFA/SxYVw9TIRQbhie5Vj5MqwdU+Gh1iR1LA=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "3c44d99b9d8dbd8a135b44b5b328e6175650305e",
+        "rev": "9d8f8602b1574ec9ac4c9b31ae0c92570221c268",
         "type": "github"
       },
       "original": {
@@ -33910,74 +38501,16 @@
     },
     "nix-bundle-lgx_37": {
       "inputs": {
-        "logos-nix": "logos-nix_570",
-        "logos-package": "logos-package_67",
-        "nix-bundle-dir": "nix-bundle-dir_99",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775836380,
-        "narHash": "sha256-XbBPcMuDFA/SxYVw9TIRQbhie5Vj5MqwdU+Gh1iR1LA=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "rev": "9d8f8602b1574ec9ac4c9b31ae0c92570221c268",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "type": "github"
-      }
-    },
-    "nix-bundle-lgx_38": {
-      "inputs": {
         "logos-nix": "logos-nix_583",
-        "logos-package": "logos-package_69",
-        "nix-bundle-dir": "nix-bundle-dir_104",
+        "logos-package": "logos-package_66",
+        "nix-bundle-dir": "nix-bundle-dir_95",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775836380,
-        "narHash": "sha256-XbBPcMuDFA/SxYVw9TIRQbhie5Vj5MqwdU+Gh1iR1LA=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "rev": "9d8f8602b1574ec9ac4c9b31ae0c92570221c268",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "type": "github"
-      }
-    },
-    "nix-bundle-lgx_39": {
-      "inputs": {
-        "logos-nix": "logos-nix_619",
-        "logos-package": "logos-package_71",
-        "nix-bundle-dir": "nix-bundle-dir_107",
-        "nixpkgs": [
-          "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
+          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -33991,6 +38524,73 @@
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
         "rev": "3c44d99b9d8dbd8a135b44b5b328e6175650305e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_38": {
+      "inputs": {
+        "logos-nix": "logos-nix_587",
+        "logos-package": "logos-package_67",
+        "nix-bundle-dir": "nix-bundle-dir_96",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575520,
+        "narHash": "sha256-HOwg1N4NfGYq579IppVPpVjPDZfYQGndXGlcl1VRXXo=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "3c44d99b9d8dbd8a135b44b5b328e6175650305e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_39": {
+      "inputs": {
+        "logos-nix": "logos-nix_596",
+        "logos-package": "logos-package_69",
+        "nix-bundle-dir": "nix-bundle-dir_99",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775836380,
+        "narHash": "sha256-XbBPcMuDFA/SxYVw9TIRQbhie5Vj5MqwdU+Gh1iR1LA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "9d8f8602b1574ec9ac4c9b31ae0c92570221c268",
         "type": "github"
       },
       "original": {
@@ -34031,15 +38631,75 @@
     },
     "nix-bundle-lgx_40": {
       "inputs": {
-        "logos-nix": "logos-nix_623",
+        "logos-nix": "logos-nix_620",
         "logos-package": "logos-package_72",
-        "nix-bundle-dir": "nix-bundle-dir_108",
+        "nix-bundle-dir": "nix-bundle-dir_106",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775836380,
+        "narHash": "sha256-XbBPcMuDFA/SxYVw9TIRQbhie5Vj5MqwdU+Gh1iR1LA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "9d8f8602b1574ec9ac4c9b31ae0c92570221c268",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_41": {
+      "inputs": {
+        "logos-nix": "logos-nix_649",
+        "logos-package": "logos-package_74",
+        "nix-bundle-dir": "nix-bundle-dir_109",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-capability-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575520,
+        "narHash": "sha256-HOwg1N4NfGYq579IppVPpVjPDZfYQGndXGlcl1VRXXo=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "3c44d99b9d8dbd8a135b44b5b328e6175650305e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_42": {
+      "inputs": {
+        "logos-nix": "logos-nix_653",
+        "logos-package": "logos-package_75",
+        "nix-bundle-dir": "nix-bundle-dir_110",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "nix-bundle-lgx",
           "logos-nix",
@@ -34060,17 +38720,16 @@
         "type": "github"
       }
     },
-    "nix-bundle-lgx_41": {
+    "nix-bundle-lgx_43": {
       "inputs": {
-        "logos-nix": "logos-nix_632",
-        "logos-package": "logos-package_74",
-        "nix-bundle-dir": "nix-bundle-dir_111",
+        "logos-nix": "logos-nix_662",
+        "logos-package": "logos-package_77",
+        "nix-bundle-dir": "nix-bundle-dir_113",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -34092,83 +38751,15 @@
         "type": "github"
       }
     },
-    "nix-bundle-lgx_42": {
-      "inputs": {
-        "logos-nix": "logos-nix_663",
-        "logos-package": "logos-package_76",
-        "nix-bundle-dir": "nix-bundle-dir_114",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575520,
-        "narHash": "sha256-HOwg1N4NfGYq579IppVPpVjPDZfYQGndXGlcl1VRXXo=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "rev": "3c44d99b9d8dbd8a135b44b5b328e6175650305e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "type": "github"
-      }
-    },
-    "nix-bundle-lgx_43": {
-      "inputs": {
-        "logos-nix": "logos-nix_667",
-        "logos-package": "logos-package_77",
-        "nix-bundle-dir": "nix-bundle-dir_115",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575520,
-        "narHash": "sha256-HOwg1N4NfGYq579IppVPpVjPDZfYQGndXGlcl1VRXXo=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "rev": "3c44d99b9d8dbd8a135b44b5b328e6175650305e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "type": "github"
-      }
-    },
     "nix-bundle-lgx_44": {
       "inputs": {
-        "logos-nix": "logos-nix_676",
+        "logos-nix": "logos-nix_675",
         "logos-package": "logos-package_79",
         "nix-bundle-dir": "nix-bundle-dir_118",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "logos-logoscore-cli",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "logos-nix",
@@ -34191,7 +38782,7 @@
     },
     "nix-bundle-lgx_45": {
       "inputs": {
-        "logos-nix": "logos-nix_691",
+        "logos-nix": "logos-nix_711",
         "logos-package": "logos-package_81",
         "nix-bundle-dir": "nix-bundle-dir_121",
         "nixpkgs": [
@@ -34199,7 +38790,9 @@
           "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
-          "nix-bundle-lgx",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-nix",
           "nixpkgs"
         ]
@@ -34220,12 +38813,15 @@
     },
     "nix-bundle-lgx_46": {
       "inputs": {
-        "logos-nix": "logos-nix_695",
+        "logos-nix": "logos-nix_715",
         "logos-package": "logos-package_82",
         "nix-bundle-dir": "nix-bundle-dir_122",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "logos-nix",
@@ -34248,12 +38844,15 @@
     },
     "nix-bundle-lgx_47": {
       "inputs": {
-        "logos-nix": "logos-nix_704",
+        "logos-nix": "logos-nix_724",
         "logos-package": "logos-package_84",
         "nix-bundle-dir": "nix-bundle-dir_125",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -34277,23 +38876,60 @@
     },
     "nix-bundle-lgx_48": {
       "inputs": {
-        "logos-nix": "logos-nix_717",
+        "logos-nix": "logos-nix_755",
         "logos-package": "logos-package_86",
-        "nix-bundle-dir": "nix-bundle-dir_130",
+        "nix-bundle-dir": "nix-bundle-dir_128",
         "nixpkgs": [
           "logoscore-cli",
-          "nix-bundle-logos-module-install",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575520,
+        "narHash": "sha256-HOwg1N4NfGYq579IppVPpVjPDZfYQGndXGlcl1VRXXo=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "3c44d99b9d8dbd8a135b44b5b328e6175650305e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_49": {
+      "inputs": {
+        "logos-nix": "logos-nix_759",
+        "logos-package": "logos-package_87",
+        "nix-bundle-dir": "nix-bundle-dir_129",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-lgx",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775836380,
-        "narHash": "sha256-XbBPcMuDFA/SxYVw9TIRQbhie5Vj5MqwdU+Gh1iR1LA=",
+        "lastModified": 1777575520,
+        "narHash": "sha256-HOwg1N4NfGYq579IppVPpVjPDZfYQGndXGlcl1VRXXo=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "9d8f8602b1574ec9ac4c9b31ae0c92570221c268",
+        "rev": "3c44d99b9d8dbd8a135b44b5b328e6175650305e",
         "type": "github"
       },
       "original": {
@@ -34324,6 +38960,152 @@
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
         "rev": "3c44d99b9d8dbd8a135b44b5b328e6175650305e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_50": {
+      "inputs": {
+        "logos-nix": "logos-nix_768",
+        "logos-package": "logos-package_89",
+        "nix-bundle-dir": "nix-bundle-dir_132",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775836380,
+        "narHash": "sha256-XbBPcMuDFA/SxYVw9TIRQbhie5Vj5MqwdU+Gh1iR1LA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "9d8f8602b1574ec9ac4c9b31ae0c92570221c268",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_51": {
+      "inputs": {
+        "logos-nix": "logos-nix_783",
+        "logos-package": "logos-package_91",
+        "nix-bundle-dir": "nix-bundle-dir_135",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575520,
+        "narHash": "sha256-HOwg1N4NfGYq579IppVPpVjPDZfYQGndXGlcl1VRXXo=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "3c44d99b9d8dbd8a135b44b5b328e6175650305e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_52": {
+      "inputs": {
+        "logos-nix": "logos-nix_787",
+        "logos-package": "logos-package_92",
+        "nix-bundle-dir": "nix-bundle-dir_136",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575520,
+        "narHash": "sha256-HOwg1N4NfGYq579IppVPpVjPDZfYQGndXGlcl1VRXXo=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "3c44d99b9d8dbd8a135b44b5b328e6175650305e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_53": {
+      "inputs": {
+        "logos-nix": "logos-nix_796",
+        "logos-package": "logos-package_94",
+        "nix-bundle-dir": "nix-bundle-dir_139",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775836380,
+        "narHash": "sha256-XbBPcMuDFA/SxYVw9TIRQbhie5Vj5MqwdU+Gh1iR1LA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "9d8f8602b1574ec9ac4c9b31ae0c92570221c268",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_54": {
+      "inputs": {
+        "logos-nix": "logos-nix_809",
+        "logos-package": "logos-package_96",
+        "nix-bundle-dir": "nix-bundle-dir_144",
+        "nixpkgs": [
+          "logoscore-cli",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775836380,
+        "narHash": "sha256-XbBPcMuDFA/SxYVw9TIRQbhie5Vj5MqwdU+Gh1iR1LA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "9d8f8602b1574ec9ac4c9b31ae0c92570221c268",
         "type": "github"
       },
       "original": {
@@ -34403,11 +39185,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777575520,
-        "narHash": "sha256-HOwg1N4NfGYq579IppVPpVjPDZfYQGndXGlcl1VRXXo=",
+        "lastModified": 1781872587,
+        "narHash": "sha256-zl9odZ1Tq7QBAYJVrXiLSC47FVYra3kIakb/TeGPoZI=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "3c44d99b9d8dbd8a135b44b5b328e6175650305e",
+        "rev": "b49074a8e1157832002b11d3d254c1aaa4b96680",
         "type": "github"
       },
       "original": {
@@ -34474,15 +39256,14 @@
     },
     "nix-bundle-logos-module-install_10": {
       "inputs": {
-        "logos-nix": "logos-nix_455",
-        "logos-package-manager": "logos-package-manager_24",
+        "logos-nix": "logos-nix_442",
+        "logos-package-manager": "logos-package-manager_22",
         "nix-bundle-lgx": "nix-bundle-lgx_30",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -34506,15 +39287,14 @@
     },
     "nix-bundle-logos-module-install_11": {
       "inputs": {
-        "logos-nix": "logos-nix_498",
-        "logos-package-manager": "logos-package-manager_26",
+        "logos-nix": "logos-nix_496",
+        "logos-package-manager": "logos-package-manager_25",
         "nix-bundle-lgx": "nix-bundle-lgx_33",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -34539,9 +39319,74 @@
     },
     "nix-bundle-logos-module-install_12": {
       "inputs": {
-        "logos-nix": "logos-nix_522",
+        "logos-nix": "logos-nix_547",
         "logos-package-manager": "logos-package-manager_28",
-        "nix-bundle-lgx": "nix-bundle-lgx_34",
+        "nix-bundle-lgx": "nix-bundle-lgx_36",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775839388,
+        "narHash": "sha256-0QH146bzL2kKBYJq2yA35iPwug55j2xjEyKCS7tjhvg=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-logos-module-install",
+        "rev": "89cc9ea91275396d589c767d76926459ac77ef20",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-logos-module-install",
+        "type": "github"
+      }
+    },
+    "nix-bundle-logos-module-install_13": {
+      "inputs": {
+        "logos-nix": "logos-nix_590",
+        "logos-package-manager": "logos-package-manager_30",
+        "nix-bundle-lgx": "nix-bundle-lgx_39",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775839388,
+        "narHash": "sha256-0QH146bzL2kKBYJq2yA35iPwug55j2xjEyKCS7tjhvg=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-logos-module-install",
+        "rev": "89cc9ea91275396d589c767d76926459ac77ef20",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-logos-module-install",
+        "type": "github"
+      }
+    },
+    "nix-bundle-logos-module-install_14": {
+      "inputs": {
+        "logos-nix": "logos-nix_614",
+        "logos-package-manager": "logos-package-manager_32",
+        "nix-bundle-lgx": "nix-bundle-lgx_40",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34567,11 +39412,11 @@
         "type": "github"
       }
     },
-    "nix-bundle-logos-module-install_13": {
+    "nix-bundle-logos-module-install_15": {
       "inputs": {
-        "logos-nix": "logos-nix_564",
-        "logos-package-manager": "logos-package-manager_30",
-        "nix-bundle-lgx": "nix-bundle-lgx_37",
+        "logos-nix": "logos-nix_656",
+        "logos-package-manager": "logos-package-manager_34",
+        "nix-bundle-lgx": "nix-bundle-lgx_43",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34597,11 +39442,11 @@
         "type": "github"
       }
     },
-    "nix-bundle-logos-module-install_14": {
+    "nix-bundle-logos-module-install_16": {
       "inputs": {
-        "logos-nix": "logos-nix_577",
-        "logos-package-manager": "logos-package-manager_31",
-        "nix-bundle-lgx": "nix-bundle-lgx_38",
+        "logos-nix": "logos-nix_669",
+        "logos-package-manager": "logos-package-manager_35",
+        "nix-bundle-lgx": "nix-bundle-lgx_44",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34625,11 +39470,11 @@
         "type": "github"
       }
     },
-    "nix-bundle-logos-module-install_15": {
+    "nix-bundle-logos-module-install_17": {
       "inputs": {
-        "logos-nix": "logos-nix_626",
-        "logos-package-manager": "logos-package-manager_33",
-        "nix-bundle-lgx": "nix-bundle-lgx_41",
+        "logos-nix": "logos-nix_718",
+        "logos-package-manager": "logos-package-manager_37",
+        "nix-bundle-lgx": "nix-bundle-lgx_47",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34656,11 +39501,11 @@
         "type": "github"
       }
     },
-    "nix-bundle-logos-module-install_16": {
+    "nix-bundle-logos-module-install_18": {
       "inputs": {
-        "logos-nix": "logos-nix_670",
-        "logos-package-manager": "logos-package-manager_35",
-        "nix-bundle-lgx": "nix-bundle-lgx_44",
+        "logos-nix": "logos-nix_762",
+        "logos-package-manager": "logos-package-manager_39",
+        "nix-bundle-lgx": "nix-bundle-lgx_50",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34688,41 +39533,15 @@
         "type": "github"
       }
     },
-    "nix-bundle-logos-module-install_17": {
+    "nix-bundle-logos-module-install_19": {
       "inputs": {
-        "logos-nix": "logos-nix_698",
-        "logos-package-manager": "logos-package-manager_37",
-        "nix-bundle-lgx": "nix-bundle-lgx_47",
+        "logos-nix": "logos-nix_790",
+        "logos-package-manager": "logos-package-manager_41",
+        "nix-bundle-lgx": "nix-bundle-lgx_53",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775839388,
-        "narHash": "sha256-0QH146bzL2kKBYJq2yA35iPwug55j2xjEyKCS7tjhvg=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-logos-module-install",
-        "rev": "89cc9ea91275396d589c767d76926459ac77ef20",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-logos-module-install",
-        "type": "github"
-      }
-    },
-    "nix-bundle-logos-module-install_18": {
-      "inputs": {
-        "logos-nix": "logos-nix_711",
-        "logos-package-manager": "logos-package-manager_38",
-        "nix-bundle-lgx": "nix-bundle-lgx_48",
-        "nixpkgs": [
-          "logoscore-cli",
           "nix-bundle-logos-module-install",
           "logos-nix",
           "nixpkgs"
@@ -34753,6 +39572,32 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775839388,
+        "narHash": "sha256-0QH146bzL2kKBYJq2yA35iPwug55j2xjEyKCS7tjhvg=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-logos-module-install",
+        "rev": "89cc9ea91275396d589c767d76926459ac77ef20",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-logos-module-install",
+        "type": "github"
+      }
+    },
+    "nix-bundle-logos-module-install_20": {
+      "inputs": {
+        "logos-nix": "logos-nix_803",
+        "logos-package-manager": "logos-package-manager_42",
+        "nix-bundle-lgx": "nix-bundle-lgx_54",
+        "nixpkgs": [
+          "logoscore-cli",
           "nix-bundle-logos-module-install",
           "logos-nix",
           "nixpkgs"
@@ -34828,12 +39673,15 @@
     },
     "nix-bundle-logos-module-install_5": {
       "inputs": {
-        "logos-nix": "logos-nix_200",
+        "logos-nix": "logos-nix_217",
         "logos-package-manager": "logos-package-manager_10",
         "nix-bundle-lgx": "nix-bundle-lgx_15",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -34857,12 +39705,15 @@
     },
     "nix-bundle-logos-module-install_6": {
       "inputs": {
-        "logos-nix": "logos-nix_256",
-        "logos-package-manager": "logos-package-manager_13",
+        "logos-nix": "logos-nix_261",
+        "logos-package-manager": "logos-package-manager_12",
         "nix-bundle-lgx": "nix-bundle-lgx_18",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -34887,13 +39738,12 @@
     },
     "nix-bundle-logos-module-install_7": {
       "inputs": {
-        "logos-nix": "logos-nix_307",
-        "logos-package-manager": "logos-package-manager_16",
+        "logos-nix": "logos-nix_289",
+        "logos-package-manager": "logos-package-manager_14",
         "nix-bundle-lgx": "nix-bundle-lgx_21",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -34917,13 +39767,12 @@
     },
     "nix-bundle-logos-module-install_8": {
       "inputs": {
-        "logos-nix": "logos-nix_350",
-        "logos-package-manager": "logos-package-manager_18",
+        "logos-nix": "logos-nix_348",
+        "logos-package-manager": "logos-package-manager_17",
         "nix-bundle-lgx": "nix-bundle-lgx_24",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -34948,15 +39797,13 @@
     },
     "nix-bundle-logos-module-install_9": {
       "inputs": {
-        "logos-nix": "logos-nix_404",
-        "logos-package-manager": "logos-package-manager_21",
+        "logos-nix": "logos-nix_399",
+        "logos-package-manager": "logos-package-manager_20",
         "nix-bundle-lgx": "nix-bundle-lgx_27",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -46114,7 +50961,231 @@
         "type": "github"
       }
     },
+    "nixpkgs_726": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_727": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_728": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_729": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_73": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_730": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_731": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_732": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_733": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_734": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_735": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_736": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_737": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_738": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_739": {
       "locked": {
         "lastModified": 1759036355,
         "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
@@ -46146,7 +51217,327 @@
         "type": "github"
       }
     },
+    "nixpkgs_740": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_741": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_742": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_743": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_744": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_745": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_746": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_747": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_748": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_749": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_75": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_750": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_751": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_752": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_753": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_754": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_755": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_756": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_757": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_758": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_759": {
       "locked": {
         "lastModified": 1759036355,
         "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
@@ -46178,7 +51569,327 @@
         "type": "github"
       }
     },
+    "nixpkgs_760": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_761": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_762": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_763": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_764": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_765": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_766": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_767": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_768": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_769": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_77": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_770": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_771": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_772": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_773": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_774": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_775": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_776": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_777": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_778": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_779": {
       "locked": {
         "lastModified": 1759036355,
         "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
@@ -46210,7 +51921,327 @@
         "type": "github"
       }
     },
+    "nixpkgs_780": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_781": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_782": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_783": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_784": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_785": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_786": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_787": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_788": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_789": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_79": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_790": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_791": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_792": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_793": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_794": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_795": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_796": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_797": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_798": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_799": {
       "locked": {
         "lastModified": 1759036355,
         "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
@@ -46258,7 +52289,295 @@
         "type": "github"
       }
     },
+    "nixpkgs_800": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_801": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_802": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_803": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_804": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_805": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_806": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_807": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_808": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_809": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_81": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_810": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_811": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_812": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_813": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_814": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_815": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_816": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_817": {
       "locked": {
         "lastModified": 1759036355,
         "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
@@ -46600,10 +52919,10 @@
     },
     "package-manager": {
       "inputs": {
-        "logos-nix": "logos-nix_720",
-        "logos-package": "logos-package_87",
-        "nix-bundle-appimage": "nix-bundle-appimage_42",
-        "nix-bundle-dir": "nix-bundle-dir_132",
+        "logos-nix": "logos-nix_812",
+        "logos-package": "logos-package_97",
+        "nix-bundle-appimage": "nix-bundle-appimage_46",
+        "nix-bundle-dir": "nix-bundle-dir_146",
         "nixpkgs": [
           "package-manager",
           "logos-nix",
@@ -46611,11 +52930,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781795505,
-        "narHash": "sha256-AVUIfNRBo4yx3UGe+keZFW+PLpa3iJpJ1t3gAy30CwY=",
+        "lastModified": 1782134133,
+        "narHash": "sha256-65w2mEijAjUPVntS3kUKZygjRkZoj7dgCYtk8lD5jL8=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "05b2cf853a81cc61d6c6e81b6f2b5ef2a9466c24",
+        "rev": "4871ed198d6e35f198af15c93afd184aa36788e0",
         "type": "github"
       },
       "original": {
@@ -46655,12 +52974,37 @@
     },
     "process-stats_10": {
       "inputs": {
-        "logos-nix": "logos-nix_339",
+        "logos-nix": "logos-nix_365",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "process-stats",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775744159,
+        "narHash": "sha256-hTVAnDREBQOVHML6KU3K7Ge0CRBqnFIg7uYL7qDnD8o=",
+        "owner": "logos-co",
+        "repo": "process-stats",
+        "rev": "33ace1270f90c89b3565e803139c0970fcd1ce8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "process-stats",
+        "type": "github"
+      }
+    },
+    "process-stats_11": {
+      "inputs": {
+        "logos-nix": "logos-nix_388",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -46684,41 +53028,13 @@
         "type": "github"
       }
     },
-    "process-stats_11": {
-      "inputs": {
-        "logos-nix": "logos-nix_367",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-liblogos",
-          "process-stats",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775744159,
-        "narHash": "sha256-hTVAnDREBQOVHML6KU3K7Ge0CRBqnFIg7uYL7qDnD8o=",
-        "owner": "logos-co",
-        "repo": "process-stats",
-        "rev": "33ace1270f90c89b3565e803139c0970fcd1ce8f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "process-stats",
-        "type": "github"
-      }
-    },
     "process-stats_12": {
       "inputs": {
-        "logos-nix": "logos-nix_393",
+        "logos-nix": "logos-nix_431",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -46745,12 +53061,11 @@
     },
     "process-stats_13": {
       "inputs": {
-        "logos-nix": "logos-nix_421",
+        "logos-nix": "logos-nix_459",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "process-stats",
           "logos-nix",
@@ -46773,13 +53088,13 @@
     },
     "process-stats_14": {
       "inputs": {
-        "logos-nix": "logos-nix_444",
+        "logos-nix": "logos-nix_485",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -46805,14 +53120,41 @@
     },
     "process-stats_15": {
       "inputs": {
-        "logos-nix": "logos-nix_487",
+        "logos-nix": "logos-nix_513",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-liblogos",
+          "process-stats",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775744159,
+        "narHash": "sha256-hTVAnDREBQOVHML6KU3K7Ge0CRBqnFIg7uYL7qDnD8o=",
+        "owner": "logos-co",
+        "repo": "process-stats",
+        "rev": "33ace1270f90c89b3565e803139c0970fcd1ce8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "process-stats",
+        "type": "github"
+      }
+    },
+    "process-stats_16": {
+      "inputs": {
+        "logos-nix": "logos-nix_536",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-test-modules",
           "logos-logoscore-cli",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -46836,9 +53178,9 @@
         "type": "github"
       }
     },
-    "process-stats_16": {
+    "process-stats_17": {
       "inputs": {
-        "logos-nix": "logos-nix_515",
+        "logos-nix": "logos-nix_579",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -46846,33 +53188,7 @@
           "logos-test-modules",
           "logos-logoscore-cli",
           "logos-liblogos",
-          "process-stats",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775744159,
-        "narHash": "sha256-hTVAnDREBQOVHML6KU3K7Ge0CRBqnFIg7uYL7qDnD8o=",
-        "owner": "logos-co",
-        "repo": "process-stats",
-        "rev": "33ace1270f90c89b3565e803139c0970fcd1ce8f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "process-stats",
-        "type": "github"
-      }
-    },
-    "process-stats_17": {
-      "inputs": {
-        "logos-nix": "logos-nix_553",
-        "nixpkgs": [
-          "logoscore-cli",
-          "logos-test-modules",
-          "logos-logoscore-cli",
-          "logos-test-modules",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -46897,15 +53213,13 @@
     },
     "process-stats_18": {
       "inputs": {
-        "logos-nix": "logos-nix_615",
+        "logos-nix": "logos-nix_607",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
+          "logos-logoscore-cli",
+          "logos-test-modules",
+          "logos-logoscore-cli",
           "logos-liblogos",
           "process-stats",
           "logos-nix",
@@ -46928,14 +53242,12 @@
     },
     "process-stats_19": {
       "inputs": {
-        "logos-nix": "logos-nix_659",
+        "logos-nix": "logos-nix_645",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-logoscore-cli",
+          "logos-test-modules",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -46990,7 +53302,70 @@
     },
     "process-stats_20": {
       "inputs": {
-        "logos-nix": "logos-nix_687",
+        "logos-nix": "logos-nix_707",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "process-stats",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775744159,
+        "narHash": "sha256-hTVAnDREBQOVHML6KU3K7Ge0CRBqnFIg7uYL7qDnD8o=",
+        "owner": "logos-co",
+        "repo": "process-stats",
+        "rev": "33ace1270f90c89b3565e803139c0970fcd1ce8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "process-stats",
+        "type": "github"
+      }
+    },
+    "process-stats_21": {
+      "inputs": {
+        "logos-nix": "logos-nix_751",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-test-modules",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "process-stats",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775744159,
+        "narHash": "sha256-hTVAnDREBQOVHML6KU3K7Ge0CRBqnFIg7uYL7qDnD8o=",
+        "owner": "logos-co",
+        "repo": "process-stats",
+        "rev": "33ace1270f90c89b3565e803139c0970fcd1ce8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "process-stats",
+        "type": "github"
+      }
+    },
+    "process-stats_22": {
+      "inputs": {
+        "logos-nix": "logos-nix_779",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -47072,10 +53447,13 @@
     },
     "process-stats_5": {
       "inputs": {
-        "logos-nix": "logos-nix_189",
+        "logos-nix": "logos-nix_206",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -47101,9 +53479,17 @@
     },
     "process-stats_6": {
       "inputs": {
-        "logos-nix": "logos-nix_219",
+        "logos-nix": "logos-nix_250",
         "nixpkgs": [
           "logoscore-cli",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "process-stats",
           "logos-nix",
@@ -47126,10 +53512,9 @@
     },
     "process-stats_7": {
       "inputs": {
-        "logos-nix": "logos-nix_245",
+        "logos-nix": "logos-nix_278",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -47156,10 +53541,9 @@
     },
     "process-stats_8": {
       "inputs": {
-        "logos-nix": "logos-nix_273",
+        "logos-nix": "logos-nix_311",
         "nixpkgs": [
           "logoscore-cli",
-          "logos-test-modules",
           "logos-liblogos",
           "process-stats",
           "logos-nix",
@@ -47182,11 +53566,11 @@
     },
     "process-stats_9": {
       "inputs": {
-        "logos-nix": "logos-nix_296",
+        "logos-nix": "logos-nix_337",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
-          "logos-logoscore-cli",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -47217,6 +53601,27 @@
         "logoscore-cli": "logoscore-cli",
         "openmetrics-module": "openmetrics-module",
         "package-manager": "package-manager"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "logos-module-builder",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782012058,
+        "narHash": "sha256-9mWUnReOUXfKjZuJAL/bAFH3LUyECTRtXgSNVjRw3UY=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "8534567325bd8a8d2928e6afd81e0a87d19efd3c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },


### PR DESCRIPTION
Transitive override of logos-module-builder/nix-bundle-lgx so the LGX bundler copies display_name from metadata.json into the embedded manifest.json