### PR TITLE
feat: user-provided XPRs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,7 @@ use cases using the `logos-libp2p-module`.
   - Advertising a named service (`discoStartAdvertising`)
   - Registering interest and looking it up from another node (`discoRegisterInterest` / `discoLookup`)
   - Resolving the advertiser's peer record (peerId, seqNo, addrs)
+  - Building a signed Extended Peer Record for the node's own services (`createXpr`)
 
 ## Building
 Enter the development shell and configure cmake

--- a/examples/service_discovery.cpp
+++ b/examples/service_discovery.cpp
@@ -124,7 +124,9 @@ int main()
         {"chat", std::string{0x01, 0x02, 0x03}},
     };
     auto xpr = advertiser.createXpr({}, xprServices, 0);
-    if (xpr.success) {
+    if (!xpr.success) {
+        printf("Failed to create XPR: %s\n", xpr.error.c_str());
+    } else {
         printf("Signed XPR is %zu bytes\n", xpr.value.get<std::string>().size());
     }
 

--- a/examples/service_discovery.cpp
+++ b/examples/service_discovery.cpp
@@ -118,6 +118,16 @@ int main()
         printf("Random lookup returned %zu peer(s)\n", randRes.value.size());
     }
 
+    printf("Advertiser: building a signed Extended Peer Record\n");
+    std::vector<std::pair<std::string, std::string>> xprServices = {
+        {serviceId, serviceData},
+        {"chat", std::string{0x01, 0x02, 0x03}},
+    };
+    auto xpr = advertiser.createXpr({}, xprServices, 0);
+    if (xpr.success) {
+        printf("Signed XPR is %zu bytes\n", xpr.value.get<std::string>().size());
+    }
+
     printf("Discoverer: unregistering interest in %s\n", serviceId.c_str());
     discoverer.discoUnregisterInterest(serviceId);
 

--- a/flake.lock
+++ b/flake.lock
@@ -62,16 +62,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1781885898,
-        "narHash": "sha256-DCpx1MviiN5wjkcKrQQier+fLERMaY4egKqdkRWkVmU=",
+        "lastModified": 1782233897,
+        "narHash": "sha256-pVlOHa5R4hwKRr4TKqEWQhEuHwLnIjcgpIDFoVWGdqE=",
         "owner": "vacp2p",
         "repo": "nim-libp2p",
-        "rev": "4b275fe6b11c0b70a42966d3d3649b3f10f99399",
+        "rev": "265947fe8a04157fa9115c1d26159491262a30c3",
         "type": "github"
       },
       "original": {
         "owner": "vacp2p",
-        "ref": "chore/cbind/metrics",
+        "ref": "feat/cbind/user-provided-xprs",
         "repo": "nim-libp2p",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,7 +3,7 @@
     "default-container": {
       "inputs": {
         "logos-container": "logos-container",
-        "logos-nix": "logos-nix_168",
+        "logos-nix": "logos-nix_170",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -32,9 +32,9 @@
         "logos-cpp-sdk": "logos-cpp-sdk_18",
         "logos-module": "logos-module_23",
         "logos-module-loader": "logos-module-loader",
-        "logos-nix": "logos-nix_174",
-        "logos-protocol": "logos-protocol_3",
-        "logos-qt-sdk": "logos-qt-sdk_3",
+        "logos-nix": "logos-nix_176",
+        "logos-protocol": "logos-protocol_8",
+        "logos-qt-sdk": "logos-qt-sdk_6",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -62,16 +62,15 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1782233897,
-        "narHash": "sha256-pVlOHa5R4hwKRr4TKqEWQhEuHwLnIjcgpIDFoVWGdqE=",
+        "lastModified": 1782318742,
+        "narHash": "sha256-XPiZLmswgXGBsPgK8XNyGV1mEtUE4MYrHxd8VDWWZ7U=",
         "owner": "vacp2p",
         "repo": "nim-libp2p",
-        "rev": "265947fe8a04157fa9115c1d26159491262a30c3",
+        "rev": "9b112339434db71b73ba4fafcc77b4cae9f97c57",
         "type": "github"
       },
       "original": {
         "owner": "vacp2p",
-        "ref": "feat/cbind/user-provided-xprs",
         "repo": "nim-libp2p",
         "type": "github"
       }
@@ -81,11 +80,11 @@
         "logos-module-builder": "logos-module-builder_2"
       },
       "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
+        "lastModified": 1780946924,
+        "narHash": "sha256-8wFILW1oMS1L77Ff4bcC/5W9dytNe6I1rhf5AHhQW2U=",
         "owner": "logos-co",
         "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "rev": "0013e7653eb1b23d5495e39f149259bd60dc1db4",
         "type": "github"
       },
       "original": {
@@ -144,7 +143,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_30",
-        "logos-nix": "logos-nix_192",
+        "logos-nix": "logos-nix_194",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -176,7 +175,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_22",
         "logos-module": "logos-module_31",
-        "logos-nix": "logos-nix_197",
+        "logos-nix": "logos-nix_199",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -239,7 +238,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_36",
-        "logos-nix": "logos-nix_236",
+        "logos-nix": "logos-nix_238",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -272,7 +271,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_27",
         "logos-module": "logos-module_37",
-        "logos-nix": "logos-nix_241",
+        "logos-nix": "logos-nix_243",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -333,7 +332,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_44",
-        "logos-nix": "logos-nix_323",
+        "logos-nix": "logos-nix_325",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -363,7 +362,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_34",
         "logos-module": "logos-module_45",
-        "logos-nix": "logos-nix_328",
+        "logos-nix": "logos-nix_330",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -457,7 +456,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_51",
-        "logos-nix": "logos-nix_374",
+        "logos-nix": "logos-nix_376",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -487,7 +486,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_39",
         "logos-module": "logos-module_52",
-        "logos-nix": "logos-nix_379",
+        "logos-nix": "logos-nix_381",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -546,7 +545,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_57",
-        "logos-nix": "logos-nix_417",
+        "logos-nix": "logos-nix_419",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -577,7 +576,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_44",
         "logos-module": "logos-module_58",
-        "logos-nix": "logos-nix_422",
+        "logos-nix": "logos-nix_424",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -638,7 +637,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_64",
-        "logos-nix": "logos-nix_471",
+        "logos-nix": "logos-nix_473",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -670,7 +669,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_50",
         "logos-module": "logos-module_65",
-        "logos-nix": "logos-nix_476",
+        "logos-nix": "logos-nix_478",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -763,7 +762,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_71",
-        "logos-nix": "logos-nix_522",
+        "logos-nix": "logos-nix_524",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -795,7 +794,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_55",
         "logos-module": "logos-module_72",
-        "logos-nix": "logos-nix_527",
+        "logos-nix": "logos-nix_529",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -858,7 +857,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_77",
-        "logos-nix": "logos-nix_565",
+        "logos-nix": "logos-nix_567",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -891,7 +890,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_60",
         "logos-module": "logos-module_78",
-        "logos-nix": "logos-nix_570",
+        "logos-nix": "logos-nix_572",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -934,7 +933,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_84",
-        "logos-nix": "logos-nix_631",
+        "logos-nix": "logos-nix_633",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -964,7 +963,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_66",
         "logos-module": "logos-module_85",
-        "logos-nix": "logos-nix_636",
+        "logos-nix": "logos-nix_638",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -1023,7 +1022,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_93",
-        "logos-nix": "logos-nix_693",
+        "logos-nix": "logos-nix_695",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -1054,7 +1053,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_71",
         "logos-module": "logos-module_94",
-        "logos-nix": "logos-nix_698",
+        "logos-nix": "logos-nix_700",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -1088,11 +1087,11 @@
         "logos-module-builder": "logos-module-builder_3"
       },
       "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
+        "lastModified": 1781129198,
+        "narHash": "sha256-vnJCkDQlGKXStnXFGhATzY3dXwwQT4/nnljReFmAzQc=",
         "owner": "logos-co",
         "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "rev": "5d438961e2defe72b76028150787d59e586eec8c",
         "type": "github"
       },
       "original": {
@@ -1133,7 +1132,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_99",
-        "logos-nix": "logos-nix_737",
+        "logos-nix": "logos-nix_739",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -1165,7 +1164,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_76",
         "logos-module": "logos-module_100",
-        "logos-nix": "logos-nix_742",
+        "logos-nix": "logos-nix_744",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -1293,7 +1292,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_20",
-        "logos-nix": "logos-nix_132",
+        "logos-nix": "logos-nix_134",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -1321,7 +1320,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_15",
         "logos-module": "logos-module_21",
-        "logos-nix": "logos-nix_137",
+        "logos-nix": "logos-nix_139",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -1349,7 +1348,7 @@
     },
     "logos-container": {
       "inputs": {
-        "logos-nix": "logos-nix_167",
+        "logos-nix": "logos-nix_169",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -1375,7 +1374,7 @@
     },
     "logos-container_2": {
       "inputs": {
-        "logos-nix": "logos-nix_169",
+        "logos-nix": "logos-nix_171",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -1401,7 +1400,7 @@
     },
     "logos-container_3": {
       "inputs": {
-        "logos-nix": "logos-nix_172",
+        "logos-nix": "logos-nix_174",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -1428,7 +1427,7 @@
     },
     "logos-container_4": {
       "inputs": {
-        "logos-nix": "logos-nix_298",
+        "logos-nix": "logos-nix_300",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -1453,7 +1452,7 @@
     },
     "logos-container_5": {
       "inputs": {
-        "logos-nix": "logos-nix_301",
+        "logos-nix": "logos-nix_303",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -1493,11 +1492,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781897505,
-        "narHash": "sha256-sRVgfo8VfWOXb3IH2JqZQAqBSfL0bYo3FrFSgS6yvqk=",
+        "lastModified": 1782292503,
+        "narHash": "sha256-XKjPeGtv07xufTeUQJWST5vOznSVn1ykFQR3IxDbFto=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "aea29d37975aa0c32fdf37d7119830be905acf34",
+        "rev": "31b9d2bf5f2b7542df50d07c1050b865b4b30de8",
         "type": "github"
       },
       "original": {
@@ -1539,6 +1538,12 @@
     "logos-cpp-sdk_11": {
       "inputs": {
         "logos-nix": "logos-nix_96",
+        "logos-protocol": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logos-module-builder",
           "logos-standalone-app",
@@ -1549,11 +1554,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "lastModified": 1781304979,
+        "narHash": "sha256-uCCoJJRVCUUO6j03GO6/02+uuLd9GaAi/0dHaiW2bXs=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "rev": "f0fe8cbfeb1fe62d934b4abf8c300047a49420c9",
         "type": "github"
       },
       "original": {
@@ -1570,6 +1575,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_5",
         "nixpkgs": [
           "logos-module-builder",
           "logos-standalone-app",
@@ -1580,11 +1586,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "lastModified": 1781313016,
+        "narHash": "sha256-gbchE6ExNqonj5XXVURXahYaaML0qAtSV9wHHMjs+/E=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "rev": "87abcd804422cbd733c2e658ae2f42c20162115c",
         "type": "github"
       },
       "original": {
@@ -1595,7 +1601,7 @@
     },
     "logos-cpp-sdk_13": {
       "inputs": {
-        "logos-nix": "logos-nix_124",
+        "logos-nix": "logos-nix_126",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -1621,7 +1627,7 @@
     },
     "logos-cpp-sdk_14": {
       "inputs": {
-        "logos-nix": "logos-nix_133",
+        "logos-nix": "logos-nix_135",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -1648,7 +1654,7 @@
     },
     "logos-cpp-sdk_15": {
       "inputs": {
-        "logos-nix": "logos-nix_135",
+        "logos-nix": "logos-nix_137",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -1677,7 +1683,7 @@
     },
     "logos-cpp-sdk_16": {
       "inputs": {
-        "logos-nix": "logos-nix_138",
+        "logos-nix": "logos-nix_140",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -1705,7 +1711,7 @@
     },
     "logos-cpp-sdk_17": {
       "inputs": {
-        "logos-nix": "logos-nix_166",
+        "logos-nix": "logos-nix_168",
         "logos-protocol": [
           "logoscore-cli",
           "logos-protocol"
@@ -1734,7 +1740,7 @@
     "logos-cpp-sdk_18": {
       "inputs": {
         "logos-lidl": "logos-lidl_4",
-        "logos-nix": "logos-nix_170",
+        "logos-nix": "logos-nix_172",
         "logos-protocol": [
           "logoscore-cli",
           "logos-liblogos",
@@ -1766,7 +1772,7 @@
     },
     "logos-cpp-sdk_19": {
       "inputs": {
-        "logos-nix": "logos-nix_177",
+        "logos-nix": "logos-nix_179",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -1820,7 +1826,7 @@
     },
     "logos-cpp-sdk_20": {
       "inputs": {
-        "logos-nix": "logos-nix_184",
+        "logos-nix": "logos-nix_186",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -1850,7 +1856,7 @@
     },
     "logos-cpp-sdk_21": {
       "inputs": {
-        "logos-nix": "logos-nix_193",
+        "logos-nix": "logos-nix_195",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -1881,7 +1887,7 @@
     },
     "logos-cpp-sdk_22": {
       "inputs": {
-        "logos-nix": "logos-nix_195",
+        "logos-nix": "logos-nix_197",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -1914,7 +1920,7 @@
     },
     "logos-cpp-sdk_23": {
       "inputs": {
-        "logos-nix": "logos-nix_198",
+        "logos-nix": "logos-nix_200",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -1946,7 +1952,7 @@
     },
     "logos-cpp-sdk_24": {
       "inputs": {
-        "logos-nix": "logos-nix_226",
+        "logos-nix": "logos-nix_228",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -1974,7 +1980,7 @@
     },
     "logos-cpp-sdk_25": {
       "inputs": {
-        "logos-nix": "logos-nix_228",
+        "logos-nix": "logos-nix_230",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -2005,7 +2011,7 @@
     },
     "logos-cpp-sdk_26": {
       "inputs": {
-        "logos-nix": "logos-nix_237",
+        "logos-nix": "logos-nix_239",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -2037,7 +2043,7 @@
     },
     "logos-cpp-sdk_27": {
       "inputs": {
-        "logos-nix": "logos-nix_239",
+        "logos-nix": "logos-nix_241",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -2071,7 +2077,7 @@
     },
     "logos-cpp-sdk_28": {
       "inputs": {
-        "logos-nix": "logos-nix_242",
+        "logos-nix": "logos-nix_244",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -2104,7 +2110,7 @@
     },
     "logos-cpp-sdk_29": {
       "inputs": {
-        "logos-nix": "logos-nix_270",
+        "logos-nix": "logos-nix_272",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -2199,7 +2205,7 @@
     "logos-cpp-sdk_31": {
       "inputs": {
         "logos-lidl": "logos-lidl_6",
-        "logos-nix": "logos-nix_299",
+        "logos-nix": "logos-nix_301",
         "logos-protocol": [
           "logoscore-cli",
           "logos-liblogos",
@@ -2229,7 +2235,7 @@
     },
     "logos-cpp-sdk_32": {
       "inputs": {
-        "logos-nix": "logos-nix_315",
+        "logos-nix": "logos-nix_317",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2257,7 +2263,7 @@
     },
     "logos-cpp-sdk_33": {
       "inputs": {
-        "logos-nix": "logos-nix_324",
+        "logos-nix": "logos-nix_326",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2286,7 +2292,7 @@
     },
     "logos-cpp-sdk_34": {
       "inputs": {
-        "logos-nix": "logos-nix_326",
+        "logos-nix": "logos-nix_328",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2317,7 +2323,7 @@
     },
     "logos-cpp-sdk_35": {
       "inputs": {
-        "logos-nix": "logos-nix_329",
+        "logos-nix": "logos-nix_331",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2347,7 +2353,7 @@
     },
     "logos-cpp-sdk_36": {
       "inputs": {
-        "logos-nix": "logos-nix_357",
+        "logos-nix": "logos-nix_359",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2373,7 +2379,7 @@
     },
     "logos-cpp-sdk_37": {
       "inputs": {
-        "logos-nix": "logos-nix_366",
+        "logos-nix": "logos-nix_368",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2401,7 +2407,7 @@
     },
     "logos-cpp-sdk_38": {
       "inputs": {
-        "logos-nix": "logos-nix_375",
+        "logos-nix": "logos-nix_377",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2430,7 +2436,7 @@
     },
     "logos-cpp-sdk_39": {
       "inputs": {
-        "logos-nix": "logos-nix_377",
+        "logos-nix": "logos-nix_379",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2491,7 +2497,7 @@
     },
     "logos-cpp-sdk_40": {
       "inputs": {
-        "logos-nix": "logos-nix_380",
+        "logos-nix": "logos-nix_382",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2521,7 +2527,7 @@
     },
     "logos-cpp-sdk_41": {
       "inputs": {
-        "logos-nix": "logos-nix_408",
+        "logos-nix": "logos-nix_410",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2547,7 +2553,7 @@
     },
     "logos-cpp-sdk_42": {
       "inputs": {
-        "logos-nix": "logos-nix_409",
+        "logos-nix": "logos-nix_411",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2576,7 +2582,7 @@
     },
     "logos-cpp-sdk_43": {
       "inputs": {
-        "logos-nix": "logos-nix_418",
+        "logos-nix": "logos-nix_420",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2606,7 +2612,7 @@
     },
     "logos-cpp-sdk_44": {
       "inputs": {
-        "logos-nix": "logos-nix_420",
+        "logos-nix": "logos-nix_422",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2638,7 +2644,7 @@
     },
     "logos-cpp-sdk_45": {
       "inputs": {
-        "logos-nix": "logos-nix_423",
+        "logos-nix": "logos-nix_425",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2669,7 +2675,7 @@
     },
     "logos-cpp-sdk_46": {
       "inputs": {
-        "logos-nix": "logos-nix_451",
+        "logos-nix": "logos-nix_453",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2696,7 +2702,7 @@
     },
     "logos-cpp-sdk_47": {
       "inputs": {
-        "logos-nix": "logos-nix_460",
+        "logos-nix": "logos-nix_462",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2723,7 +2729,7 @@
     },
     "logos-cpp-sdk_48": {
       "inputs": {
-        "logos-nix": "logos-nix_463",
+        "logos-nix": "logos-nix_465",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2753,7 +2759,7 @@
     },
     "logos-cpp-sdk_49": {
       "inputs": {
-        "logos-nix": "logos-nix_472",
+        "logos-nix": "logos-nix_474",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2813,7 +2819,7 @@
     },
     "logos-cpp-sdk_50": {
       "inputs": {
-        "logos-nix": "logos-nix_474",
+        "logos-nix": "logos-nix_476",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2846,7 +2852,7 @@
     },
     "logos-cpp-sdk_51": {
       "inputs": {
-        "logos-nix": "logos-nix_477",
+        "logos-nix": "logos-nix_479",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2878,7 +2884,7 @@
     },
     "logos-cpp-sdk_52": {
       "inputs": {
-        "logos-nix": "logos-nix_505",
+        "logos-nix": "logos-nix_507",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2906,7 +2912,7 @@
     },
     "logos-cpp-sdk_53": {
       "inputs": {
-        "logos-nix": "logos-nix_514",
+        "logos-nix": "logos-nix_516",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2936,7 +2942,7 @@
     },
     "logos-cpp-sdk_54": {
       "inputs": {
-        "logos-nix": "logos-nix_523",
+        "logos-nix": "logos-nix_525",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -2967,7 +2973,7 @@
     },
     "logos-cpp-sdk_55": {
       "inputs": {
-        "logos-nix": "logos-nix_525",
+        "logos-nix": "logos-nix_527",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3000,7 +3006,7 @@
     },
     "logos-cpp-sdk_56": {
       "inputs": {
-        "logos-nix": "logos-nix_528",
+        "logos-nix": "logos-nix_530",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3032,7 +3038,7 @@
     },
     "logos-cpp-sdk_57": {
       "inputs": {
-        "logos-nix": "logos-nix_556",
+        "logos-nix": "logos-nix_558",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3060,7 +3066,7 @@
     },
     "logos-cpp-sdk_58": {
       "inputs": {
-        "logos-nix": "logos-nix_557",
+        "logos-nix": "logos-nix_559",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3091,7 +3097,7 @@
     },
     "logos-cpp-sdk_59": {
       "inputs": {
-        "logos-nix": "logos-nix_566",
+        "logos-nix": "logos-nix_568",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3124,6 +3130,7 @@
     "logos-cpp-sdk_6": {
       "inputs": {
         "logos-nix": "logos-nix_52",
+        "logos-protocol": "logos-protocol_2",
         "nixpkgs": [
           "logos-module-builder",
           "logos-standalone-app",
@@ -3133,11 +3140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "lastModified": 1781313016,
+        "narHash": "sha256-gbchE6ExNqonj5XXVURXahYaaML0qAtSV9wHHMjs+/E=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "rev": "87abcd804422cbd733c2e658ae2f42c20162115c",
         "type": "github"
       },
       "original": {
@@ -3148,7 +3155,7 @@
     },
     "logos-cpp-sdk_60": {
       "inputs": {
-        "logos-nix": "logos-nix_568",
+        "logos-nix": "logos-nix_570",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3182,7 +3189,7 @@
     },
     "logos-cpp-sdk_61": {
       "inputs": {
-        "logos-nix": "logos-nix_571",
+        "logos-nix": "logos-nix_573",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3215,7 +3222,7 @@
     },
     "logos-cpp-sdk_62": {
       "inputs": {
-        "logos-nix": "logos-nix_599",
+        "logos-nix": "logos-nix_601",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3244,7 +3251,7 @@
     },
     "logos-cpp-sdk_63": {
       "inputs": {
-        "logos-nix": "logos-nix_608",
+        "logos-nix": "logos-nix_610",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3273,7 +3280,7 @@
     },
     "logos-cpp-sdk_64": {
       "inputs": {
-        "logos-nix": "logos-nix_623",
+        "logos-nix": "logos-nix_625",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3301,7 +3308,7 @@
     },
     "logos-cpp-sdk_65": {
       "inputs": {
-        "logos-nix": "logos-nix_632",
+        "logos-nix": "logos-nix_634",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3330,7 +3337,7 @@
     },
     "logos-cpp-sdk_66": {
       "inputs": {
-        "logos-nix": "logos-nix_634",
+        "logos-nix": "logos-nix_636",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3361,7 +3368,7 @@
     },
     "logos-cpp-sdk_67": {
       "inputs": {
-        "logos-nix": "logos-nix_637",
+        "logos-nix": "logos-nix_639",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3391,7 +3398,7 @@
     },
     "logos-cpp-sdk_68": {
       "inputs": {
-        "logos-nix": "logos-nix_678",
+        "logos-nix": "logos-nix_680",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3417,7 +3424,7 @@
     },
     "logos-cpp-sdk_69": {
       "inputs": {
-        "logos-nix": "logos-nix_685",
+        "logos-nix": "logos-nix_687",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3474,7 +3481,7 @@
     },
     "logos-cpp-sdk_70": {
       "inputs": {
-        "logos-nix": "logos-nix_694",
+        "logos-nix": "logos-nix_696",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3504,7 +3511,7 @@
     },
     "logos-cpp-sdk_71": {
       "inputs": {
-        "logos-nix": "logos-nix_696",
+        "logos-nix": "logos-nix_698",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3536,7 +3543,7 @@
     },
     "logos-cpp-sdk_72": {
       "inputs": {
-        "logos-nix": "logos-nix_699",
+        "logos-nix": "logos-nix_701",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3567,7 +3574,7 @@
     },
     "logos-cpp-sdk_73": {
       "inputs": {
-        "logos-nix": "logos-nix_727",
+        "logos-nix": "logos-nix_729",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3594,7 +3601,7 @@
     },
     "logos-cpp-sdk_74": {
       "inputs": {
-        "logos-nix": "logos-nix_729",
+        "logos-nix": "logos-nix_731",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3624,7 +3631,7 @@
     },
     "logos-cpp-sdk_75": {
       "inputs": {
-        "logos-nix": "logos-nix_738",
+        "logos-nix": "logos-nix_740",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3655,7 +3662,7 @@
     },
     "logos-cpp-sdk_76": {
       "inputs": {
-        "logos-nix": "logos-nix_740",
+        "logos-nix": "logos-nix_742",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3688,7 +3695,7 @@
     },
     "logos-cpp-sdk_77": {
       "inputs": {
-        "logos-nix": "logos-nix_743",
+        "logos-nix": "logos-nix_745",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3720,7 +3727,7 @@
     },
     "logos-cpp-sdk_78": {
       "inputs": {
-        "logos-nix": "logos-nix_771",
+        "logos-nix": "logos-nix_773",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3871,7 +3878,7 @@
     },
     "logos-design-system_10": {
       "inputs": {
-        "logos-nix": "logos-nix_419",
+        "logos-nix": "logos-nix_421",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3901,7 +3908,7 @@
     },
     "logos-design-system_11": {
       "inputs": {
-        "logos-nix": "logos-nix_473",
+        "logos-nix": "logos-nix_475",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3932,7 +3939,7 @@
     },
     "logos-design-system_12": {
       "inputs": {
-        "logos-nix": "logos-nix_524",
+        "logos-nix": "logos-nix_526",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3963,7 +3970,7 @@
     },
     "logos-design-system_13": {
       "inputs": {
-        "logos-nix": "logos-nix_567",
+        "logos-nix": "logos-nix_569",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -3995,7 +4002,7 @@
     },
     "logos-design-system_14": {
       "inputs": {
-        "logos-nix": "logos-nix_633",
+        "logos-nix": "logos-nix_635",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -4024,7 +4031,7 @@
     },
     "logos-design-system_15": {
       "inputs": {
-        "logos-nix": "logos-nix_695",
+        "logos-nix": "logos-nix_697",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -4054,7 +4061,7 @@
     },
     "logos-design-system_16": {
       "inputs": {
-        "logos-nix": "logos-nix_728",
+        "logos-nix": "logos-nix_730",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -4081,7 +4088,7 @@
     },
     "logos-design-system_17": {
       "inputs": {
-        "logos-nix": "logos-nix_739",
+        "logos-nix": "logos-nix_741",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -4122,11 +4129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778224414,
-        "narHash": "sha256-QSSCCE4eKGiIS5PqHDfk9Lj4VFmeCh18khbFWrGxvvc=",
+        "lastModified": 1780947586,
+        "narHash": "sha256-0l5Xjbx9bLRc6LF0FU3LZ15RmEYK9oOPy/EaOxQYHkc=",
         "owner": "logos-co",
         "repo": "logos-design-system",
-        "rev": "6176f0d7a5dfeb64a7f0f98e7ca2bf71a4804772",
+        "rev": "4a37b34446ef4e55b16a5aeb011ffc5e8cbcbbb8",
         "type": "github"
       },
       "original": {
@@ -4166,7 +4173,7 @@
     },
     "logos-design-system_4": {
       "inputs": {
-        "logos-nix": "logos-nix_134",
+        "logos-nix": "logos-nix_136",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -4193,7 +4200,7 @@
     },
     "logos-design-system_5": {
       "inputs": {
-        "logos-nix": "logos-nix_194",
+        "logos-nix": "logos-nix_196",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -4224,7 +4231,7 @@
     },
     "logos-design-system_6": {
       "inputs": {
-        "logos-nix": "logos-nix_227",
+        "logos-nix": "logos-nix_229",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -4252,7 +4259,7 @@
     },
     "logos-design-system_7": {
       "inputs": {
-        "logos-nix": "logos-nix_238",
+        "logos-nix": "logos-nix_240",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -4284,7 +4291,7 @@
     },
     "logos-design-system_8": {
       "inputs": {
-        "logos-nix": "logos-nix_325",
+        "logos-nix": "logos-nix_327",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -4313,7 +4320,7 @@
     },
     "logos-design-system_9": {
       "inputs": {
-        "logos-nix": "logos-nix_376",
+        "logos-nix": "logos-nix_378",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -4377,7 +4384,7 @@
         "logos-capability-module": "logos-capability-module_19",
         "logos-cpp-sdk": "logos-cpp-sdk_35",
         "logos-module": "logos-module_46",
-        "logos-nix": "logos-nix_331",
+        "logos-nix": "logos-nix_333",
         "logos-package-manager": "logos-package-manager_16",
         "nixpkgs": [
           "logoscore-cli",
@@ -4410,7 +4417,7 @@
         "logos-capability-module": "logos-capability-module_22",
         "logos-cpp-sdk": "logos-cpp-sdk_40",
         "logos-module": "logos-module_53",
-        "logos-nix": "logos-nix_382",
+        "logos-nix": "logos-nix_384",
         "logos-package-manager": "logos-package-manager_19",
         "nixpkgs": [
           "logoscore-cli",
@@ -4443,7 +4450,7 @@
         "logos-capability-module": "logos-capability-module_23",
         "logos-cpp-sdk": "logos-cpp-sdk_46",
         "logos-module": "logos-module_60",
-        "logos-nix": "logos-nix_453",
+        "logos-nix": "logos-nix_455",
         "logos-package-manager": "logos-package-manager_23",
         "nixpkgs": [
           "logoscore-cli",
@@ -4474,7 +4481,7 @@
         "logos-capability-module": "logos-capability-module_25",
         "logos-cpp-sdk": "logos-cpp-sdk_45",
         "logos-module": "logos-module_59",
-        "logos-nix": "logos-nix_425",
+        "logos-nix": "logos-nix_427",
         "logos-package-manager": "logos-package-manager_21",
         "nixpkgs": [
           "logoscore-cli",
@@ -4508,7 +4515,7 @@
         "logos-capability-module": "logos-capability-module_26",
         "logos-cpp-sdk": "logos-cpp-sdk_52",
         "logos-module": "logos-module_67",
-        "logos-nix": "logos-nix_507",
+        "logos-nix": "logos-nix_509",
         "logos-package-manager": "logos-package-manager_26",
         "nixpkgs": [
           "logoscore-cli",
@@ -4540,7 +4547,7 @@
         "logos-capability-module": "logos-capability-module_28",
         "logos-cpp-sdk": "logos-cpp-sdk_51",
         "logos-module": "logos-module_66",
-        "logos-nix": "logos-nix_479",
+        "logos-nix": "logos-nix_481",
         "logos-package-manager": "logos-package-manager_24",
         "nixpkgs": [
           "logoscore-cli",
@@ -4575,7 +4582,7 @@
         "logos-capability-module": "logos-capability-module_31",
         "logos-cpp-sdk": "logos-cpp-sdk_56",
         "logos-module": "logos-module_73",
-        "logos-nix": "logos-nix_530",
+        "logos-nix": "logos-nix_532",
         "logos-package-manager": "logos-package-manager_27",
         "nixpkgs": [
           "logoscore-cli",
@@ -4610,7 +4617,7 @@
         "logos-capability-module": "logos-capability-module_32",
         "logos-cpp-sdk": "logos-cpp-sdk_62",
         "logos-module": "logos-module_80",
-        "logos-nix": "logos-nix_601",
+        "logos-nix": "logos-nix_603",
         "logos-package-manager": "logos-package-manager_31",
         "nixpkgs": [
           "logoscore-cli",
@@ -4643,7 +4650,7 @@
         "logos-capability-module": "logos-capability-module_34",
         "logos-cpp-sdk": "logos-cpp-sdk_61",
         "logos-module": "logos-module_79",
-        "logos-nix": "logos-nix_573",
+        "logos-nix": "logos-nix_575",
         "logos-package-manager": "logos-package-manager_29",
         "nixpkgs": [
           "logoscore-cli",
@@ -4679,7 +4686,7 @@
         "logos-capability-module": "logos-capability-module_36",
         "logos-cpp-sdk": "logos-cpp-sdk_67",
         "logos-module": "logos-module_86",
-        "logos-nix": "logos-nix_639",
+        "logos-nix": "logos-nix_641",
         "logos-package-manager": "logos-package-manager_33",
         "nixpkgs": [
           "logoscore-cli",
@@ -4714,6 +4721,8 @@
         "logos-module": "logos-module_16",
         "logos-nix": "logos-nix_98",
         "logos-package-manager": "logos-package-manager_5",
+        "logos-protocol": "logos-protocol_3",
+        "logos-qt-sdk": "logos-qt-sdk_2",
         "nixpkgs": [
           "logos-module-builder",
           "logos-standalone-app",
@@ -4724,11 +4733,11 @@
         "process-stats": "process-stats_3"
       },
       "locked": {
-        "lastModified": 1779724404,
-        "narHash": "sha256-HKgY1cbcm1BgFau0KBJba0pKGNZ/7oJMcqJMhPDQ20Q=",
+        "lastModified": 1781311549,
+        "narHash": "sha256-1laKvOevI1RrXQxllvlXFJnFmRQWLbvWfmbUZ02O7NY=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "be7c8fd8e89e9c7506421735e18dc85bde0c1cb2",
+        "rev": "050f2d36284d29e0660a4086b5a8af49fd70f4ff",
         "type": "github"
       },
       "original": {
@@ -4742,7 +4751,7 @@
         "logos-capability-module": "logos-capability-module_39",
         "logos-cpp-sdk": "logos-cpp-sdk_72",
         "logos-module": "logos-module_95",
-        "logos-nix": "logos-nix_701",
+        "logos-nix": "logos-nix_703",
         "logos-package-manager": "logos-package-manager_36",
         "nixpkgs": [
           "logoscore-cli",
@@ -4776,7 +4785,7 @@
         "logos-capability-module": "logos-capability-module_40",
         "logos-cpp-sdk": "logos-cpp-sdk_78",
         "logos-module": "logos-module_102",
-        "logos-nix": "logos-nix_773",
+        "logos-nix": "logos-nix_775",
         "logos-package-manager": "logos-package-manager_40",
         "nixpkgs": [
           "logoscore-cli",
@@ -4808,7 +4817,7 @@
         "logos-capability-module": "logos-capability-module_42",
         "logos-cpp-sdk": "logos-cpp-sdk_77",
         "logos-module": "logos-module_101",
-        "logos-nix": "logos-nix_745",
+        "logos-nix": "logos-nix_747",
         "logos-package-manager": "logos-package-manager_38",
         "nixpkgs": [
           "logoscore-cli",
@@ -4876,7 +4885,7 @@
         "logos-capability-module": "logos-capability-module_9",
         "logos-cpp-sdk": "logos-cpp-sdk_16",
         "logos-module": "logos-module_22",
-        "logos-nix": "logos-nix_140",
+        "logos-nix": "logos-nix_142",
         "logos-package-manager": "logos-package-manager_7",
         "nixpkgs": [
           "logoscore-cli",
@@ -4911,10 +4920,10 @@
         "logos-cpp-sdk": "logos-cpp-sdk_31",
         "logos-module": "logos-module_40",
         "logos-module-loader": "logos-module-loader_2",
-        "logos-nix": "logos-nix_303",
+        "logos-nix": "logos-nix_305",
         "logos-package-manager": "logos-package-manager_15",
-        "logos-protocol": "logos-protocol_4",
-        "logos-qt-sdk": "logos-qt-sdk_4",
+        "logos-protocol": "logos-protocol_9",
+        "logos-qt-sdk": "logos-qt-sdk_7",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -4942,7 +4951,7 @@
         "logos-capability-module": "logos-capability-module_13",
         "logos-cpp-sdk": "logos-cpp-sdk_23",
         "logos-module": "logos-module_32",
-        "logos-nix": "logos-nix_200",
+        "logos-nix": "logos-nix_202",
         "logos-package-manager": "logos-package-manager_9",
         "nixpkgs": [
           "logoscore-cli",
@@ -4977,7 +4986,7 @@
         "logos-capability-module": "logos-capability-module_14",
         "logos-cpp-sdk": "logos-cpp-sdk_29",
         "logos-module": "logos-module_39",
-        "logos-nix": "logos-nix_272",
+        "logos-nix": "logos-nix_274",
         "logos-package-manager": "logos-package-manager_13",
         "nixpkgs": [
           "logoscore-cli",
@@ -5010,7 +5019,7 @@
         "logos-capability-module": "logos-capability-module_16",
         "logos-cpp-sdk": "logos-cpp-sdk_28",
         "logos-module": "logos-module_38",
-        "logos-nix": "logos-nix_244",
+        "logos-nix": "logos-nix_246",
         "logos-package-manager": "logos-package-manager_11",
         "nixpkgs": [
           "logoscore-cli",
@@ -5046,7 +5055,7 @@
         "logos-capability-module": "logos-capability-module_17",
         "logos-cpp-sdk": "logos-cpp-sdk_36",
         "logos-module": "logos-module_47",
-        "logos-nix": "logos-nix_359",
+        "logos-nix": "logos-nix_361",
         "logos-package-manager": "logos-package-manager_18",
         "nixpkgs": [
           "logoscore-cli",
@@ -5292,7 +5301,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_41",
         "logos-liblogos": "logos-liblogos_12",
         "logos-module-client": "logos-module-client",
-        "logos-nix": "logos-nix_462",
+        "logos-nix": "logos-nix_464",
         "logos-test-modules": "logos-test-modules_2",
         "nix-bundle-appimage": "nix-bundle-appimage_36",
         "nix-bundle-dir": "nix-bundle-dir_115",
@@ -5325,7 +5334,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_57",
         "logos-liblogos": "logos-liblogos_17",
         "logos-module-client": "logos-module-client_2",
-        "logos-nix": "logos-nix_610",
+        "logos-nix": "logos-nix_612",
         "nix-bundle-appimage": "nix-bundle-appimage_32",
         "nix-bundle-dir": "nix-bundle-dir_103",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_14",
@@ -5364,11 +5373,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781311603,
-        "narHash": "sha256-Ym3i52f5MWuZy8Qas3+zfoxz+mxQUsyW+Qol1no6kDs=",
+        "lastModified": 1781873810,
+        "narHash": "sha256-GDUq1PFeN24RmXAcb7l2GH9YyjPQeLxg0hfeKOUxcmo=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "a3e288a71d6f79445db598b0ffcca2ee435596b9",
+        "rev": "7583396720a33153f4bec85c1464bc463fb95477",
         "type": "github"
       },
       "original": {
@@ -5399,11 +5408,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1782146416,
-        "narHash": "sha256-WkkDTc8p0YkZ5H1w9KmYih0WFT1+k/yjPKXtM3Mt6+E=",
+        "lastModified": 1782297704,
+        "narHash": "sha256-7BtfWuFsBvZ9dBcF2LjZttXhHzt/3tuHI7TJ4p+w2E0=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "f4942648c28127d4ef4d4b467b22bd33873ab4fa",
+        "rev": "0325d6aa9d5737fca461482c204f594339da24e2",
         "type": "github"
       },
       "original": {
@@ -5416,7 +5425,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_42",
         "logos-module": "logos-module_54",
-        "logos-nix": "logos-nix_411",
+        "logos-nix": "logos-nix_413",
         "logos-plugin-core": "logos-plugin-core_10",
         "logos-plugin-qt": "logos-plugin-qt_10",
         "logos-standalone-app": "logos-standalone-app_10",
@@ -5452,7 +5461,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_48",
         "logos-module": "logos-module_61",
-        "logos-nix": "logos-nix_465",
+        "logos-nix": "logos-nix_467",
         "logos-plugin-core": "logos-plugin-core_11",
         "logos-plugin-qt": "logos-plugin-qt_11",
         "logos-standalone-app": "logos-standalone-app_11",
@@ -5489,7 +5498,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_53",
         "logos-module": "logos-module_68",
-        "logos-nix": "logos-nix_516",
+        "logos-nix": "logos-nix_518",
         "logos-plugin-core": "logos-plugin-core_12",
         "logos-plugin-qt": "logos-plugin-qt_12",
         "logos-standalone-app": "logos-standalone-app_12",
@@ -5526,7 +5535,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_58",
         "logos-module": "logos-module_74",
-        "logos-nix": "logos-nix_559",
+        "logos-nix": "logos-nix_561",
         "logos-plugin-core": "logos-plugin-core_13",
         "logos-plugin-qt": "logos-plugin-qt_13",
         "logos-standalone-app": "logos-standalone-app_13",
@@ -5564,7 +5573,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_64",
         "logos-module": "logos-module_81",
-        "logos-nix": "logos-nix_625",
+        "logos-nix": "logos-nix_627",
         "logos-plugin-core": "logos-plugin-core_14",
         "logos-plugin-qt": "logos-plugin-qt_14",
         "logos-standalone-app": "logos-standalone-app_14",
@@ -5599,7 +5608,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_68",
         "logos-module": "logos-module_87",
-        "logos-nix": "logos-nix_680",
+        "logos-nix": "logos-nix_682",
         "logos-plugin-core": "logos-plugin-core_15",
         "logos-plugin-qt": "logos-plugin-qt_15",
         "logos-standalone-app": "logos-standalone-app_15",
@@ -5632,7 +5641,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_69",
         "logos-module": "logos-module_90",
-        "logos-nix": "logos-nix_687",
+        "logos-nix": "logos-nix_689",
         "logos-plugin-core": "logos-plugin-core_16",
         "logos-plugin-qt": "logos-plugin-qt_16",
         "logos-standalone-app": "logos-standalone-app_16",
@@ -5668,7 +5677,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_74",
         "logos-module": "logos-module_96",
-        "logos-nix": "logos-nix_731",
+        "logos-nix": "logos-nix_733",
         "logos-plugin-core": "logos-plugin-core_17",
         "logos-plugin-qt": "logos-plugin-qt_17",
         "logos-standalone-app": "logos-standalone-app_17",
@@ -5774,7 +5783,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_13",
         "logos-module": "logos-module_17",
-        "logos-nix": "logos-nix_126",
+        "logos-nix": "logos-nix_128",
         "logos-plugin-core": "logos-plugin-core_4",
         "logos-plugin-qt": "logos-plugin-qt_4",
         "logos-standalone-app": "logos-standalone-app_4",
@@ -5807,7 +5816,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_19",
         "logos-module": "logos-module_24",
-        "logos-nix": "logos-nix_179",
+        "logos-nix": "logos-nix_181",
         "logos-plugin-core": "logos-plugin-core_5",
         "logos-plugin-qt": "logos-plugin-qt_5",
         "logos-standalone-app": "logos-standalone-app_5",
@@ -5841,7 +5850,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_20",
         "logos-module": "logos-module_27",
-        "logos-nix": "logos-nix_186",
+        "logos-nix": "logos-nix_188",
         "logos-plugin-core": "logos-plugin-core_6",
         "logos-plugin-qt": "logos-plugin-qt_6",
         "logos-standalone-app": "logos-standalone-app_6",
@@ -5878,7 +5887,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_25",
         "logos-module": "logos-module_33",
-        "logos-nix": "logos-nix_230",
+        "logos-nix": "logos-nix_232",
         "logos-plugin-core": "logos-plugin-core_7",
         "logos-plugin-qt": "logos-plugin-qt_7",
         "logos-standalone-app": "logos-standalone-app_7",
@@ -5916,7 +5925,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_32",
         "logos-module": "logos-module_41",
-        "logos-nix": "logos-nix_317",
+        "logos-nix": "logos-nix_319",
         "logos-plugin-core": "logos-plugin-core_8",
         "logos-plugin-qt": "logos-plugin-qt_8",
         "logos-standalone-app": "logos-standalone-app_8",
@@ -5951,7 +5960,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_37",
         "logos-module": "logos-module_48",
-        "logos-nix": "logos-nix_368",
+        "logos-nix": "logos-nix_370",
         "logos-plugin-core": "logos-plugin-core_9",
         "logos-plugin-qt": "logos-plugin-qt_9",
         "logos-standalone-app": "logos-standalone-app_9",
@@ -5985,7 +5994,7 @@
     "logos-module-client": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_47",
-        "logos-nix": "logos-nix_461",
+        "logos-nix": "logos-nix_463",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -6012,7 +6021,7 @@
     "logos-module-client_2": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_63",
-        "logos-nix": "logos-nix_609",
+        "logos-nix": "logos-nix_611",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -6041,7 +6050,7 @@
     "logos-module-loader": {
       "inputs": {
         "logos-container": "logos-container_3",
-        "logos-nix": "logos-nix_173",
+        "logos-nix": "logos-nix_175",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -6068,7 +6077,7 @@
     "logos-module-loader_2": {
       "inputs": {
         "logos-container": "logos-container_5",
-        "logos-nix": "logos-nix_302",
+        "logos-nix": "logos-nix_304",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -6121,7 +6130,7 @@
     },
     "logos-module_100": {
       "inputs": {
-        "logos-nix": "logos-nix_741",
+        "logos-nix": "logos-nix_743",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -6154,7 +6163,7 @@
     },
     "logos-module_101": {
       "inputs": {
-        "logos-nix": "logos-nix_744",
+        "logos-nix": "logos-nix_746",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -6186,7 +6195,7 @@
     },
     "logos-module_102": {
       "inputs": {
-        "logos-nix": "logos-nix_772",
+        "logos-nix": "logos-nix_774",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -6374,11 +6383,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "lastModified": 1781310867,
+        "narHash": "sha256-Ym3i52f5MWuZy8Qas3+zfoxz+mxQUsyW+Qol1no6kDs=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "rev": "b42805dac2874d8f72e1c12f7ac6a92ca7e5452c",
         "type": "github"
       },
       "original": {
@@ -6389,7 +6398,7 @@
     },
     "logos-module_17": {
       "inputs": {
-        "logos-nix": "logos-nix_125",
+        "logos-nix": "logos-nix_127",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -6415,7 +6424,7 @@
     },
     "logos-module_18": {
       "inputs": {
-        "logos-nix": "logos-nix_127",
+        "logos-nix": "logos-nix_129",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -6442,7 +6451,7 @@
     },
     "logos-module_19": {
       "inputs": {
-        "logos-nix": "logos-nix_129",
+        "logos-nix": "logos-nix_131",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -6494,7 +6503,7 @@
     },
     "logos-module_20": {
       "inputs": {
-        "logos-nix": "logos-nix_131",
+        "logos-nix": "logos-nix_133",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -6522,7 +6531,7 @@
     },
     "logos-module_21": {
       "inputs": {
-        "logos-nix": "logos-nix_136",
+        "logos-nix": "logos-nix_138",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -6551,7 +6560,7 @@
     },
     "logos-module_22": {
       "inputs": {
-        "logos-nix": "logos-nix_139",
+        "logos-nix": "logos-nix_141",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -6579,7 +6588,7 @@
     },
     "logos-module_23": {
       "inputs": {
-        "logos-nix": "logos-nix_171",
+        "logos-nix": "logos-nix_173",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -6605,7 +6614,7 @@
     },
     "logos-module_24": {
       "inputs": {
-        "logos-nix": "logos-nix_178",
+        "logos-nix": "logos-nix_180",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -6632,7 +6641,7 @@
     },
     "logos-module_25": {
       "inputs": {
-        "logos-nix": "logos-nix_180",
+        "logos-nix": "logos-nix_182",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -6660,7 +6669,7 @@
     },
     "logos-module_26": {
       "inputs": {
-        "logos-nix": "logos-nix_182",
+        "logos-nix": "logos-nix_184",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -6688,7 +6697,7 @@
     },
     "logos-module_27": {
       "inputs": {
-        "logos-nix": "logos-nix_185",
+        "logos-nix": "logos-nix_187",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -6718,7 +6727,7 @@
     },
     "logos-module_28": {
       "inputs": {
-        "logos-nix": "logos-nix_187",
+        "logos-nix": "logos-nix_189",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -6749,7 +6758,7 @@
     },
     "logos-module_29": {
       "inputs": {
-        "logos-nix": "logos-nix_189",
+        "logos-nix": "logos-nix_191",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -6805,7 +6814,7 @@
     },
     "logos-module_30": {
       "inputs": {
-        "logos-nix": "logos-nix_191",
+        "logos-nix": "logos-nix_193",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -6837,7 +6846,7 @@
     },
     "logos-module_31": {
       "inputs": {
-        "logos-nix": "logos-nix_196",
+        "logos-nix": "logos-nix_198",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -6870,7 +6879,7 @@
     },
     "logos-module_32": {
       "inputs": {
-        "logos-nix": "logos-nix_199",
+        "logos-nix": "logos-nix_201",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -6902,7 +6911,7 @@
     },
     "logos-module_33": {
       "inputs": {
-        "logos-nix": "logos-nix_229",
+        "logos-nix": "logos-nix_231",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -6933,7 +6942,7 @@
     },
     "logos-module_34": {
       "inputs": {
-        "logos-nix": "logos-nix_231",
+        "logos-nix": "logos-nix_233",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -6965,7 +6974,7 @@
     },
     "logos-module_35": {
       "inputs": {
-        "logos-nix": "logos-nix_233",
+        "logos-nix": "logos-nix_235",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -6997,7 +7006,7 @@
     },
     "logos-module_36": {
       "inputs": {
-        "logos-nix": "logos-nix_235",
+        "logos-nix": "logos-nix_237",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -7030,7 +7039,7 @@
     },
     "logos-module_37": {
       "inputs": {
-        "logos-nix": "logos-nix_240",
+        "logos-nix": "logos-nix_242",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -7064,7 +7073,7 @@
     },
     "logos-module_38": {
       "inputs": {
-        "logos-nix": "logos-nix_243",
+        "logos-nix": "logos-nix_245",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -7097,7 +7106,7 @@
     },
     "logos-module_39": {
       "inputs": {
-        "logos-nix": "logos-nix_271",
+        "logos-nix": "logos-nix_273",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -7153,7 +7162,7 @@
     },
     "logos-module_40": {
       "inputs": {
-        "logos-nix": "logos-nix_300",
+        "logos-nix": "logos-nix_302",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -7178,7 +7187,7 @@
     },
     "logos-module_41": {
       "inputs": {
-        "logos-nix": "logos-nix_316",
+        "logos-nix": "logos-nix_318",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7206,7 +7215,7 @@
     },
     "logos-module_42": {
       "inputs": {
-        "logos-nix": "logos-nix_318",
+        "logos-nix": "logos-nix_320",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7235,7 +7244,7 @@
     },
     "logos-module_43": {
       "inputs": {
-        "logos-nix": "logos-nix_320",
+        "logos-nix": "logos-nix_322",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7264,7 +7273,7 @@
     },
     "logos-module_44": {
       "inputs": {
-        "logos-nix": "logos-nix_322",
+        "logos-nix": "logos-nix_324",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7294,7 +7303,7 @@
     },
     "logos-module_45": {
       "inputs": {
-        "logos-nix": "logos-nix_327",
+        "logos-nix": "logos-nix_329",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7325,7 +7334,7 @@
     },
     "logos-module_46": {
       "inputs": {
-        "logos-nix": "logos-nix_330",
+        "logos-nix": "logos-nix_332",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7355,7 +7364,7 @@
     },
     "logos-module_47": {
       "inputs": {
-        "logos-nix": "logos-nix_358",
+        "logos-nix": "logos-nix_360",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7381,7 +7390,7 @@
     },
     "logos-module_48": {
       "inputs": {
-        "logos-nix": "logos-nix_367",
+        "logos-nix": "logos-nix_369",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7409,7 +7418,7 @@
     },
     "logos-module_49": {
       "inputs": {
-        "logos-nix": "logos-nix_369",
+        "logos-nix": "logos-nix_371",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7466,7 +7475,7 @@
     },
     "logos-module_50": {
       "inputs": {
-        "logos-nix": "logos-nix_371",
+        "logos-nix": "logos-nix_373",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7495,7 +7504,7 @@
     },
     "logos-module_51": {
       "inputs": {
-        "logos-nix": "logos-nix_373",
+        "logos-nix": "logos-nix_375",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7525,7 +7534,7 @@
     },
     "logos-module_52": {
       "inputs": {
-        "logos-nix": "logos-nix_378",
+        "logos-nix": "logos-nix_380",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7556,7 +7565,7 @@
     },
     "logos-module_53": {
       "inputs": {
-        "logos-nix": "logos-nix_381",
+        "logos-nix": "logos-nix_383",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7586,7 +7595,7 @@
     },
     "logos-module_54": {
       "inputs": {
-        "logos-nix": "logos-nix_410",
+        "logos-nix": "logos-nix_412",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7615,7 +7624,7 @@
     },
     "logos-module_55": {
       "inputs": {
-        "logos-nix": "logos-nix_412",
+        "logos-nix": "logos-nix_414",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7645,7 +7654,7 @@
     },
     "logos-module_56": {
       "inputs": {
-        "logos-nix": "logos-nix_414",
+        "logos-nix": "logos-nix_416",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7675,7 +7684,7 @@
     },
     "logos-module_57": {
       "inputs": {
-        "logos-nix": "logos-nix_416",
+        "logos-nix": "logos-nix_418",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7706,7 +7715,7 @@
     },
     "logos-module_58": {
       "inputs": {
-        "logos-nix": "logos-nix_421",
+        "logos-nix": "logos-nix_423",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7738,7 +7747,7 @@
     },
     "logos-module_59": {
       "inputs": {
-        "logos-nix": "logos-nix_424",
+        "logos-nix": "logos-nix_426",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7797,7 +7806,7 @@
     },
     "logos-module_60": {
       "inputs": {
-        "logos-nix": "logos-nix_452",
+        "logos-nix": "logos-nix_454",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7824,7 +7833,7 @@
     },
     "logos-module_61": {
       "inputs": {
-        "logos-nix": "logos-nix_464",
+        "logos-nix": "logos-nix_466",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7854,7 +7863,7 @@
     },
     "logos-module_62": {
       "inputs": {
-        "logos-nix": "logos-nix_466",
+        "logos-nix": "logos-nix_468",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7885,7 +7894,7 @@
     },
     "logos-module_63": {
       "inputs": {
-        "logos-nix": "logos-nix_468",
+        "logos-nix": "logos-nix_470",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7916,7 +7925,7 @@
     },
     "logos-module_64": {
       "inputs": {
-        "logos-nix": "logos-nix_470",
+        "logos-nix": "logos-nix_472",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7948,7 +7957,7 @@
     },
     "logos-module_65": {
       "inputs": {
-        "logos-nix": "logos-nix_475",
+        "logos-nix": "logos-nix_477",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -7981,7 +7990,7 @@
     },
     "logos-module_66": {
       "inputs": {
-        "logos-nix": "logos-nix_478",
+        "logos-nix": "logos-nix_480",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8013,7 +8022,7 @@
     },
     "logos-module_67": {
       "inputs": {
-        "logos-nix": "logos-nix_506",
+        "logos-nix": "logos-nix_508",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8041,7 +8050,7 @@
     },
     "logos-module_68": {
       "inputs": {
-        "logos-nix": "logos-nix_515",
+        "logos-nix": "logos-nix_517",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8071,7 +8080,7 @@
     },
     "logos-module_69": {
       "inputs": {
-        "logos-nix": "logos-nix_517",
+        "logos-nix": "logos-nix_519",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8131,7 +8140,7 @@
     },
     "logos-module_70": {
       "inputs": {
-        "logos-nix": "logos-nix_519",
+        "logos-nix": "logos-nix_521",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8162,7 +8171,7 @@
     },
     "logos-module_71": {
       "inputs": {
-        "logos-nix": "logos-nix_521",
+        "logos-nix": "logos-nix_523",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8194,7 +8203,7 @@
     },
     "logos-module_72": {
       "inputs": {
-        "logos-nix": "logos-nix_526",
+        "logos-nix": "logos-nix_528",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8227,7 +8236,7 @@
     },
     "logos-module_73": {
       "inputs": {
-        "logos-nix": "logos-nix_529",
+        "logos-nix": "logos-nix_531",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8259,7 +8268,7 @@
     },
     "logos-module_74": {
       "inputs": {
-        "logos-nix": "logos-nix_558",
+        "logos-nix": "logos-nix_560",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8290,7 +8299,7 @@
     },
     "logos-module_75": {
       "inputs": {
-        "logos-nix": "logos-nix_560",
+        "logos-nix": "logos-nix_562",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8322,7 +8331,7 @@
     },
     "logos-module_76": {
       "inputs": {
-        "logos-nix": "logos-nix_562",
+        "logos-nix": "logos-nix_564",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8354,7 +8363,7 @@
     },
     "logos-module_77": {
       "inputs": {
-        "logos-nix": "logos-nix_564",
+        "logos-nix": "logos-nix_566",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8387,7 +8396,7 @@
     },
     "logos-module_78": {
       "inputs": {
-        "logos-nix": "logos-nix_569",
+        "logos-nix": "logos-nix_571",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8421,7 +8430,7 @@
     },
     "logos-module_79": {
       "inputs": {
-        "logos-nix": "logos-nix_572",
+        "logos-nix": "logos-nix_574",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8484,7 +8493,7 @@
     },
     "logos-module_80": {
       "inputs": {
-        "logos-nix": "logos-nix_600",
+        "logos-nix": "logos-nix_602",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8513,7 +8522,7 @@
     },
     "logos-module_81": {
       "inputs": {
-        "logos-nix": "logos-nix_624",
+        "logos-nix": "logos-nix_626",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8541,7 +8550,7 @@
     },
     "logos-module_82": {
       "inputs": {
-        "logos-nix": "logos-nix_626",
+        "logos-nix": "logos-nix_628",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8570,7 +8579,7 @@
     },
     "logos-module_83": {
       "inputs": {
-        "logos-nix": "logos-nix_628",
+        "logos-nix": "logos-nix_630",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8599,7 +8608,7 @@
     },
     "logos-module_84": {
       "inputs": {
-        "logos-nix": "logos-nix_630",
+        "logos-nix": "logos-nix_632",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8629,7 +8638,7 @@
     },
     "logos-module_85": {
       "inputs": {
-        "logos-nix": "logos-nix_635",
+        "logos-nix": "logos-nix_637",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8660,7 +8669,7 @@
     },
     "logos-module_86": {
       "inputs": {
-        "logos-nix": "logos-nix_638",
+        "logos-nix": "logos-nix_640",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8690,7 +8699,7 @@
     },
     "logos-module_87": {
       "inputs": {
-        "logos-nix": "logos-nix_679",
+        "logos-nix": "logos-nix_681",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8716,7 +8725,7 @@
     },
     "logos-module_88": {
       "inputs": {
-        "logos-nix": "logos-nix_681",
+        "logos-nix": "logos-nix_683",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8743,7 +8752,7 @@
     },
     "logos-module_89": {
       "inputs": {
-        "logos-nix": "logos-nix_683",
+        "logos-nix": "logos-nix_685",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8799,7 +8808,7 @@
     },
     "logos-module_90": {
       "inputs": {
-        "logos-nix": "logos-nix_686",
+        "logos-nix": "logos-nix_688",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8828,7 +8837,7 @@
     },
     "logos-module_91": {
       "inputs": {
-        "logos-nix": "logos-nix_688",
+        "logos-nix": "logos-nix_690",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8858,7 +8867,7 @@
     },
     "logos-module_92": {
       "inputs": {
-        "logos-nix": "logos-nix_690",
+        "logos-nix": "logos-nix_692",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8888,7 +8897,7 @@
     },
     "logos-module_93": {
       "inputs": {
-        "logos-nix": "logos-nix_692",
+        "logos-nix": "logos-nix_694",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8919,7 +8928,7 @@
     },
     "logos-module_94": {
       "inputs": {
-        "logos-nix": "logos-nix_697",
+        "logos-nix": "logos-nix_699",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8951,7 +8960,7 @@
     },
     "logos-module_95": {
       "inputs": {
-        "logos-nix": "logos-nix_700",
+        "logos-nix": "logos-nix_702",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -8982,7 +8991,7 @@
     },
     "logos-module_96": {
       "inputs": {
-        "logos-nix": "logos-nix_730",
+        "logos-nix": "logos-nix_732",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -9012,7 +9021,7 @@
     },
     "logos-module_97": {
       "inputs": {
-        "logos-nix": "logos-nix_732",
+        "logos-nix": "logos-nix_734",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -9043,7 +9052,7 @@
     },
     "logos-module_98": {
       "inputs": {
-        "logos-nix": "logos-nix_734",
+        "logos-nix": "logos-nix_736",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -9074,7 +9083,7 @@
     },
     "logos-module_99": {
       "inputs": {
-        "logos-nix": "logos-nix_736",
+        "logos-nix": "logos-nix_738",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -9217,11 +9226,11 @@
         "nixpkgs": "nixpkgs_105"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9289,11 +9298,11 @@
         "nixpkgs": "nixpkgs_109"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -9307,11 +9316,11 @@
         "nixpkgs": "nixpkgs_110"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9343,11 +9352,11 @@
         "nixpkgs": "nixpkgs_111"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9361,11 +9370,11 @@
         "nixpkgs": "nixpkgs_112"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -9379,11 +9388,11 @@
         "nixpkgs": "nixpkgs_113"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -9397,11 +9406,11 @@
         "nixpkgs": "nixpkgs_114"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9415,11 +9424,11 @@
         "nixpkgs": "nixpkgs_115"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9433,11 +9442,11 @@
         "nixpkgs": "nixpkgs_116"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -9451,11 +9460,11 @@
         "nixpkgs": "nixpkgs_117"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -9469,11 +9478,11 @@
         "nixpkgs": "nixpkgs_118"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9487,11 +9496,11 @@
         "nixpkgs": "nixpkgs_119"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9559,11 +9568,11 @@
         "nixpkgs": "nixpkgs_122"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -9595,11 +9604,11 @@
         "nixpkgs": "nixpkgs_124"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9613,11 +9622,11 @@
         "nixpkgs": "nixpkgs_125"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -9775,11 +9784,11 @@
         "nixpkgs": "nixpkgs_133"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9793,11 +9802,11 @@
         "nixpkgs": "nixpkgs_134"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -9829,11 +9838,11 @@
         "nixpkgs": "nixpkgs_136"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9883,11 +9892,11 @@
         "nixpkgs": "nixpkgs_139"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -9955,11 +9964,11 @@
         "nixpkgs": "nixpkgs_142"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -9973,11 +9982,11 @@
         "nixpkgs": "nixpkgs_143"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -9991,11 +10000,11 @@
         "nixpkgs": "nixpkgs_144"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10063,11 +10072,11 @@
         "nixpkgs": "nixpkgs_148"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10135,11 +10144,11 @@
         "nixpkgs": "nixpkgs_151"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10153,11 +10162,11 @@
         "nixpkgs": "nixpkgs_152"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10171,11 +10180,11 @@
         "nixpkgs": "nixpkgs_153"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10189,11 +10198,11 @@
         "nixpkgs": "nixpkgs_154"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10207,11 +10216,11 @@
         "nixpkgs": "nixpkgs_155"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10225,11 +10234,11 @@
         "nixpkgs": "nixpkgs_156"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10243,11 +10252,11 @@
         "nixpkgs": "nixpkgs_157"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10261,11 +10270,11 @@
         "nixpkgs": "nixpkgs_158"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10279,11 +10288,11 @@
         "nixpkgs": "nixpkgs_159"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10297,11 +10306,11 @@
         "nixpkgs": "nixpkgs_160"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10333,11 +10342,11 @@
         "nixpkgs": "nixpkgs_161"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10387,11 +10396,11 @@
         "nixpkgs": "nixpkgs_164"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10423,11 +10432,11 @@
         "nixpkgs": "nixpkgs_166"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10441,11 +10450,11 @@
         "nixpkgs": "nixpkgs_167"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10459,11 +10468,11 @@
         "nixpkgs": "nixpkgs_168"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10549,11 +10558,11 @@
         "nixpkgs": "nixpkgs_172"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10585,11 +10594,11 @@
         "nixpkgs": "nixpkgs_174"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10675,11 +10684,11 @@
         "nixpkgs": "nixpkgs_179"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10801,11 +10810,11 @@
         "nixpkgs": "nixpkgs_185"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10819,11 +10828,11 @@
         "nixpkgs": "nixpkgs_186"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10963,11 +10972,11 @@
         "nixpkgs": "nixpkgs_193"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10981,11 +10990,11 @@
         "nixpkgs": "nixpkgs_194"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11017,11 +11026,11 @@
         "nixpkgs": "nixpkgs_196"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11071,11 +11080,11 @@
         "nixpkgs": "nixpkgs_199"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11161,11 +11170,11 @@
         "nixpkgs": "nixpkgs_202"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11179,11 +11188,11 @@
         "nixpkgs": "nixpkgs_203"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11197,11 +11206,11 @@
         "nixpkgs": "nixpkgs_204"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11269,11 +11278,11 @@
         "nixpkgs": "nixpkgs_208"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11341,11 +11350,11 @@
         "nixpkgs": "nixpkgs_211"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11359,11 +11368,11 @@
         "nixpkgs": "nixpkgs_212"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11377,11 +11386,11 @@
         "nixpkgs": "nixpkgs_213"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11395,11 +11404,11 @@
         "nixpkgs": "nixpkgs_214"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11413,11 +11422,11 @@
         "nixpkgs": "nixpkgs_215"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11431,11 +11440,11 @@
         "nixpkgs": "nixpkgs_216"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11449,11 +11458,11 @@
         "nixpkgs": "nixpkgs_217"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11467,11 +11476,11 @@
         "nixpkgs": "nixpkgs_218"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11485,11 +11494,11 @@
         "nixpkgs": "nixpkgs_219"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11503,11 +11512,11 @@
         "nixpkgs": "nixpkgs_220"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11539,11 +11548,11 @@
         "nixpkgs": "nixpkgs_221"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11593,11 +11602,11 @@
         "nixpkgs": "nixpkgs_224"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11629,11 +11638,11 @@
         "nixpkgs": "nixpkgs_226"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11647,11 +11656,11 @@
         "nixpkgs": "nixpkgs_227"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11845,11 +11854,11 @@
         "nixpkgs": "nixpkgs_237"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11863,11 +11872,11 @@
         "nixpkgs": "nixpkgs_238"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11899,11 +11908,11 @@
         "nixpkgs": "nixpkgs_240"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11971,11 +11980,11 @@
         "nixpkgs": "nixpkgs_243"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12025,11 +12034,11 @@
         "nixpkgs": "nixpkgs_246"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12043,11 +12052,11 @@
         "nixpkgs": "nixpkgs_247"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12061,11 +12070,11 @@
         "nixpkgs": "nixpkgs_248"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12151,11 +12160,11 @@
         "nixpkgs": "nixpkgs_252"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12205,11 +12214,11 @@
         "nixpkgs": "nixpkgs_255"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12223,11 +12232,11 @@
         "nixpkgs": "nixpkgs_256"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12241,11 +12250,11 @@
         "nixpkgs": "nixpkgs_257"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12259,11 +12268,11 @@
         "nixpkgs": "nixpkgs_258"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12277,11 +12286,11 @@
         "nixpkgs": "nixpkgs_259"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12295,11 +12304,11 @@
         "nixpkgs": "nixpkgs_260"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12331,11 +12340,11 @@
         "nixpkgs": "nixpkgs_261"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12349,11 +12358,11 @@
         "nixpkgs": "nixpkgs_262"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12367,11 +12376,11 @@
         "nixpkgs": "nixpkgs_263"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12385,11 +12394,11 @@
         "nixpkgs": "nixpkgs_264"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12403,11 +12412,11 @@
         "nixpkgs": "nixpkgs_265"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12457,11 +12466,11 @@
         "nixpkgs": "nixpkgs_268"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12493,11 +12502,11 @@
         "nixpkgs": "nixpkgs_270"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12529,11 +12538,11 @@
         "nixpkgs": "nixpkgs_271"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12583,11 +12592,11 @@
         "nixpkgs": "nixpkgs_274"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12601,11 +12610,11 @@
         "nixpkgs": "nixpkgs_275"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12619,11 +12628,11 @@
         "nixpkgs": "nixpkgs_276"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12691,11 +12700,11 @@
         "nixpkgs": "nixpkgs_280"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12763,11 +12772,11 @@
         "nixpkgs": "nixpkgs_283"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12781,11 +12790,11 @@
         "nixpkgs": "nixpkgs_284"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12799,11 +12808,11 @@
         "nixpkgs": "nixpkgs_285"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12817,11 +12826,11 @@
         "nixpkgs": "nixpkgs_286"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12835,11 +12844,11 @@
         "nixpkgs": "nixpkgs_287"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12853,11 +12862,11 @@
         "nixpkgs": "nixpkgs_288"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12871,11 +12880,11 @@
         "nixpkgs": "nixpkgs_289"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12889,11 +12898,11 @@
         "nixpkgs": "nixpkgs_290"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12925,11 +12934,11 @@
         "nixpkgs": "nixpkgs_291"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12943,11 +12952,11 @@
         "nixpkgs": "nixpkgs_292"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12961,11 +12970,11 @@
         "nixpkgs": "nixpkgs_293"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13015,11 +13024,11 @@
         "nixpkgs": "nixpkgs_296"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13051,11 +13060,11 @@
         "nixpkgs": "nixpkgs_298"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13069,11 +13078,11 @@
         "nixpkgs": "nixpkgs_299"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13087,11 +13096,11 @@
         "nixpkgs": "nixpkgs_300"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13141,11 +13150,11 @@
         "nixpkgs": "nixpkgs_301"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13177,11 +13186,11 @@
         "nixpkgs": "nixpkgs_303"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13231,11 +13240,11 @@
         "nixpkgs": "nixpkgs_306"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13249,11 +13258,11 @@
         "nixpkgs": "nixpkgs_307"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13303,11 +13312,11 @@
         "nixpkgs": "nixpkgs_310"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13339,11 +13348,11 @@
         "nixpkgs": "nixpkgs_311"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13357,11 +13366,11 @@
         "nixpkgs": "nixpkgs_312"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13393,11 +13402,11 @@
         "nixpkgs": "nixpkgs_314"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13447,11 +13456,11 @@
         "nixpkgs": "nixpkgs_317"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13591,11 +13600,11 @@
         "nixpkgs": "nixpkgs_324"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13609,11 +13618,11 @@
         "nixpkgs": "nixpkgs_325"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13645,11 +13654,11 @@
         "nixpkgs": "nixpkgs_327"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13699,11 +13708,11 @@
         "nixpkgs": "nixpkgs_330"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13771,11 +13780,11 @@
         "nixpkgs": "nixpkgs_333"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13789,11 +13798,11 @@
         "nixpkgs": "nixpkgs_334"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13807,11 +13816,11 @@
         "nixpkgs": "nixpkgs_335"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13879,11 +13888,11 @@
         "nixpkgs": "nixpkgs_339"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13951,11 +13960,11 @@
         "nixpkgs": "nixpkgs_342"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13969,11 +13978,11 @@
         "nixpkgs": "nixpkgs_343"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13987,11 +13996,11 @@
         "nixpkgs": "nixpkgs_344"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14005,11 +14014,11 @@
         "nixpkgs": "nixpkgs_345"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14023,11 +14032,11 @@
         "nixpkgs": "nixpkgs_346"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14041,11 +14050,11 @@
         "nixpkgs": "nixpkgs_347"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14059,11 +14068,11 @@
         "nixpkgs": "nixpkgs_348"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14077,11 +14086,11 @@
         "nixpkgs": "nixpkgs_349"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14095,11 +14104,11 @@
         "nixpkgs": "nixpkgs_350"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14131,11 +14140,11 @@
         "nixpkgs": "nixpkgs_351"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14149,11 +14158,11 @@
         "nixpkgs": "nixpkgs_352"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14203,11 +14212,11 @@
         "nixpkgs": "nixpkgs_355"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14239,11 +14248,11 @@
         "nixpkgs": "nixpkgs_357"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14257,11 +14266,11 @@
         "nixpkgs": "nixpkgs_358"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14329,11 +14338,11 @@
         "nixpkgs": "nixpkgs_361"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14347,11 +14356,11 @@
         "nixpkgs": "nixpkgs_362"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14365,11 +14374,11 @@
         "nixpkgs": "nixpkgs_363"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14437,11 +14446,11 @@
         "nixpkgs": "nixpkgs_367"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14599,11 +14608,11 @@
         "nixpkgs": "nixpkgs_375"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14617,11 +14626,11 @@
         "nixpkgs": "nixpkgs_376"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14653,11 +14662,11 @@
         "nixpkgs": "nixpkgs_378"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14725,11 +14734,11 @@
         "nixpkgs": "nixpkgs_381"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14779,11 +14788,11 @@
         "nixpkgs": "nixpkgs_384"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14797,11 +14806,11 @@
         "nixpkgs": "nixpkgs_385"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14815,11 +14824,11 @@
         "nixpkgs": "nixpkgs_386"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14887,11 +14896,11 @@
         "nixpkgs": "nixpkgs_390"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14959,11 +14968,11 @@
         "nixpkgs": "nixpkgs_393"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14977,11 +14986,11 @@
         "nixpkgs": "nixpkgs_394"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14995,11 +15004,11 @@
         "nixpkgs": "nixpkgs_395"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15013,11 +15022,11 @@
         "nixpkgs": "nixpkgs_396"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15031,11 +15040,11 @@
         "nixpkgs": "nixpkgs_397"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15049,11 +15058,11 @@
         "nixpkgs": "nixpkgs_398"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15067,11 +15076,11 @@
         "nixpkgs": "nixpkgs_399"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15085,11 +15094,11 @@
         "nixpkgs": "nixpkgs_400"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15139,11 +15148,11 @@
         "nixpkgs": "nixpkgs_401"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15157,11 +15166,11 @@
         "nixpkgs": "nixpkgs_402"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15175,11 +15184,11 @@
         "nixpkgs": "nixpkgs_403"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15229,11 +15238,11 @@
         "nixpkgs": "nixpkgs_406"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15265,11 +15274,11 @@
         "nixpkgs": "nixpkgs_408"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15283,11 +15292,11 @@
         "nixpkgs": "nixpkgs_409"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15301,11 +15310,11 @@
         "nixpkgs": "nixpkgs_410"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15337,11 +15346,11 @@
         "nixpkgs": "nixpkgs_411"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15463,11 +15472,11 @@
         "nixpkgs": "nixpkgs_418"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15481,11 +15490,11 @@
         "nixpkgs": "nixpkgs_419"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15535,11 +15544,11 @@
         "nixpkgs": "nixpkgs_421"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15589,11 +15598,11 @@
         "nixpkgs": "nixpkgs_424"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15643,11 +15652,11 @@
         "nixpkgs": "nixpkgs_427"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15661,11 +15670,11 @@
         "nixpkgs": "nixpkgs_428"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15679,11 +15688,11 @@
         "nixpkgs": "nixpkgs_429"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15769,11 +15778,11 @@
         "nixpkgs": "nixpkgs_433"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15823,11 +15832,11 @@
         "nixpkgs": "nixpkgs_436"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15841,11 +15850,11 @@
         "nixpkgs": "nixpkgs_437"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15859,11 +15868,11 @@
         "nixpkgs": "nixpkgs_438"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15877,11 +15886,11 @@
         "nixpkgs": "nixpkgs_439"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15895,11 +15904,11 @@
         "nixpkgs": "nixpkgs_440"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15931,11 +15940,11 @@
         "nixpkgs": "nixpkgs_441"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15949,11 +15958,11 @@
         "nixpkgs": "nixpkgs_442"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15967,11 +15976,11 @@
         "nixpkgs": "nixpkgs_443"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15985,11 +15994,11 @@
         "nixpkgs": "nixpkgs_444"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16003,11 +16012,11 @@
         "nixpkgs": "nixpkgs_445"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16021,11 +16030,11 @@
         "nixpkgs": "nixpkgs_446"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16075,11 +16084,11 @@
         "nixpkgs": "nixpkgs_449"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16129,11 +16138,11 @@
         "nixpkgs": "nixpkgs_451"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16147,11 +16156,11 @@
         "nixpkgs": "nixpkgs_452"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16201,11 +16210,11 @@
         "nixpkgs": "nixpkgs_455"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16219,11 +16228,11 @@
         "nixpkgs": "nixpkgs_456"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16237,11 +16246,11 @@
         "nixpkgs": "nixpkgs_457"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16327,11 +16336,11 @@
         "nixpkgs": "nixpkgs_461"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16345,11 +16354,11 @@
         "nixpkgs": "nixpkgs_462"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16399,11 +16408,11 @@
         "nixpkgs": "nixpkgs_465"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16543,11 +16552,11 @@
         "nixpkgs": "nixpkgs_472"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16561,11 +16570,11 @@
         "nixpkgs": "nixpkgs_473"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16597,11 +16606,11 @@
         "nixpkgs": "nixpkgs_475"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16651,11 +16660,11 @@
         "nixpkgs": "nixpkgs_478"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16723,11 +16732,11 @@
         "nixpkgs": "nixpkgs_481"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16741,11 +16750,11 @@
         "nixpkgs": "nixpkgs_482"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16759,11 +16768,11 @@
         "nixpkgs": "nixpkgs_483"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16831,11 +16840,11 @@
         "nixpkgs": "nixpkgs_487"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16885,11 +16894,11 @@
         "nixpkgs": "nixpkgs_490"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16921,11 +16930,11 @@
         "nixpkgs": "nixpkgs_491"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16939,11 +16948,11 @@
         "nixpkgs": "nixpkgs_492"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16957,11 +16966,11 @@
         "nixpkgs": "nixpkgs_493"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16975,11 +16984,11 @@
         "nixpkgs": "nixpkgs_494"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16993,11 +17002,11 @@
         "nixpkgs": "nixpkgs_495"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17011,11 +17020,11 @@
         "nixpkgs": "nixpkgs_496"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17029,11 +17038,11 @@
         "nixpkgs": "nixpkgs_497"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17047,11 +17056,11 @@
         "nixpkgs": "nixpkgs_498"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17065,11 +17074,11 @@
         "nixpkgs": "nixpkgs_499"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17083,11 +17092,11 @@
         "nixpkgs": "nixpkgs_500"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17173,11 +17182,11 @@
         "nixpkgs": "nixpkgs_503"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17209,11 +17218,11 @@
         "nixpkgs": "nixpkgs_505"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17227,11 +17236,11 @@
         "nixpkgs": "nixpkgs_506"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17281,11 +17290,11 @@
         "nixpkgs": "nixpkgs_509"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17299,11 +17308,11 @@
         "nixpkgs": "nixpkgs_510"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17335,11 +17344,11 @@
         "nixpkgs": "nixpkgs_511"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17407,11 +17416,11 @@
         "nixpkgs": "nixpkgs_515"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17569,11 +17578,11 @@
         "nixpkgs": "nixpkgs_523"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17587,11 +17596,11 @@
         "nixpkgs": "nixpkgs_524"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17623,11 +17632,11 @@
         "nixpkgs": "nixpkgs_526"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17677,11 +17686,11 @@
         "nixpkgs": "nixpkgs_529"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17749,11 +17758,11 @@
         "nixpkgs": "nixpkgs_532"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17767,11 +17776,11 @@
         "nixpkgs": "nixpkgs_533"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17785,11 +17794,11 @@
         "nixpkgs": "nixpkgs_534"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17857,11 +17866,11 @@
         "nixpkgs": "nixpkgs_538"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17929,11 +17938,11 @@
         "nixpkgs": "nixpkgs_541"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17947,11 +17956,11 @@
         "nixpkgs": "nixpkgs_542"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17965,11 +17974,11 @@
         "nixpkgs": "nixpkgs_543"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17983,11 +17992,11 @@
         "nixpkgs": "nixpkgs_544"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18001,11 +18010,11 @@
         "nixpkgs": "nixpkgs_545"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18019,11 +18028,11 @@
         "nixpkgs": "nixpkgs_546"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18037,11 +18046,11 @@
         "nixpkgs": "nixpkgs_547"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18055,11 +18064,11 @@
         "nixpkgs": "nixpkgs_548"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18073,11 +18082,11 @@
         "nixpkgs": "nixpkgs_549"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18091,11 +18100,11 @@
         "nixpkgs": "nixpkgs_550"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18127,11 +18136,11 @@
         "nixpkgs": "nixpkgs_551"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18181,11 +18190,11 @@
         "nixpkgs": "nixpkgs_554"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18217,11 +18226,11 @@
         "nixpkgs": "nixpkgs_556"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18235,11 +18244,11 @@
         "nixpkgs": "nixpkgs_557"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18253,11 +18262,11 @@
         "nixpkgs": "nixpkgs_558"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18271,11 +18280,11 @@
         "nixpkgs": "nixpkgs_559"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18415,11 +18424,11 @@
         "nixpkgs": "nixpkgs_566"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18433,11 +18442,11 @@
         "nixpkgs": "nixpkgs_567"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18469,11 +18478,11 @@
         "nixpkgs": "nixpkgs_569"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18541,11 +18550,11 @@
         "nixpkgs": "nixpkgs_572"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18595,11 +18604,11 @@
         "nixpkgs": "nixpkgs_575"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18613,11 +18622,11 @@
         "nixpkgs": "nixpkgs_576"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18631,11 +18640,11 @@
         "nixpkgs": "nixpkgs_577"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18721,11 +18730,11 @@
         "nixpkgs": "nixpkgs_581"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18775,11 +18784,11 @@
         "nixpkgs": "nixpkgs_584"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18793,11 +18802,11 @@
         "nixpkgs": "nixpkgs_585"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18811,11 +18820,11 @@
         "nixpkgs": "nixpkgs_586"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18829,11 +18838,11 @@
         "nixpkgs": "nixpkgs_587"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18847,11 +18856,11 @@
         "nixpkgs": "nixpkgs_588"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18865,11 +18874,11 @@
         "nixpkgs": "nixpkgs_589"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18883,11 +18892,11 @@
         "nixpkgs": "nixpkgs_590"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18919,11 +18928,11 @@
         "nixpkgs": "nixpkgs_591"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18937,11 +18946,11 @@
         "nixpkgs": "nixpkgs_592"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18955,11 +18964,11 @@
         "nixpkgs": "nixpkgs_593"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18973,11 +18982,11 @@
         "nixpkgs": "nixpkgs_594"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19027,11 +19036,11 @@
         "nixpkgs": "nixpkgs_597"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19063,11 +19072,11 @@
         "nixpkgs": "nixpkgs_599"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19081,11 +19090,11 @@
         "nixpkgs": "nixpkgs_600"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19171,11 +19180,11 @@
         "nixpkgs": "nixpkgs_603"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19189,11 +19198,11 @@
         "nixpkgs": "nixpkgs_604"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19207,11 +19216,11 @@
         "nixpkgs": "nixpkgs_605"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19279,11 +19288,11 @@
         "nixpkgs": "nixpkgs_609"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19297,11 +19306,11 @@
         "nixpkgs": "nixpkgs_610"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19369,11 +19378,11 @@
         "nixpkgs": "nixpkgs_613"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19387,11 +19396,11 @@
         "nixpkgs": "nixpkgs_614"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19405,11 +19414,11 @@
         "nixpkgs": "nixpkgs_615"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19423,11 +19432,11 @@
         "nixpkgs": "nixpkgs_616"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19441,11 +19450,11 @@
         "nixpkgs": "nixpkgs_617"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19459,11 +19468,11 @@
         "nixpkgs": "nixpkgs_618"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19531,11 +19540,11 @@
         "nixpkgs": "nixpkgs_621"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19567,11 +19576,11 @@
         "nixpkgs": "nixpkgs_623"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19585,11 +19594,11 @@
         "nixpkgs": "nixpkgs_624"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19747,11 +19756,11 @@
         "nixpkgs": "nixpkgs_632"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19765,11 +19774,11 @@
         "nixpkgs": "nixpkgs_633"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19801,11 +19810,11 @@
         "nixpkgs": "nixpkgs_635"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19855,11 +19864,11 @@
         "nixpkgs": "nixpkgs_638"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19927,11 +19936,11 @@
         "nixpkgs": "nixpkgs_641"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19945,11 +19954,11 @@
         "nixpkgs": "nixpkgs_642"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19963,11 +19972,11 @@
         "nixpkgs": "nixpkgs_643"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20035,11 +20044,11 @@
         "nixpkgs": "nixpkgs_647"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20089,11 +20098,11 @@
         "nixpkgs": "nixpkgs_650"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20125,11 +20134,11 @@
         "nixpkgs": "nixpkgs_651"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20143,11 +20152,11 @@
         "nixpkgs": "nixpkgs_652"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20161,11 +20170,11 @@
         "nixpkgs": "nixpkgs_653"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20179,11 +20188,11 @@
         "nixpkgs": "nixpkgs_654"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20197,11 +20206,11 @@
         "nixpkgs": "nixpkgs_655"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20215,11 +20224,11 @@
         "nixpkgs": "nixpkgs_656"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20233,11 +20242,11 @@
         "nixpkgs": "nixpkgs_657"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20251,11 +20260,11 @@
         "nixpkgs": "nixpkgs_658"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20269,11 +20278,11 @@
         "nixpkgs": "nixpkgs_659"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20287,11 +20296,11 @@
         "nixpkgs": "nixpkgs_660"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20359,11 +20368,11 @@
         "nixpkgs": "nixpkgs_663"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20395,11 +20404,11 @@
         "nixpkgs": "nixpkgs_665"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20413,11 +20422,11 @@
         "nixpkgs": "nixpkgs_666"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20431,11 +20440,11 @@
         "nixpkgs": "nixpkgs_667"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20449,11 +20458,11 @@
         "nixpkgs": "nixpkgs_668"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20467,11 +20476,11 @@
         "nixpkgs": "nixpkgs_669"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20485,11 +20494,11 @@
         "nixpkgs": "nixpkgs_670"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20521,11 +20530,11 @@
         "nixpkgs": "nixpkgs_671"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20539,11 +20548,11 @@
         "nixpkgs": "nixpkgs_672"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20557,11 +20566,11 @@
         "nixpkgs": "nixpkgs_673"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20611,11 +20620,11 @@
         "nixpkgs": "nixpkgs_676"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20647,11 +20656,11 @@
         "nixpkgs": "nixpkgs_678"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20665,11 +20674,11 @@
         "nixpkgs": "nixpkgs_679"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20809,11 +20818,11 @@
         "nixpkgs": "nixpkgs_686"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20827,11 +20836,11 @@
         "nixpkgs": "nixpkgs_687"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20971,11 +20980,11 @@
         "nixpkgs": "nixpkgs_694"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20989,11 +20998,11 @@
         "nixpkgs": "nixpkgs_695"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21025,11 +21034,11 @@
         "nixpkgs": "nixpkgs_697"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21079,11 +21088,11 @@
         "nixpkgs": "nixpkgs_700"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21169,11 +21178,11 @@
         "nixpkgs": "nixpkgs_703"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21187,11 +21196,11 @@
         "nixpkgs": "nixpkgs_704"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21205,11 +21214,11 @@
         "nixpkgs": "nixpkgs_705"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21277,11 +21286,11 @@
         "nixpkgs": "nixpkgs_709"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21349,11 +21358,11 @@
         "nixpkgs": "nixpkgs_712"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21367,11 +21376,11 @@
         "nixpkgs": "nixpkgs_713"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21385,11 +21394,11 @@
         "nixpkgs": "nixpkgs_714"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21403,11 +21412,11 @@
         "nixpkgs": "nixpkgs_715"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21421,11 +21430,11 @@
         "nixpkgs": "nixpkgs_716"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21439,11 +21448,11 @@
         "nixpkgs": "nixpkgs_717"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21457,11 +21466,11 @@
         "nixpkgs": "nixpkgs_718"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21475,11 +21484,11 @@
         "nixpkgs": "nixpkgs_719"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21493,11 +21502,11 @@
         "nixpkgs": "nixpkgs_720"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21529,11 +21538,11 @@
         "nixpkgs": "nixpkgs_721"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21547,11 +21556,11 @@
         "nixpkgs": "nixpkgs_722"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21601,11 +21610,11 @@
         "nixpkgs": "nixpkgs_725"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21637,11 +21646,11 @@
         "nixpkgs": "nixpkgs_727"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21655,11 +21664,11 @@
         "nixpkgs": "nixpkgs_728"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21853,11 +21862,11 @@
         "nixpkgs": "nixpkgs_738"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21871,11 +21880,11 @@
         "nixpkgs": "nixpkgs_739"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21925,11 +21934,11 @@
         "nixpkgs": "nixpkgs_741"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21979,11 +21988,11 @@
         "nixpkgs": "nixpkgs_744"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22033,11 +22042,11 @@
         "nixpkgs": "nixpkgs_747"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22051,11 +22060,11 @@
         "nixpkgs": "nixpkgs_748"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22069,11 +22078,11 @@
         "nixpkgs": "nixpkgs_749"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22159,11 +22168,11 @@
         "nixpkgs": "nixpkgs_753"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22213,11 +22222,11 @@
         "nixpkgs": "nixpkgs_756"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22231,11 +22240,11 @@
         "nixpkgs": "nixpkgs_757"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22249,11 +22258,11 @@
         "nixpkgs": "nixpkgs_758"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22267,11 +22276,11 @@
         "nixpkgs": "nixpkgs_759"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22285,11 +22294,11 @@
         "nixpkgs": "nixpkgs_760"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22321,11 +22330,11 @@
         "nixpkgs": "nixpkgs_761"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22339,11 +22348,11 @@
         "nixpkgs": "nixpkgs_762"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22357,11 +22366,11 @@
         "nixpkgs": "nixpkgs_763"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22375,11 +22384,11 @@
         "nixpkgs": "nixpkgs_764"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22393,11 +22402,11 @@
         "nixpkgs": "nixpkgs_765"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22411,11 +22420,11 @@
         "nixpkgs": "nixpkgs_766"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22465,11 +22474,11 @@
         "nixpkgs": "nixpkgs_769"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22519,11 +22528,11 @@
         "nixpkgs": "nixpkgs_771"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22537,11 +22546,11 @@
         "nixpkgs": "nixpkgs_772"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22591,11 +22600,11 @@
         "nixpkgs": "nixpkgs_775"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22609,11 +22618,11 @@
         "nixpkgs": "nixpkgs_776"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22627,11 +22636,11 @@
         "nixpkgs": "nixpkgs_777"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22717,11 +22726,11 @@
         "nixpkgs": "nixpkgs_781"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22771,11 +22780,11 @@
         "nixpkgs": "nixpkgs_784"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22789,11 +22798,11 @@
         "nixpkgs": "nixpkgs_785"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22807,11 +22816,11 @@
         "nixpkgs": "nixpkgs_786"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22825,11 +22834,11 @@
         "nixpkgs": "nixpkgs_787"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22843,11 +22852,11 @@
         "nixpkgs": "nixpkgs_788"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22861,11 +22870,11 @@
         "nixpkgs": "nixpkgs_789"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22879,11 +22888,11 @@
         "nixpkgs": "nixpkgs_790"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22915,11 +22924,11 @@
         "nixpkgs": "nixpkgs_791"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22933,11 +22942,11 @@
         "nixpkgs": "nixpkgs_792"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22951,11 +22960,11 @@
         "nixpkgs": "nixpkgs_793"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22969,11 +22978,11 @@
         "nixpkgs": "nixpkgs_794"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23023,11 +23032,11 @@
         "nixpkgs": "nixpkgs_797"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23059,11 +23068,11 @@
         "nixpkgs": "nixpkgs_799"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23077,11 +23086,11 @@
         "nixpkgs": "nixpkgs_800"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23131,11 +23140,11 @@
         "nixpkgs": "nixpkgs_801"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23149,11 +23158,11 @@
         "nixpkgs": "nixpkgs_802"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23167,11 +23176,11 @@
         "nixpkgs": "nixpkgs_803"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23185,11 +23194,11 @@
         "nixpkgs": "nixpkgs_804"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23203,11 +23212,11 @@
         "nixpkgs": "nixpkgs_805"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23221,11 +23230,11 @@
         "nixpkgs": "nixpkgs_806"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23239,11 +23248,11 @@
         "nixpkgs": "nixpkgs_807"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23293,11 +23302,11 @@
         "nixpkgs": "nixpkgs_810"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23347,11 +23356,11 @@
         "nixpkgs": "nixpkgs_812"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23365,11 +23374,11 @@
         "nixpkgs": "nixpkgs_813"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23401,11 +23410,11 @@
         "nixpkgs": "nixpkgs_815"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23435,6 +23444,42 @@
     "logos-nix_816": {
       "inputs": {
         "nixpkgs": "nixpkgs_817"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_817": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_818"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_818": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_819"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -23856,7 +23901,7 @@
     },
     "logos-package-manager_10": {
       "inputs": {
-        "logos-nix": "logos-nix_218",
+        "logos-nix": "logos-nix_220",
         "logos-package": "logos-package_24",
         "nix-bundle-appimage": "nix-bundle-appimage_10",
         "nix-bundle-dir": "nix-bundle-dir_34",
@@ -23890,7 +23935,7 @@
     },
     "logos-package-manager_11": {
       "inputs": {
-        "logos-nix": "logos-nix_245",
+        "logos-nix": "logos-nix_247",
         "logos-package": "logos-package_26",
         "nix-bundle-appimage": "nix-bundle-appimage_11",
         "nix-bundle-dir": "nix-bundle-dir_37",
@@ -23926,7 +23971,7 @@
     },
     "logos-package-manager_12": {
       "inputs": {
-        "logos-nix": "logos-nix_262",
+        "logos-nix": "logos-nix_264",
         "logos-package": "logos-package_29",
         "nix-bundle-appimage": "nix-bundle-appimage_12",
         "nix-bundle-dir": "nix-bundle-dir_41",
@@ -23961,7 +24006,7 @@
     },
     "logos-package-manager_13": {
       "inputs": {
-        "logos-nix": "logos-nix_273",
+        "logos-nix": "logos-nix_275",
         "logos-package": "logos-package_31",
         "nix-bundle-appimage": "nix-bundle-appimage_13",
         "nix-bundle-dir": "nix-bundle-dir_44",
@@ -23993,7 +24038,7 @@
     },
     "logos-package-manager_14": {
       "inputs": {
-        "logos-nix": "logos-nix_290",
+        "logos-nix": "logos-nix_292",
         "logos-package": "logos-package_34",
         "nix-bundle-appimage": "nix-bundle-appimage_14",
         "nix-bundle-dir": "nix-bundle-dir_48",
@@ -24024,7 +24069,7 @@
     },
     "logos-package-manager_15": {
       "inputs": {
-        "logos-nix": "logos-nix_304",
+        "logos-nix": "logos-nix_306",
         "logos-package": "logos-package_36",
         "nix-bundle-appimage": "nix-bundle-appimage_15",
         "nix-bundle-dir": "nix-bundle-dir_51",
@@ -24052,7 +24097,7 @@
     },
     "logos-package-manager_16": {
       "inputs": {
-        "logos-nix": "logos-nix_332",
+        "logos-nix": "logos-nix_334",
         "logos-package": "logos-package_37",
         "nix-bundle-appimage": "nix-bundle-appimage_16",
         "nix-bundle-dir": "nix-bundle-dir_53",
@@ -24085,7 +24130,7 @@
     },
     "logos-package-manager_17": {
       "inputs": {
-        "logos-nix": "logos-nix_349",
+        "logos-nix": "logos-nix_351",
         "logos-package": "logos-package_40",
         "nix-bundle-appimage": "nix-bundle-appimage_17",
         "nix-bundle-dir": "nix-bundle-dir_57",
@@ -24117,7 +24162,7 @@
     },
     "logos-package-manager_18": {
       "inputs": {
-        "logos-nix": "logos-nix_360",
+        "logos-nix": "logos-nix_362",
         "logos-package": "logos-package_42",
         "nix-bundle-appimage": "nix-bundle-appimage_18",
         "nix-bundle-dir": "nix-bundle-dir_60",
@@ -24146,7 +24191,7 @@
     },
     "logos-package-manager_19": {
       "inputs": {
-        "logos-nix": "logos-nix_383",
+        "logos-nix": "logos-nix_385",
         "logos-package": "logos-package_43",
         "nix-bundle-appimage": "nix-bundle-appimage_19",
         "nix-bundle-dir": "nix-bundle-dir_62",
@@ -24210,7 +24255,7 @@
     },
     "logos-package-manager_20": {
       "inputs": {
-        "logos-nix": "logos-nix_400",
+        "logos-nix": "logos-nix_402",
         "logos-package": "logos-package_46",
         "nix-bundle-appimage": "nix-bundle-appimage_20",
         "nix-bundle-dir": "nix-bundle-dir_66",
@@ -24242,7 +24287,7 @@
     },
     "logos-package-manager_21": {
       "inputs": {
-        "logos-nix": "logos-nix_426",
+        "logos-nix": "logos-nix_428",
         "logos-package": "logos-package_48",
         "nix-bundle-appimage": "nix-bundle-appimage_21",
         "nix-bundle-dir": "nix-bundle-dir_69",
@@ -24276,7 +24321,7 @@
     },
     "logos-package-manager_22": {
       "inputs": {
-        "logos-nix": "logos-nix_443",
+        "logos-nix": "logos-nix_445",
         "logos-package": "logos-package_51",
         "nix-bundle-appimage": "nix-bundle-appimage_22",
         "nix-bundle-dir": "nix-bundle-dir_73",
@@ -24309,7 +24354,7 @@
     },
     "logos-package-manager_23": {
       "inputs": {
-        "logos-nix": "logos-nix_454",
+        "logos-nix": "logos-nix_456",
         "logos-package": "logos-package_53",
         "nix-bundle-appimage": "nix-bundle-appimage_23",
         "nix-bundle-dir": "nix-bundle-dir_76",
@@ -24339,7 +24384,7 @@
     },
     "logos-package-manager_24": {
       "inputs": {
-        "logos-nix": "logos-nix_480",
+        "logos-nix": "logos-nix_482",
         "logos-package": "logos-package_54",
         "nix-bundle-appimage": "nix-bundle-appimage_24",
         "nix-bundle-dir": "nix-bundle-dir_78",
@@ -24374,7 +24419,7 @@
     },
     "logos-package-manager_25": {
       "inputs": {
-        "logos-nix": "logos-nix_497",
+        "logos-nix": "logos-nix_499",
         "logos-package": "logos-package_57",
         "nix-bundle-appimage": "nix-bundle-appimage_25",
         "nix-bundle-dir": "nix-bundle-dir_82",
@@ -24408,7 +24453,7 @@
     },
     "logos-package-manager_26": {
       "inputs": {
-        "logos-nix": "logos-nix_508",
+        "logos-nix": "logos-nix_510",
         "logos-package": "logos-package_59",
         "nix-bundle-appimage": "nix-bundle-appimage_26",
         "nix-bundle-dir": "nix-bundle-dir_85",
@@ -24439,7 +24484,7 @@
     },
     "logos-package-manager_27": {
       "inputs": {
-        "logos-nix": "logos-nix_531",
+        "logos-nix": "logos-nix_533",
         "logos-package": "logos-package_60",
         "nix-bundle-appimage": "nix-bundle-appimage_27",
         "nix-bundle-dir": "nix-bundle-dir_87",
@@ -24474,7 +24519,7 @@
     },
     "logos-package-manager_28": {
       "inputs": {
-        "logos-nix": "logos-nix_548",
+        "logos-nix": "logos-nix_550",
         "logos-package": "logos-package_63",
         "nix-bundle-appimage": "nix-bundle-appimage_28",
         "nix-bundle-dir": "nix-bundle-dir_91",
@@ -24508,7 +24553,7 @@
     },
     "logos-package-manager_29": {
       "inputs": {
-        "logos-nix": "logos-nix_574",
+        "logos-nix": "logos-nix_576",
         "logos-package": "logos-package_65",
         "nix-bundle-appimage": "nix-bundle-appimage_29",
         "nix-bundle-dir": "nix-bundle-dir_94",
@@ -24577,7 +24622,7 @@
     },
     "logos-package-manager_30": {
       "inputs": {
-        "logos-nix": "logos-nix_591",
+        "logos-nix": "logos-nix_593",
         "logos-package": "logos-package_68",
         "nix-bundle-appimage": "nix-bundle-appimage_30",
         "nix-bundle-dir": "nix-bundle-dir_98",
@@ -24612,7 +24657,7 @@
     },
     "logos-package-manager_31": {
       "inputs": {
-        "logos-nix": "logos-nix_602",
+        "logos-nix": "logos-nix_604",
         "logos-package": "logos-package_70",
         "nix-bundle-appimage": "nix-bundle-appimage_31",
         "nix-bundle-dir": "nix-bundle-dir_101",
@@ -24644,7 +24689,7 @@
     },
     "logos-package-manager_32": {
       "inputs": {
-        "logos-nix": "logos-nix_615",
+        "logos-nix": "logos-nix_617",
         "logos-package": "logos-package_71",
         "nix-bundle-appimage": "nix-bundle-appimage_33",
         "nix-bundle-dir": "nix-bundle-dir_105",
@@ -24676,7 +24721,7 @@
     },
     "logos-package-manager_33": {
       "inputs": {
-        "logos-nix": "logos-nix_640",
+        "logos-nix": "logos-nix_642",
         "logos-package": "logos-package_73",
         "nix-bundle-appimage": "nix-bundle-appimage_34",
         "nix-bundle-dir": "nix-bundle-dir_108",
@@ -24709,7 +24754,7 @@
     },
     "logos-package-manager_34": {
       "inputs": {
-        "logos-nix": "logos-nix_657",
+        "logos-nix": "logos-nix_659",
         "logos-package": "logos-package_76",
         "nix-bundle-appimage": "nix-bundle-appimage_35",
         "nix-bundle-dir": "nix-bundle-dir_112",
@@ -24741,7 +24786,7 @@
     },
     "logos-package-manager_35": {
       "inputs": {
-        "logos-nix": "logos-nix_670",
+        "logos-nix": "logos-nix_672",
         "logos-package": "logos-package_78",
         "nix-bundle-appimage": "nix-bundle-appimage_37",
         "nix-bundle-dir": "nix-bundle-dir_117",
@@ -24771,7 +24816,7 @@
     },
     "logos-package-manager_36": {
       "inputs": {
-        "logos-nix": "logos-nix_702",
+        "logos-nix": "logos-nix_704",
         "logos-package": "logos-package_80",
         "nix-bundle-appimage": "nix-bundle-appimage_38",
         "nix-bundle-dir": "nix-bundle-dir_120",
@@ -24805,7 +24850,7 @@
     },
     "logos-package-manager_37": {
       "inputs": {
-        "logos-nix": "logos-nix_719",
+        "logos-nix": "logos-nix_721",
         "logos-package": "logos-package_83",
         "nix-bundle-appimage": "nix-bundle-appimage_39",
         "nix-bundle-dir": "nix-bundle-dir_124",
@@ -24838,7 +24883,7 @@
     },
     "logos-package-manager_38": {
       "inputs": {
-        "logos-nix": "logos-nix_746",
+        "logos-nix": "logos-nix_748",
         "logos-package": "logos-package_85",
         "nix-bundle-appimage": "nix-bundle-appimage_40",
         "nix-bundle-dir": "nix-bundle-dir_127",
@@ -24873,7 +24918,7 @@
     },
     "logos-package-manager_39": {
       "inputs": {
-        "logos-nix": "logos-nix_763",
+        "logos-nix": "logos-nix_765",
         "logos-package": "logos-package_88",
         "nix-bundle-appimage": "nix-bundle-appimage_41",
         "nix-bundle-dir": "nix-bundle-dir_131",
@@ -24939,7 +24984,7 @@
     },
     "logos-package-manager_40": {
       "inputs": {
-        "logos-nix": "logos-nix_774",
+        "logos-nix": "logos-nix_776",
         "logos-package": "logos-package_90",
         "nix-bundle-appimage": "nix-bundle-appimage_42",
         "nix-bundle-dir": "nix-bundle-dir_134",
@@ -24970,7 +25015,7 @@
     },
     "logos-package-manager_41": {
       "inputs": {
-        "logos-nix": "logos-nix_791",
+        "logos-nix": "logos-nix_793",
         "logos-package": "logos-package_93",
         "nix-bundle-appimage": "nix-bundle-appimage_43",
         "nix-bundle-dir": "nix-bundle-dir_138",
@@ -25000,7 +25045,7 @@
     },
     "logos-package-manager_42": {
       "inputs": {
-        "logos-nix": "logos-nix_804",
+        "logos-nix": "logos-nix_806",
         "logos-package": "logos-package_95",
         "nix-bundle-appimage": "nix-bundle-appimage_45",
         "nix-bundle-dir": "nix-bundle-dir_143",
@@ -25057,7 +25102,7 @@
     },
     "logos-package-manager_6": {
       "inputs": {
-        "logos-nix": "logos-nix_116",
+        "logos-nix": "logos-nix_118",
         "logos-package": "logos-package_14",
         "nix-bundle-appimage": "nix-bundle-appimage_6",
         "nix-bundle-dir": "nix-bundle-dir_20",
@@ -25070,11 +25115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775836847,
-        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
+        "lastModified": 1782134133,
+        "narHash": "sha256-65w2mEijAjUPVntS3kUKZygjRkZoj7dgCYtk8lD5jL8=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
+        "rev": "4871ed198d6e35f198af15c93afd184aa36788e0",
         "type": "github"
       },
       "original": {
@@ -25085,7 +25130,7 @@
     },
     "logos-package-manager_7": {
       "inputs": {
-        "logos-nix": "logos-nix_141",
+        "logos-nix": "logos-nix_143",
         "logos-package": "logos-package_16",
         "nix-bundle-appimage": "nix-bundle-appimage_7",
         "nix-bundle-dir": "nix-bundle-dir_23",
@@ -25116,7 +25161,7 @@
     },
     "logos-package-manager_8": {
       "inputs": {
-        "logos-nix": "logos-nix_158",
+        "logos-nix": "logos-nix_160",
         "logos-package": "logos-package_19",
         "nix-bundle-appimage": "nix-bundle-appimage_8",
         "nix-bundle-dir": "nix-bundle-dir_27",
@@ -25146,7 +25191,7 @@
     },
     "logos-package-manager_9": {
       "inputs": {
-        "logos-nix": "logos-nix_201",
+        "logos-nix": "logos-nix_203",
         "logos-package": "logos-package_21",
         "nix-bundle-appimage": "nix-bundle-appimage_9",
         "nix-bundle-dir": "nix-bundle-dir_30",
@@ -25238,7 +25283,7 @@
     },
     "logos-package_12": {
       "inputs": {
-        "logos-nix": "logos-nix_109",
+        "logos-nix": "logos-nix_111",
         "nixpkgs": [
           "logos-module-builder",
           "logos-standalone-app",
@@ -25264,7 +25309,7 @@
     },
     "logos-package_13": {
       "inputs": {
-        "logos-nix": "logos-nix_113",
+        "logos-nix": "logos-nix_115",
         "nixpkgs": [
           "logos-module-builder",
           "nix-bundle-lgx",
@@ -25289,7 +25334,7 @@
     },
     "logos-package_14": {
       "inputs": {
-        "logos-nix": "logos-nix_117",
+        "logos-nix": "logos-nix_119",
         "nixpkgs": [
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -25300,11 +25345,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1781873979,
+        "narHash": "sha256-Z5XUSB9wfdrmQhG/0fehJeBd9CjrlIEeO+mKDhE46H4=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "c207525d30f48620696668c38486884bad5384bc",
         "type": "github"
       },
       "original": {
@@ -25315,7 +25360,7 @@
     },
     "logos-package_15": {
       "inputs": {
-        "logos-nix": "logos-nix_122",
+        "logos-nix": "logos-nix_124",
         "nixpkgs": [
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -25326,11 +25371,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1781872378,
+        "narHash": "sha256-ZHh+krtTbn6Qt7Hm3+shrhAAGCFa7FXt8ajYqx+Nt1o=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "ab885df3641e9adb61ff16e42d3e6f63b24db8f6",
         "type": "github"
       },
       "original": {
@@ -25341,7 +25386,7 @@
     },
     "logos-package_16": {
       "inputs": {
-        "logos-nix": "logos-nix_142",
+        "logos-nix": "logos-nix_144",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -25370,7 +25415,7 @@
     },
     "logos-package_17": {
       "inputs": {
-        "logos-nix": "logos-nix_151",
+        "logos-nix": "logos-nix_153",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -25398,7 +25443,7 @@
     },
     "logos-package_18": {
       "inputs": {
-        "logos-nix": "logos-nix_155",
+        "logos-nix": "logos-nix_157",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -25425,7 +25470,7 @@
     },
     "logos-package_19": {
       "inputs": {
-        "logos-nix": "logos-nix_159",
+        "logos-nix": "logos-nix_161",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -25482,7 +25527,7 @@
     },
     "logos-package_20": {
       "inputs": {
-        "logos-nix": "logos-nix_164",
+        "logos-nix": "logos-nix_166",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -25510,7 +25555,7 @@
     },
     "logos-package_21": {
       "inputs": {
-        "logos-nix": "logos-nix_202",
+        "logos-nix": "logos-nix_204",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -25543,7 +25588,7 @@
     },
     "logos-package_22": {
       "inputs": {
-        "logos-nix": "logos-nix_211",
+        "logos-nix": "logos-nix_213",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -25575,7 +25620,7 @@
     },
     "logos-package_23": {
       "inputs": {
-        "logos-nix": "logos-nix_215",
+        "logos-nix": "logos-nix_217",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -25606,7 +25651,7 @@
     },
     "logos-package_24": {
       "inputs": {
-        "logos-nix": "logos-nix_219",
+        "logos-nix": "logos-nix_221",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -25638,7 +25683,7 @@
     },
     "logos-package_25": {
       "inputs": {
-        "logos-nix": "logos-nix_224",
+        "logos-nix": "logos-nix_226",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -25670,7 +25715,7 @@
     },
     "logos-package_26": {
       "inputs": {
-        "logos-nix": "logos-nix_246",
+        "logos-nix": "logos-nix_248",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -25704,7 +25749,7 @@
     },
     "logos-package_27": {
       "inputs": {
-        "logos-nix": "logos-nix_255",
+        "logos-nix": "logos-nix_257",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -25737,7 +25782,7 @@
     },
     "logos-package_28": {
       "inputs": {
-        "logos-nix": "logos-nix_259",
+        "logos-nix": "logos-nix_261",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -25769,7 +25814,7 @@
     },
     "logos-package_29": {
       "inputs": {
-        "logos-nix": "logos-nix_263",
+        "logos-nix": "logos-nix_265",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -25830,7 +25875,7 @@
     },
     "logos-package_30": {
       "inputs": {
-        "logos-nix": "logos-nix_268",
+        "logos-nix": "logos-nix_270",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -25863,7 +25908,7 @@
     },
     "logos-package_31": {
       "inputs": {
-        "logos-nix": "logos-nix_274",
+        "logos-nix": "logos-nix_276",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -25893,7 +25938,7 @@
     },
     "logos-package_32": {
       "inputs": {
-        "logos-nix": "logos-nix_283",
+        "logos-nix": "logos-nix_285",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -25922,7 +25967,7 @@
     },
     "logos-package_33": {
       "inputs": {
-        "logos-nix": "logos-nix_287",
+        "logos-nix": "logos-nix_289",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -25950,7 +25995,7 @@
     },
     "logos-package_34": {
       "inputs": {
-        "logos-nix": "logos-nix_291",
+        "logos-nix": "logos-nix_293",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -25979,7 +26024,7 @@
     },
     "logos-package_35": {
       "inputs": {
-        "logos-nix": "logos-nix_296",
+        "logos-nix": "logos-nix_298",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -26008,7 +26053,7 @@
     },
     "logos-package_36": {
       "inputs": {
-        "logos-nix": "logos-nix_305",
+        "logos-nix": "logos-nix_307",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -26034,7 +26079,7 @@
     },
     "logos-package_37": {
       "inputs": {
-        "logos-nix": "logos-nix_333",
+        "logos-nix": "logos-nix_335",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26065,7 +26110,7 @@
     },
     "logos-package_38": {
       "inputs": {
-        "logos-nix": "logos-nix_342",
+        "logos-nix": "logos-nix_344",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26095,7 +26140,7 @@
     },
     "logos-package_39": {
       "inputs": {
-        "logos-nix": "logos-nix_346",
+        "logos-nix": "logos-nix_348",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26153,7 +26198,7 @@
     },
     "logos-package_40": {
       "inputs": {
-        "logos-nix": "logos-nix_350",
+        "logos-nix": "logos-nix_352",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26183,7 +26228,7 @@
     },
     "logos-package_41": {
       "inputs": {
-        "logos-nix": "logos-nix_355",
+        "logos-nix": "logos-nix_357",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26213,7 +26258,7 @@
     },
     "logos-package_42": {
       "inputs": {
-        "logos-nix": "logos-nix_361",
+        "logos-nix": "logos-nix_363",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26240,7 +26285,7 @@
     },
     "logos-package_43": {
       "inputs": {
-        "logos-nix": "logos-nix_384",
+        "logos-nix": "logos-nix_386",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26271,7 +26316,7 @@
     },
     "logos-package_44": {
       "inputs": {
-        "logos-nix": "logos-nix_393",
+        "logos-nix": "logos-nix_395",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26301,7 +26346,7 @@
     },
     "logos-package_45": {
       "inputs": {
-        "logos-nix": "logos-nix_397",
+        "logos-nix": "logos-nix_399",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26330,7 +26375,7 @@
     },
     "logos-package_46": {
       "inputs": {
-        "logos-nix": "logos-nix_401",
+        "logos-nix": "logos-nix_403",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26360,7 +26405,7 @@
     },
     "logos-package_47": {
       "inputs": {
-        "logos-nix": "logos-nix_406",
+        "logos-nix": "logos-nix_408",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26390,7 +26435,7 @@
     },
     "logos-package_48": {
       "inputs": {
-        "logos-nix": "logos-nix_427",
+        "logos-nix": "logos-nix_429",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26422,7 +26467,7 @@
     },
     "logos-package_49": {
       "inputs": {
-        "logos-nix": "logos-nix_436",
+        "logos-nix": "logos-nix_438",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26482,7 +26527,7 @@
     },
     "logos-package_50": {
       "inputs": {
-        "logos-nix": "logos-nix_440",
+        "logos-nix": "logos-nix_442",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26512,7 +26557,7 @@
     },
     "logos-package_51": {
       "inputs": {
-        "logos-nix": "logos-nix_444",
+        "logos-nix": "logos-nix_446",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26543,7 +26588,7 @@
     },
     "logos-package_52": {
       "inputs": {
-        "logos-nix": "logos-nix_449",
+        "logos-nix": "logos-nix_451",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26574,7 +26619,7 @@
     },
     "logos-package_53": {
       "inputs": {
-        "logos-nix": "logos-nix_455",
+        "logos-nix": "logos-nix_457",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26602,7 +26647,7 @@
     },
     "logos-package_54": {
       "inputs": {
-        "logos-nix": "logos-nix_481",
+        "logos-nix": "logos-nix_483",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26635,7 +26680,7 @@
     },
     "logos-package_55": {
       "inputs": {
-        "logos-nix": "logos-nix_490",
+        "logos-nix": "logos-nix_492",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26667,7 +26712,7 @@
     },
     "logos-package_56": {
       "inputs": {
-        "logos-nix": "logos-nix_494",
+        "logos-nix": "logos-nix_496",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26698,7 +26743,7 @@
     },
     "logos-package_57": {
       "inputs": {
-        "logos-nix": "logos-nix_498",
+        "logos-nix": "logos-nix_500",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26730,7 +26775,7 @@
     },
     "logos-package_58": {
       "inputs": {
-        "logos-nix": "logos-nix_503",
+        "logos-nix": "logos-nix_505",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26762,7 +26807,7 @@
     },
     "logos-package_59": {
       "inputs": {
-        "logos-nix": "logos-nix_509",
+        "logos-nix": "logos-nix_511",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26822,7 +26867,7 @@
     },
     "logos-package_60": {
       "inputs": {
-        "logos-nix": "logos-nix_532",
+        "logos-nix": "logos-nix_534",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26855,7 +26900,7 @@
     },
     "logos-package_61": {
       "inputs": {
-        "logos-nix": "logos-nix_541",
+        "logos-nix": "logos-nix_543",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26887,7 +26932,7 @@
     },
     "logos-package_62": {
       "inputs": {
-        "logos-nix": "logos-nix_545",
+        "logos-nix": "logos-nix_547",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26918,7 +26963,7 @@
     },
     "logos-package_63": {
       "inputs": {
-        "logos-nix": "logos-nix_549",
+        "logos-nix": "logos-nix_551",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26950,7 +26995,7 @@
     },
     "logos-package_64": {
       "inputs": {
-        "logos-nix": "logos-nix_554",
+        "logos-nix": "logos-nix_556",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -26982,7 +27027,7 @@
     },
     "logos-package_65": {
       "inputs": {
-        "logos-nix": "logos-nix_575",
+        "logos-nix": "logos-nix_577",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27016,7 +27061,7 @@
     },
     "logos-package_66": {
       "inputs": {
-        "logos-nix": "logos-nix_584",
+        "logos-nix": "logos-nix_586",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27049,7 +27094,7 @@
     },
     "logos-package_67": {
       "inputs": {
-        "logos-nix": "logos-nix_588",
+        "logos-nix": "logos-nix_590",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27081,7 +27126,7 @@
     },
     "logos-package_68": {
       "inputs": {
-        "logos-nix": "logos-nix_592",
+        "logos-nix": "logos-nix_594",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27114,7 +27159,7 @@
     },
     "logos-package_69": {
       "inputs": {
-        "logos-nix": "logos-nix_597",
+        "logos-nix": "logos-nix_599",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27177,7 +27222,7 @@
     },
     "logos-package_70": {
       "inputs": {
-        "logos-nix": "logos-nix_603",
+        "logos-nix": "logos-nix_605",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27207,7 +27252,7 @@
     },
     "logos-package_71": {
       "inputs": {
-        "logos-nix": "logos-nix_616",
+        "logos-nix": "logos-nix_618",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27237,7 +27282,7 @@
     },
     "logos-package_72": {
       "inputs": {
-        "logos-nix": "logos-nix_621",
+        "logos-nix": "logos-nix_623",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27267,7 +27312,7 @@
     },
     "logos-package_73": {
       "inputs": {
-        "logos-nix": "logos-nix_641",
+        "logos-nix": "logos-nix_643",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27298,7 +27343,7 @@
     },
     "logos-package_74": {
       "inputs": {
-        "logos-nix": "logos-nix_650",
+        "logos-nix": "logos-nix_652",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27328,7 +27373,7 @@
     },
     "logos-package_75": {
       "inputs": {
-        "logos-nix": "logos-nix_654",
+        "logos-nix": "logos-nix_656",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27357,7 +27402,7 @@
     },
     "logos-package_76": {
       "inputs": {
-        "logos-nix": "logos-nix_658",
+        "logos-nix": "logos-nix_660",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27387,7 +27432,7 @@
     },
     "logos-package_77": {
       "inputs": {
-        "logos-nix": "logos-nix_663",
+        "logos-nix": "logos-nix_665",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27417,7 +27462,7 @@
     },
     "logos-package_78": {
       "inputs": {
-        "logos-nix": "logos-nix_671",
+        "logos-nix": "logos-nix_673",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27445,7 +27490,7 @@
     },
     "logos-package_79": {
       "inputs": {
-        "logos-nix": "logos-nix_676",
+        "logos-nix": "logos-nix_678",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27502,7 +27547,7 @@
     },
     "logos-package_80": {
       "inputs": {
-        "logos-nix": "logos-nix_703",
+        "logos-nix": "logos-nix_705",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27534,7 +27579,7 @@
     },
     "logos-package_81": {
       "inputs": {
-        "logos-nix": "logos-nix_712",
+        "logos-nix": "logos-nix_714",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27565,7 +27610,7 @@
     },
     "logos-package_82": {
       "inputs": {
-        "logos-nix": "logos-nix_716",
+        "logos-nix": "logos-nix_718",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27595,7 +27640,7 @@
     },
     "logos-package_83": {
       "inputs": {
-        "logos-nix": "logos-nix_720",
+        "logos-nix": "logos-nix_722",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27626,7 +27671,7 @@
     },
     "logos-package_84": {
       "inputs": {
-        "logos-nix": "logos-nix_725",
+        "logos-nix": "logos-nix_727",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27657,7 +27702,7 @@
     },
     "logos-package_85": {
       "inputs": {
-        "logos-nix": "logos-nix_747",
+        "logos-nix": "logos-nix_749",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27690,7 +27735,7 @@
     },
     "logos-package_86": {
       "inputs": {
-        "logos-nix": "logos-nix_756",
+        "logos-nix": "logos-nix_758",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27722,7 +27767,7 @@
     },
     "logos-package_87": {
       "inputs": {
-        "logos-nix": "logos-nix_760",
+        "logos-nix": "logos-nix_762",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27753,7 +27798,7 @@
     },
     "logos-package_88": {
       "inputs": {
-        "logos-nix": "logos-nix_764",
+        "logos-nix": "logos-nix_766",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27785,7 +27830,7 @@
     },
     "logos-package_89": {
       "inputs": {
-        "logos-nix": "logos-nix_769",
+        "logos-nix": "logos-nix_771",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27847,7 +27892,7 @@
     },
     "logos-package_90": {
       "inputs": {
-        "logos-nix": "logos-nix_775",
+        "logos-nix": "logos-nix_777",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27876,7 +27921,7 @@
     },
     "logos-package_91": {
       "inputs": {
-        "logos-nix": "logos-nix_784",
+        "logos-nix": "logos-nix_786",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27904,7 +27949,7 @@
     },
     "logos-package_92": {
       "inputs": {
-        "logos-nix": "logos-nix_788",
+        "logos-nix": "logos-nix_790",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27931,7 +27976,7 @@
     },
     "logos-package_93": {
       "inputs": {
-        "logos-nix": "logos-nix_792",
+        "logos-nix": "logos-nix_794",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27959,7 +28004,7 @@
     },
     "logos-package_94": {
       "inputs": {
-        "logos-nix": "logos-nix_797",
+        "logos-nix": "logos-nix_799",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -27987,7 +28032,7 @@
     },
     "logos-package_95": {
       "inputs": {
-        "logos-nix": "logos-nix_805",
+        "logos-nix": "logos-nix_807",
         "nixpkgs": [
           "logoscore-cli",
           "nix-bundle-logos-module-install",
@@ -28013,7 +28058,7 @@
     },
     "logos-package_96": {
       "inputs": {
-        "logos-nix": "logos-nix_810",
+        "logos-nix": "logos-nix_812",
         "nixpkgs": [
           "logoscore-cli",
           "nix-bundle-logos-module-install",
@@ -28039,7 +28084,7 @@
     },
     "logos-package_97": {
       "inputs": {
-        "logos-nix": "logos-nix_813",
+        "logos-nix": "logos-nix_815",
         "nixpkgs": [
           "package-manager",
           "logos-package",
@@ -28089,7 +28134,7 @@
     "logos-plugin-core_10": {
       "inputs": {
         "logos-module": "logos-module_55",
-        "logos-nix": "logos-nix_413",
+        "logos-nix": "logos-nix_415",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28119,7 +28164,7 @@
     "logos-plugin-core_11": {
       "inputs": {
         "logos-module": "logos-module_62",
-        "logos-nix": "logos-nix_467",
+        "logos-nix": "logos-nix_469",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28150,7 +28195,7 @@
     "logos-plugin-core_12": {
       "inputs": {
         "logos-module": "logos-module_69",
-        "logos-nix": "logos-nix_518",
+        "logos-nix": "logos-nix_520",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28181,7 +28226,7 @@
     "logos-plugin-core_13": {
       "inputs": {
         "logos-module": "logos-module_75",
-        "logos-nix": "logos-nix_561",
+        "logos-nix": "logos-nix_563",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28213,7 +28258,7 @@
     "logos-plugin-core_14": {
       "inputs": {
         "logos-module": "logos-module_82",
-        "logos-nix": "logos-nix_627",
+        "logos-nix": "logos-nix_629",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28242,7 +28287,7 @@
     "logos-plugin-core_15": {
       "inputs": {
         "logos-module": "logos-module_88",
-        "logos-nix": "logos-nix_682",
+        "logos-nix": "logos-nix_684",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28269,7 +28314,7 @@
     "logos-plugin-core_16": {
       "inputs": {
         "logos-module": "logos-module_91",
-        "logos-nix": "logos-nix_689",
+        "logos-nix": "logos-nix_691",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28299,7 +28344,7 @@
     "logos-plugin-core_17": {
       "inputs": {
         "logos-module": "logos-module_97",
-        "logos-nix": "logos-nix_733",
+        "logos-nix": "logos-nix_735",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28387,7 +28432,7 @@
     "logos-plugin-core_4": {
       "inputs": {
         "logos-module": "logos-module_18",
-        "logos-nix": "logos-nix_128",
+        "logos-nix": "logos-nix_130",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -28414,7 +28459,7 @@
     "logos-plugin-core_5": {
       "inputs": {
         "logos-module": "logos-module_25",
-        "logos-nix": "logos-nix_181",
+        "logos-nix": "logos-nix_183",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -28442,7 +28487,7 @@
     "logos-plugin-core_6": {
       "inputs": {
         "logos-module": "logos-module_28",
-        "logos-nix": "logos-nix_188",
+        "logos-nix": "logos-nix_190",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -28473,7 +28518,7 @@
     "logos-plugin-core_7": {
       "inputs": {
         "logos-module": "logos-module_34",
-        "logos-nix": "logos-nix_232",
+        "logos-nix": "logos-nix_234",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -28505,7 +28550,7 @@
     "logos-plugin-core_8": {
       "inputs": {
         "logos-module": "logos-module_42",
-        "logos-nix": "logos-nix_319",
+        "logos-nix": "logos-nix_321",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28534,7 +28579,7 @@
     "logos-plugin-core_9": {
       "inputs": {
         "logos-module": "logos-module_49",
-        "logos-nix": "logos-nix_370",
+        "logos-nix": "logos-nix_372",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28588,7 +28633,7 @@
     "logos-plugin-qt_10": {
       "inputs": {
         "logos-module": "logos-module_56",
-        "logos-nix": "logos-nix_415",
+        "logos-nix": "logos-nix_417",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28618,7 +28663,7 @@
     "logos-plugin-qt_11": {
       "inputs": {
         "logos-module": "logos-module_63",
-        "logos-nix": "logos-nix_469",
+        "logos-nix": "logos-nix_471",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28649,7 +28694,7 @@
     "logos-plugin-qt_12": {
       "inputs": {
         "logos-module": "logos-module_70",
-        "logos-nix": "logos-nix_520",
+        "logos-nix": "logos-nix_522",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28680,7 +28725,7 @@
     "logos-plugin-qt_13": {
       "inputs": {
         "logos-module": "logos-module_76",
-        "logos-nix": "logos-nix_563",
+        "logos-nix": "logos-nix_565",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28712,7 +28757,7 @@
     "logos-plugin-qt_14": {
       "inputs": {
         "logos-module": "logos-module_83",
-        "logos-nix": "logos-nix_629",
+        "logos-nix": "logos-nix_631",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28741,7 +28786,7 @@
     "logos-plugin-qt_15": {
       "inputs": {
         "logos-module": "logos-module_89",
-        "logos-nix": "logos-nix_684",
+        "logos-nix": "logos-nix_686",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28768,7 +28813,7 @@
     "logos-plugin-qt_16": {
       "inputs": {
         "logos-module": "logos-module_92",
-        "logos-nix": "logos-nix_691",
+        "logos-nix": "logos-nix_693",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28798,7 +28843,7 @@
     "logos-plugin-qt_17": {
       "inputs": {
         "logos-module": "logos-module_98",
-        "logos-nix": "logos-nix_735",
+        "logos-nix": "logos-nix_737",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -28886,7 +28931,7 @@
     "logos-plugin-qt_4": {
       "inputs": {
         "logos-module": "logos-module_19",
-        "logos-nix": "logos-nix_130",
+        "logos-nix": "logos-nix_132",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -28913,7 +28958,7 @@
     "logos-plugin-qt_5": {
       "inputs": {
         "logos-module": "logos-module_26",
-        "logos-nix": "logos-nix_183",
+        "logos-nix": "logos-nix_185",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -28941,7 +28986,7 @@
     "logos-plugin-qt_6": {
       "inputs": {
         "logos-module": "logos-module_29",
-        "logos-nix": "logos-nix_190",
+        "logos-nix": "logos-nix_192",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -28972,7 +29017,7 @@
     "logos-plugin-qt_7": {
       "inputs": {
         "logos-module": "logos-module_35",
-        "logos-nix": "logos-nix_234",
+        "logos-nix": "logos-nix_236",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -29004,7 +29049,7 @@
     "logos-plugin-qt_8": {
       "inputs": {
         "logos-module": "logos-module_43",
-        "logos-nix": "logos-nix_321",
+        "logos-nix": "logos-nix_323",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -29033,7 +29078,7 @@
     "logos-plugin-qt_9": {
       "inputs": {
         "logos-module": "logos-module_50",
-        "logos-nix": "logos-nix_372",
+        "logos-nix": "logos-nix_374",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -29070,11 +29115,35 @@
         ]
       },
       "locked": {
-        "lastModified": 1782082589,
-        "narHash": "sha256-Qeqxp0HYb3oTpmfD5YlFPJzpAJa7Ilb9o4sMeVvmHRI=",
+        "lastModified": 1782291447,
+        "narHash": "sha256-Jkc8MOuJNuQEEs69GMOwDL1bzAPxdMsJ7hlEUz6nkQM=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "315a3a2e0af61bc47aad5601ee44cd7689975820",
+        "rev": "c6234940fc030af2fd5c445db82120dc2162887f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_10": {
+      "inputs": {
+        "logos-nix": "logos-nix_315",
+        "nixpkgs": [
+          "logoscore-cli",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
         "type": "github"
       },
       "original": {
@@ -29084,6 +29153,152 @@
       }
     },
     "logos-protocol_2": {
+      "inputs": {
+        "logos-nix": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_3": {
+      "inputs": {
+        "logos-nix": "logos-nix_104",
+        "nixpkgs": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_4": {
+      "inputs": {
+        "logos-nix": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_5": {
+      "inputs": {
+        "logos-nix": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_6": {
+      "inputs": {
+        "logos-nix": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_7": {
       "inputs": {
         "logos-nix": [
           "logos-module-builder",
@@ -29097,11 +29312,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781065710,
-        "narHash": "sha256-QmNQ7LdrfzyvsZGISGKJKbHqB03F6JExgGF2K1f2WcE=",
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "ca28190272eef2772edf9b3e1df47e121f02a726",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
         "type": "github"
       },
       "original": {
@@ -29110,9 +29325,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_3": {
+    "logos-protocol_8": {
       "inputs": {
-        "logos-nix": "logos-nix_175",
+        "logos-nix": "logos-nix_177",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -29136,36 +29351,12 @@
         "type": "github"
       }
     },
-    "logos-protocol_4": {
+    "logos-protocol_9": {
       "inputs": {
-        "logos-nix": "logos-nix_309",
+        "logos-nix": "logos-nix_311",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781303997,
-        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_5": {
-      "inputs": {
-        "logos-nix": "logos-nix_313",
-        "nixpkgs": [
-          "logoscore-cli",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -29214,7 +29405,7 @@
     },
     "logos-qt-mcp_10": {
       "inputs": {
-        "logos-nix": "logos-nix_433",
+        "logos-nix": "logos-nix_435",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -29243,7 +29434,7 @@
     },
     "logos-qt-mcp_11": {
       "inputs": {
-        "logos-nix": "logos-nix_487",
+        "logos-nix": "logos-nix_489",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -29273,7 +29464,7 @@
     },
     "logos-qt-mcp_12": {
       "inputs": {
-        "logos-nix": "logos-nix_538",
+        "logos-nix": "logos-nix_540",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -29303,7 +29494,7 @@
     },
     "logos-qt-mcp_13": {
       "inputs": {
-        "logos-nix": "logos-nix_581",
+        "logos-nix": "logos-nix_583",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -29334,7 +29525,7 @@
     },
     "logos-qt-mcp_14": {
       "inputs": {
-        "logos-nix": "logos-nix_647",
+        "logos-nix": "logos-nix_649",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -29362,7 +29553,7 @@
     },
     "logos-qt-mcp_15": {
       "inputs": {
-        "logos-nix": "logos-nix_709",
+        "logos-nix": "logos-nix_711",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -29391,7 +29582,7 @@
     },
     "logos-qt-mcp_16": {
       "inputs": {
-        "logos-nix": "logos-nix_753",
+        "logos-nix": "logos-nix_755",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -29421,7 +29612,7 @@
     },
     "logos-qt-mcp_17": {
       "inputs": {
-        "logos-nix": "logos-nix_781",
+        "logos-nix": "logos-nix_783",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -29476,7 +29667,7 @@
     },
     "logos-qt-mcp_3": {
       "inputs": {
-        "logos-nix": "logos-nix_106",
+        "logos-nix": "logos-nix_108",
         "nixpkgs": [
           "logos-module-builder",
           "logos-standalone-app",
@@ -29486,11 +29677,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774455349,
-        "narHash": "sha256-rebrtH1UxC1hDuwQBwyYbGzNCrnuuqiVL7OvzUhk65k=",
+        "lastModified": 1781077555,
+        "narHash": "sha256-rkqva3DbhhxWrVp6KLyhVxbAK2MLIWfUcPG5HM7wnsQ=",
         "owner": "logos-co",
         "repo": "logos-qt-mcp",
-        "rev": "c5223b4b640add09e461983b8fddbd12c8b31f4f",
+        "rev": "c87f6bd985a07ec2809081c8d0830108aa895819",
         "type": "github"
       },
       "original": {
@@ -29501,7 +29692,7 @@
     },
     "logos-qt-mcp_4": {
       "inputs": {
-        "logos-nix": "logos-nix_148",
+        "logos-nix": "logos-nix_150",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -29527,7 +29718,7 @@
     },
     "logos-qt-mcp_5": {
       "inputs": {
-        "logos-nix": "logos-nix_208",
+        "logos-nix": "logos-nix_210",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -29557,7 +29748,7 @@
     },
     "logos-qt-mcp_6": {
       "inputs": {
-        "logos-nix": "logos-nix_252",
+        "logos-nix": "logos-nix_254",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -29588,7 +29779,7 @@
     },
     "logos-qt-mcp_7": {
       "inputs": {
-        "logos-nix": "logos-nix_280",
+        "logos-nix": "logos-nix_282",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -29616,7 +29807,7 @@
     },
     "logos-qt-mcp_8": {
       "inputs": {
-        "logos-nix": "logos-nix_339",
+        "logos-nix": "logos-nix_341",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -29644,7 +29835,7 @@
     },
     "logos-qt-mcp_9": {
       "inputs": {
-        "logos-nix": "logos-nix_390",
+        "logos-nix": "logos-nix_392",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -29690,11 +29881,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781962335,
-        "narHash": "sha256-TThOj0o115vPawAPJgv5zhDnV/hVfnDqjpga9Z2SlPU=",
+        "lastModified": 1782296555,
+        "narHash": "sha256-1M/TzEn/1Whby0eGlaovwHQQ1eiCXSJ/AOMFihoOHSI=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "cdf077cdb296b39fe45d6f774a0b4ae71be48d45",
+        "rev": "9020fa99f214458fd1f1c69a8ed16e02536ac9f9",
         "type": "github"
       },
       "original": {
@@ -29704,6 +29895,122 @@
       }
     },
     "logos-qt-sdk_2": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": "logos-nix_105",
+        "logos-protocol": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_3": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_4": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_5": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-module-builder",
@@ -29727,11 +30034,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781066423,
-        "narHash": "sha256-3pVeJ/cK2z4OEi5iLORjoC7YpdrRrHmigl9SyvEapI8=",
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "355774603877637b486ea0aeefbf7828ae321868",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
         "type": "github"
       },
       "original": {
@@ -29740,7 +30047,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_3": {
+    "logos-qt-sdk_6": {
       "inputs": {
         "logos-cpp-sdk": [
           "logoscore-cli",
@@ -29749,7 +30056,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_5",
-        "logos-nix": "logos-nix_176",
+        "logos-nix": "logos-nix_178",
         "logos-protocol": [
           "logoscore-cli",
           "logos-liblogos",
@@ -29779,7 +30086,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_4": {
+    "logos-qt-sdk_7": {
       "inputs": {
         "logos-cpp-sdk": [
           "logoscore-cli",
@@ -29787,7 +30094,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_7",
-        "logos-nix": "logos-nix_310",
+        "logos-nix": "logos-nix_312",
         "logos-protocol": [
           "logoscore-cli",
           "logos-liblogos",
@@ -29815,13 +30122,13 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_5": {
+    "logos-qt-sdk_8": {
       "inputs": {
         "logos-cpp-sdk": [
           "logoscore-cli",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_314",
+        "logos-nix": "logos-nix_316",
         "logos-protocol": [
           "logoscore-cli",
           "logos-protocol"
@@ -29894,8 +30201,10 @@
         "logos-cpp-sdk": "logos-cpp-sdk_6",
         "logos-design-system": "logos-design-system_2",
         "logos-liblogos": "logos-liblogos_2",
-        "logos-nix": "logos-nix_105",
+        "logos-nix": "logos-nix_107",
+        "logos-protocol": "logos-protocol_4",
         "logos-qt-mcp": "logos-qt-mcp_3",
+        "logos-qt-sdk": "logos-qt-sdk_3",
         "logos-view-module-runtime": "logos-view-module-runtime_3",
         "nix-bundle-lgx": "nix-bundle-lgx_7",
         "nixpkgs": [
@@ -29906,11 +30215,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779725202,
-        "narHash": "sha256-7IqnkRG1CkOKfiw5qf1o+Kg9ci+MKlcJNXgrg6GyYXk=",
+        "lastModified": 1781319979,
+        "narHash": "sha256-7rbkfuCeHmhv+eVqWUeVzJqtNDW9ynjf5TkajNIySDU=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "f812b43f73f3c264ee0f8a8354f40721431d6846",
+        "rev": "c8c0bece1fe8f0d21541e136b222aecbe2755b9f",
         "type": "github"
       },
       "original": {
@@ -29925,7 +30234,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_43",
         "logos-design-system": "logos-design-system_10",
         "logos-liblogos": "logos-liblogos_13",
-        "logos-nix": "logos-nix_432",
+        "logos-nix": "logos-nix_434",
         "logos-qt-mcp": "logos-qt-mcp_10",
         "logos-view-module-runtime": "logos-view-module-runtime_10",
         "nix-bundle-lgx": "nix-bundle-lgx_28",
@@ -29961,7 +30270,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_49",
         "logos-design-system": "logos-design-system_11",
         "logos-liblogos": "logos-liblogos_15",
-        "logos-nix": "logos-nix_486",
+        "logos-nix": "logos-nix_488",
         "logos-qt-mcp": "logos-qt-mcp_11",
         "logos-view-module-runtime": "logos-view-module-runtime_11",
         "nix-bundle-lgx": "nix-bundle-lgx_31",
@@ -29998,7 +30307,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_54",
         "logos-design-system": "logos-design-system_12",
         "logos-liblogos": "logos-liblogos_16",
-        "logos-nix": "logos-nix_537",
+        "logos-nix": "logos-nix_539",
         "logos-qt-mcp": "logos-qt-mcp_12",
         "logos-view-module-runtime": "logos-view-module-runtime_12",
         "nix-bundle-lgx": "nix-bundle-lgx_34",
@@ -30035,7 +30344,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_59",
         "logos-design-system": "logos-design-system_13",
         "logos-liblogos": "logos-liblogos_18",
-        "logos-nix": "logos-nix_580",
+        "logos-nix": "logos-nix_582",
         "logos-qt-mcp": "logos-qt-mcp_13",
         "logos-view-module-runtime": "logos-view-module-runtime_13",
         "nix-bundle-lgx": "nix-bundle-lgx_37",
@@ -30073,7 +30382,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_65",
         "logos-design-system": "logos-design-system_14",
         "logos-liblogos": "logos-liblogos_19",
-        "logos-nix": "logos-nix_646",
+        "logos-nix": "logos-nix_648",
         "logos-qt-mcp": "logos-qt-mcp_14",
         "logos-view-module-runtime": "logos-view-module-runtime_14",
         "nix-bundle-lgx": "nix-bundle-lgx_41",
@@ -30108,7 +30417,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_73",
         "logos-design-system": "logos-design-system_16",
         "logos-liblogos": "logos-liblogos_21",
-        "logos-nix": "logos-nix_780",
+        "logos-nix": "logos-nix_782",
         "logos-qt-mcp": "logos-qt-mcp_17",
         "logos-view-module-runtime": "logos-view-module-runtime_17",
         "nix-bundle-lgx": "nix-bundle-lgx_51",
@@ -30141,7 +30450,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_70",
         "logos-design-system": "logos-design-system_15",
         "logos-liblogos": "logos-liblogos_20",
-        "logos-nix": "logos-nix_708",
+        "logos-nix": "logos-nix_710",
         "logos-qt-mcp": "logos-qt-mcp_15",
         "logos-view-module-runtime": "logos-view-module-runtime_15",
         "nix-bundle-lgx": "nix-bundle-lgx_45",
@@ -30177,7 +30486,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_75",
         "logos-design-system": "logos-design-system_17",
         "logos-liblogos": "logos-liblogos_22",
-        "logos-nix": "logos-nix_752",
+        "logos-nix": "logos-nix_754",
         "logos-qt-mcp": "logos-qt-mcp_16",
         "logos-view-module-runtime": "logos-view-module-runtime_16",
         "nix-bundle-lgx": "nix-bundle-lgx_48",
@@ -30283,7 +30592,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_14",
         "logos-design-system": "logos-design-system_4",
         "logos-liblogos": "logos-liblogos_4",
-        "logos-nix": "logos-nix_147",
+        "logos-nix": "logos-nix_149",
         "logos-qt-mcp": "logos-qt-mcp_4",
         "logos-view-module-runtime": "logos-view-module-runtime_4",
         "nix-bundle-lgx": "nix-bundle-lgx_10",
@@ -30316,7 +30625,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_24",
         "logos-design-system": "logos-design-system_6",
         "logos-liblogos": "logos-liblogos_7",
-        "logos-nix": "logos-nix_279",
+        "logos-nix": "logos-nix_281",
         "logos-qt-mcp": "logos-qt-mcp_7",
         "logos-view-module-runtime": "logos-view-module-runtime_7",
         "nix-bundle-lgx": "nix-bundle-lgx_19",
@@ -30350,7 +30659,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_21",
         "logos-design-system": "logos-design-system_5",
         "logos-liblogos": "logos-liblogos_6",
-        "logos-nix": "logos-nix_207",
+        "logos-nix": "logos-nix_209",
         "logos-qt-mcp": "logos-qt-mcp_5",
         "logos-view-module-runtime": "logos-view-module-runtime_5",
         "nix-bundle-lgx": "nix-bundle-lgx_13",
@@ -30387,7 +30696,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_26",
         "logos-design-system": "logos-design-system_7",
         "logos-liblogos": "logos-liblogos_8",
-        "logos-nix": "logos-nix_251",
+        "logos-nix": "logos-nix_253",
         "logos-qt-mcp": "logos-qt-mcp_6",
         "logos-view-module-runtime": "logos-view-module-runtime_6",
         "nix-bundle-lgx": "nix-bundle-lgx_16",
@@ -30425,7 +30734,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_33",
         "logos-design-system": "logos-design-system_8",
         "logos-liblogos": "logos-liblogos_10",
-        "logos-nix": "logos-nix_338",
+        "logos-nix": "logos-nix_340",
         "logos-qt-mcp": "logos-qt-mcp_8",
         "logos-view-module-runtime": "logos-view-module-runtime_8",
         "nix-bundle-lgx": "nix-bundle-lgx_22",
@@ -30460,7 +30769,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_38",
         "logos-design-system": "logos-design-system_9",
         "logos-liblogos": "logos-liblogos_11",
-        "logos-nix": "logos-nix_389",
+        "logos-nix": "logos-nix_391",
         "logos-qt-mcp": "logos-qt-mcp_9",
         "logos-view-module-runtime": "logos-view-module-runtime_9",
         "nix-bundle-lgx": "nix-bundle-lgx_25",
@@ -30534,7 +30843,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_438",
+        "logos-nix": "logos-nix_440",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -30573,7 +30882,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_492",
+        "logos-nix": "logos-nix_494",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -30613,7 +30922,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_543",
+        "logos-nix": "logos-nix_545",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -30654,7 +30963,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_586",
+        "logos-nix": "logos-nix_588",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -30693,7 +31002,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_652",
+        "logos-nix": "logos-nix_654",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -30730,7 +31039,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_714",
+        "logos-nix": "logos-nix_716",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -30769,7 +31078,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_758",
+        "logos-nix": "logos-nix_760",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -30805,7 +31114,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_786",
+        "logos-nix": "logos-nix_788",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -30871,9 +31180,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_111",
-        "logos-protocol": "logos-protocol_2",
-        "logos-qt-sdk": "logos-qt-sdk_2",
+        "logos-nix": "logos-nix_113",
+        "logos-protocol": "logos-protocol_7",
+        "logos-qt-sdk": "logos-qt-sdk_5",
         "nixpkgs": [
           "logos-module-builder",
           "logos-test-framework",
@@ -30882,11 +31191,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781118884,
-        "narHash": "sha256-bM8Deqf6soZeUqWy3RdyY0APRKLWmjD/78g1fbEObaY=",
+        "lastModified": 1781319474,
+        "narHash": "sha256-dcJJymaY43fBCluUocVZHpDuUwO4Inm/vGnlO880j/0=",
         "owner": "logos-co",
         "repo": "logos-test-framework",
-        "rev": "5b8fcc9ffdc5c66511a95a6bf6b41dd74fbbacc9",
+        "rev": "9665bc792905527553cfaed1e27ce10cf5e812a4",
         "type": "github"
       },
       "original": {
@@ -30903,7 +31212,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_153",
+        "logos-nix": "logos-nix_155",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -30939,7 +31248,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_213",
+        "logos-nix": "logos-nix_215",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -30980,7 +31289,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_257",
+        "logos-nix": "logos-nix_259",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -31018,7 +31327,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_285",
+        "logos-nix": "logos-nix_287",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -31053,7 +31362,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_344",
+        "logos-nix": "logos-nix_346",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -31089,7 +31398,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_395",
+        "logos-nix": "logos-nix_397",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -31120,7 +31429,7 @@
         "logos-liblogos": "logos-liblogos_9",
         "logos-logoscore-cli": "logos-logoscore-cli",
         "logos-module-builder": "logos-module-builder_15",
-        "logos-nix": "logos-nix_799",
+        "logos-nix": "logos-nix_801",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -31147,7 +31456,7 @@
         "logos-liblogos": "logos-liblogos_14",
         "logos-logoscore-cli": "logos-logoscore-cli_2",
         "logos-module-builder": "logos-module-builder_14",
-        "logos-nix": "logos-nix_665",
+        "logos-nix": "logos-nix_667",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -31218,7 +31527,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_434",
+        "logos-nix": "logos-nix_436",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -31258,7 +31567,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_488",
+        "logos-nix": "logos-nix_490",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -31299,7 +31608,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_539",
+        "logos-nix": "logos-nix_541",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -31341,7 +31650,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_582",
+        "logos-nix": "logos-nix_584",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -31381,7 +31690,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_648",
+        "logos-nix": "logos-nix_650",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -31419,7 +31728,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_710",
+        "logos-nix": "logos-nix_712",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -31459,7 +31768,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_754",
+        "logos-nix": "logos-nix_756",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -31490,7 +31799,7 @@
     "logos-view-module-runtime_17": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_79",
-        "logos-nix": "logos-nix_782",
+        "logos-nix": "logos-nix_784",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -31555,7 +31864,9 @@
     "logos-view-module-runtime_3": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_12",
-        "logos-nix": "logos-nix_107",
+        "logos-nix": "logos-nix_109",
+        "logos-protocol": "logos-protocol_6",
+        "logos-qt-sdk": "logos-qt-sdk_4",
         "nixpkgs": [
           "logos-module-builder",
           "logos-standalone-app",
@@ -31565,11 +31876,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779723114,
-        "narHash": "sha256-6NNZG9FTaLRKwJZxtFWySlfiTanh25AmJK5Ru+S9HrM=",
+        "lastModified": 1781316066,
+        "narHash": "sha256-s5aaSGhu5HiotCXa0Vbjgp17TTMXedt52cqD/8FM4aQ=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "21dddc380eca36e7e865cf5a437f63e0e16f30d3",
+        "rev": "7541c318d85cabed61b9222d59d4110836ede430",
         "type": "github"
       },
       "original": {
@@ -31587,7 +31898,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_149",
+        "logos-nix": "logos-nix_151",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -31624,7 +31935,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_209",
+        "logos-nix": "logos-nix_211",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -31666,7 +31977,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_253",
+        "logos-nix": "logos-nix_255",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -31698,7 +32009,7 @@
     "logos-view-module-runtime_7": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_30",
-        "logos-nix": "logos-nix_281",
+        "logos-nix": "logos-nix_283",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -31735,7 +32046,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_340",
+        "logos-nix": "logos-nix_342",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -31772,7 +32083,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_391",
+        "logos-nix": "logos-nix_393",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -31803,9 +32114,9 @@
         "logos-capability-module": "logos-capability-module_7",
         "logos-cpp-sdk": "logos-cpp-sdk_17",
         "logos-liblogos": "logos-liblogos_5",
-        "logos-nix": "logos-nix_312",
-        "logos-protocol": "logos-protocol_5",
-        "logos-qt-sdk": "logos-qt-sdk_5",
+        "logos-nix": "logos-nix_314",
+        "logos-protocol": "logos-protocol_10",
+        "logos-qt-sdk": "logos-qt-sdk_8",
         "logos-test-modules": "logos-test-modules",
         "nix-bundle-appimage": "nix-bundle-appimage_44",
         "nix-bundle-dir": "nix-bundle-dir_141",
@@ -31817,11 +32128,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781907401,
-        "narHash": "sha256-7JIXkoI9DZLq59AhDH1ddvuKSLrySzefuKEHHU8H4so=",
+        "lastModified": 1782312742,
+        "narHash": "sha256-wV4jgsoab46V9yaEuP2id7PhOTpGXD8/lvC13mxYHMw=",
         "owner": "logos-co",
         "repo": "logos-logoscore-cli",
-        "rev": "859c365ea15acd27cc9acfcebbb092d26d491585",
+        "rev": "054b21440eb0c2b580a5e7b764c4f13f10c8717a",
         "type": "github"
       },
       "original": {
@@ -31863,7 +32174,7 @@
     },
     "nix-bundle-appimage_10": {
       "inputs": {
-        "logos-nix": "logos-nix_220",
+        "logos-nix": "logos-nix_222",
         "nix-bundle-dir": "nix-bundle-dir_33",
         "nixpkgs": [
           "logoscore-cli",
@@ -31896,7 +32207,7 @@
     },
     "nix-bundle-appimage_11": {
       "inputs": {
-        "logos-nix": "logos-nix_247",
+        "logos-nix": "logos-nix_249",
         "nix-bundle-dir": "nix-bundle-dir_36",
         "nixpkgs": [
           "logoscore-cli",
@@ -31931,7 +32242,7 @@
     },
     "nix-bundle-appimage_12": {
       "inputs": {
-        "logos-nix": "logos-nix_264",
+        "logos-nix": "logos-nix_266",
         "nix-bundle-dir": "nix-bundle-dir_40",
         "nixpkgs": [
           "logoscore-cli",
@@ -31965,7 +32276,7 @@
     },
     "nix-bundle-appimage_13": {
       "inputs": {
-        "logos-nix": "logos-nix_275",
+        "logos-nix": "logos-nix_277",
         "nix-bundle-dir": "nix-bundle-dir_43",
         "nixpkgs": [
           "logoscore-cli",
@@ -31996,7 +32307,7 @@
     },
     "nix-bundle-appimage_14": {
       "inputs": {
-        "logos-nix": "logos-nix_292",
+        "logos-nix": "logos-nix_294",
         "nix-bundle-dir": "nix-bundle-dir_47",
         "nixpkgs": [
           "logoscore-cli",
@@ -32026,7 +32337,7 @@
     },
     "nix-bundle-appimage_15": {
       "inputs": {
-        "logos-nix": "logos-nix_306",
+        "logos-nix": "logos-nix_308",
         "nix-bundle-dir": "nix-bundle-dir_50",
         "nixpkgs": [
           "logoscore-cli",
@@ -32053,7 +32364,7 @@
     },
     "nix-bundle-appimage_16": {
       "inputs": {
-        "logos-nix": "logos-nix_334",
+        "logos-nix": "logos-nix_336",
         "nix-bundle-dir": "nix-bundle-dir_52",
         "nixpkgs": [
           "logoscore-cli",
@@ -32085,7 +32396,7 @@
     },
     "nix-bundle-appimage_17": {
       "inputs": {
-        "logos-nix": "logos-nix_351",
+        "logos-nix": "logos-nix_353",
         "nix-bundle-dir": "nix-bundle-dir_56",
         "nixpkgs": [
           "logoscore-cli",
@@ -32116,7 +32427,7 @@
     },
     "nix-bundle-appimage_18": {
       "inputs": {
-        "logos-nix": "logos-nix_362",
+        "logos-nix": "logos-nix_364",
         "nix-bundle-dir": "nix-bundle-dir_59",
         "nixpkgs": [
           "logoscore-cli",
@@ -32144,7 +32455,7 @@
     },
     "nix-bundle-appimage_19": {
       "inputs": {
-        "logos-nix": "logos-nix_385",
+        "logos-nix": "logos-nix_387",
         "nix-bundle-dir": "nix-bundle-dir_61",
         "nixpkgs": [
           "logoscore-cli",
@@ -32206,7 +32517,7 @@
     },
     "nix-bundle-appimage_20": {
       "inputs": {
-        "logos-nix": "logos-nix_402",
+        "logos-nix": "logos-nix_404",
         "nix-bundle-dir": "nix-bundle-dir_65",
         "nixpkgs": [
           "logoscore-cli",
@@ -32237,7 +32548,7 @@
     },
     "nix-bundle-appimage_21": {
       "inputs": {
-        "logos-nix": "logos-nix_428",
+        "logos-nix": "logos-nix_430",
         "nix-bundle-dir": "nix-bundle-dir_68",
         "nixpkgs": [
           "logoscore-cli",
@@ -32270,7 +32581,7 @@
     },
     "nix-bundle-appimage_22": {
       "inputs": {
-        "logos-nix": "logos-nix_445",
+        "logos-nix": "logos-nix_447",
         "nix-bundle-dir": "nix-bundle-dir_72",
         "nixpkgs": [
           "logoscore-cli",
@@ -32302,7 +32613,7 @@
     },
     "nix-bundle-appimage_23": {
       "inputs": {
-        "logos-nix": "logos-nix_456",
+        "logos-nix": "logos-nix_458",
         "nix-bundle-dir": "nix-bundle-dir_75",
         "nixpkgs": [
           "logoscore-cli",
@@ -32331,7 +32642,7 @@
     },
     "nix-bundle-appimage_24": {
       "inputs": {
-        "logos-nix": "logos-nix_482",
+        "logos-nix": "logos-nix_484",
         "nix-bundle-dir": "nix-bundle-dir_77",
         "nixpkgs": [
           "logoscore-cli",
@@ -32365,7 +32676,7 @@
     },
     "nix-bundle-appimage_25": {
       "inputs": {
-        "logos-nix": "logos-nix_499",
+        "logos-nix": "logos-nix_501",
         "nix-bundle-dir": "nix-bundle-dir_81",
         "nixpkgs": [
           "logoscore-cli",
@@ -32398,7 +32709,7 @@
     },
     "nix-bundle-appimage_26": {
       "inputs": {
-        "logos-nix": "logos-nix_510",
+        "logos-nix": "logos-nix_512",
         "nix-bundle-dir": "nix-bundle-dir_84",
         "nixpkgs": [
           "logoscore-cli",
@@ -32428,7 +32739,7 @@
     },
     "nix-bundle-appimage_27": {
       "inputs": {
-        "logos-nix": "logos-nix_533",
+        "logos-nix": "logos-nix_535",
         "nix-bundle-dir": "nix-bundle-dir_86",
         "nixpkgs": [
           "logoscore-cli",
@@ -32462,7 +32773,7 @@
     },
     "nix-bundle-appimage_28": {
       "inputs": {
-        "logos-nix": "logos-nix_550",
+        "logos-nix": "logos-nix_552",
         "nix-bundle-dir": "nix-bundle-dir_90",
         "nixpkgs": [
           "logoscore-cli",
@@ -32495,7 +32806,7 @@
     },
     "nix-bundle-appimage_29": {
       "inputs": {
-        "logos-nix": "logos-nix_576",
+        "logos-nix": "logos-nix_578",
         "nix-bundle-dir": "nix-bundle-dir_93",
         "nixpkgs": [
           "logoscore-cli",
@@ -32562,7 +32873,7 @@
     },
     "nix-bundle-appimage_30": {
       "inputs": {
-        "logos-nix": "logos-nix_593",
+        "logos-nix": "logos-nix_595",
         "nix-bundle-dir": "nix-bundle-dir_97",
         "nixpkgs": [
           "logoscore-cli",
@@ -32596,7 +32907,7 @@
     },
     "nix-bundle-appimage_31": {
       "inputs": {
-        "logos-nix": "logos-nix_604",
+        "logos-nix": "logos-nix_606",
         "nix-bundle-dir": "nix-bundle-dir_100",
         "nixpkgs": [
           "logoscore-cli",
@@ -32627,7 +32938,7 @@
     },
     "nix-bundle-appimage_32": {
       "inputs": {
-        "logos-nix": "logos-nix_611",
+        "logos-nix": "logos-nix_613",
         "nix-bundle-dir": "nix-bundle-dir_102",
         "nixpkgs": [
           "logoscore-cli",
@@ -32656,7 +32967,7 @@
     },
     "nix-bundle-appimage_33": {
       "inputs": {
-        "logos-nix": "logos-nix_617",
+        "logos-nix": "logos-nix_619",
         "nix-bundle-dir": "nix-bundle-dir_104",
         "nixpkgs": [
           "logoscore-cli",
@@ -32687,7 +32998,7 @@
     },
     "nix-bundle-appimage_34": {
       "inputs": {
-        "logos-nix": "logos-nix_642",
+        "logos-nix": "logos-nix_644",
         "nix-bundle-dir": "nix-bundle-dir_107",
         "nixpkgs": [
           "logoscore-cli",
@@ -32719,7 +33030,7 @@
     },
     "nix-bundle-appimage_35": {
       "inputs": {
-        "logos-nix": "logos-nix_659",
+        "logos-nix": "logos-nix_661",
         "nix-bundle-dir": "nix-bundle-dir_111",
         "nixpkgs": [
           "logoscore-cli",
@@ -32750,7 +33061,7 @@
     },
     "nix-bundle-appimage_36": {
       "inputs": {
-        "logos-nix": "logos-nix_666",
+        "logos-nix": "logos-nix_668",
         "nix-bundle-dir": "nix-bundle-dir_114",
         "nixpkgs": [
           "logoscore-cli",
@@ -32777,7 +33088,7 @@
     },
     "nix-bundle-appimage_37": {
       "inputs": {
-        "logos-nix": "logos-nix_672",
+        "logos-nix": "logos-nix_674",
         "nix-bundle-dir": "nix-bundle-dir_116",
         "nixpkgs": [
           "logoscore-cli",
@@ -32806,7 +33117,7 @@
     },
     "nix-bundle-appimage_38": {
       "inputs": {
-        "logos-nix": "logos-nix_704",
+        "logos-nix": "logos-nix_706",
         "nix-bundle-dir": "nix-bundle-dir_119",
         "nixpkgs": [
           "logoscore-cli",
@@ -32839,7 +33150,7 @@
     },
     "nix-bundle-appimage_39": {
       "inputs": {
-        "logos-nix": "logos-nix_721",
+        "logos-nix": "logos-nix_723",
         "nix-bundle-dir": "nix-bundle-dir_123",
         "nixpkgs": [
           "logoscore-cli",
@@ -32902,7 +33213,7 @@
     },
     "nix-bundle-appimage_40": {
       "inputs": {
-        "logos-nix": "logos-nix_748",
+        "logos-nix": "logos-nix_750",
         "nix-bundle-dir": "nix-bundle-dir_126",
         "nixpkgs": [
           "logoscore-cli",
@@ -32936,7 +33247,7 @@
     },
     "nix-bundle-appimage_41": {
       "inputs": {
-        "logos-nix": "logos-nix_765",
+        "logos-nix": "logos-nix_767",
         "nix-bundle-dir": "nix-bundle-dir_130",
         "nixpkgs": [
           "logoscore-cli",
@@ -32969,7 +33280,7 @@
     },
     "nix-bundle-appimage_42": {
       "inputs": {
-        "logos-nix": "logos-nix_776",
+        "logos-nix": "logos-nix_778",
         "nix-bundle-dir": "nix-bundle-dir_133",
         "nixpkgs": [
           "logoscore-cli",
@@ -32999,7 +33310,7 @@
     },
     "nix-bundle-appimage_43": {
       "inputs": {
-        "logos-nix": "logos-nix_793",
+        "logos-nix": "logos-nix_795",
         "nix-bundle-dir": "nix-bundle-dir_137",
         "nixpkgs": [
           "logoscore-cli",
@@ -33028,7 +33339,7 @@
     },
     "nix-bundle-appimage_44": {
       "inputs": {
-        "logos-nix": "logos-nix_800",
+        "logos-nix": "logos-nix_802",
         "nix-bundle-dir": "nix-bundle-dir_140",
         "nixpkgs": [
           "logoscore-cli",
@@ -33053,7 +33364,7 @@
     },
     "nix-bundle-appimage_45": {
       "inputs": {
-        "logos-nix": "logos-nix_806",
+        "logos-nix": "logos-nix_808",
         "nix-bundle-dir": "nix-bundle-dir_142",
         "nixpkgs": [
           "logoscore-cli",
@@ -33080,7 +33391,7 @@
     },
     "nix-bundle-appimage_46": {
       "inputs": {
-        "logos-nix": "logos-nix_814",
+        "logos-nix": "logos-nix_816",
         "nix-bundle-dir": "nix-bundle-dir_145",
         "nixpkgs": [
           "package-manager",
@@ -33133,7 +33444,7 @@
     },
     "nix-bundle-appimage_6": {
       "inputs": {
-        "logos-nix": "logos-nix_118",
+        "logos-nix": "logos-nix_120",
         "nix-bundle-dir": "nix-bundle-dir_19",
         "nixpkgs": [
           "logos-module-builder",
@@ -33160,7 +33471,7 @@
     },
     "nix-bundle-appimage_7": {
       "inputs": {
-        "logos-nix": "logos-nix_143",
+        "logos-nix": "logos-nix_145",
         "nix-bundle-dir": "nix-bundle-dir_22",
         "nixpkgs": [
           "logoscore-cli",
@@ -33190,7 +33501,7 @@
     },
     "nix-bundle-appimage_8": {
       "inputs": {
-        "logos-nix": "logos-nix_160",
+        "logos-nix": "logos-nix_162",
         "nix-bundle-dir": "nix-bundle-dir_26",
         "nixpkgs": [
           "logoscore-cli",
@@ -33219,7 +33530,7 @@
     },
     "nix-bundle-appimage_9": {
       "inputs": {
-        "logos-nix": "logos-nix_203",
+        "logos-nix": "logos-nix_205",
         "nix-bundle-dir": "nix-bundle-dir_29",
         "nixpkgs": [
           "logoscore-cli",
@@ -33312,7 +33623,7 @@
     },
     "nix-bundle-dir_100": {
       "inputs": {
-        "logos-nix": "logos-nix_605",
+        "logos-nix": "logos-nix_607",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33341,7 +33652,7 @@
     },
     "nix-bundle-dir_101": {
       "inputs": {
-        "logos-nix": "logos-nix_606",
+        "logos-nix": "logos-nix_608",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33371,7 +33682,7 @@
     },
     "nix-bundle-dir_102": {
       "inputs": {
-        "logos-nix": "logos-nix_612",
+        "logos-nix": "logos-nix_614",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33398,7 +33709,7 @@
     },
     "nix-bundle-dir_103": {
       "inputs": {
-        "logos-nix": "logos-nix_613",
+        "logos-nix": "logos-nix_615",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33426,7 +33737,7 @@
     },
     "nix-bundle-dir_104": {
       "inputs": {
-        "logos-nix": "logos-nix_618",
+        "logos-nix": "logos-nix_620",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33455,7 +33766,7 @@
     },
     "nix-bundle-dir_105": {
       "inputs": {
-        "logos-nix": "logos-nix_619",
+        "logos-nix": "logos-nix_621",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33485,7 +33796,7 @@
     },
     "nix-bundle-dir_106": {
       "inputs": {
-        "logos-nix": "logos-nix_622",
+        "logos-nix": "logos-nix_624",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33515,7 +33826,7 @@
     },
     "nix-bundle-dir_107": {
       "inputs": {
-        "logos-nix": "logos-nix_643",
+        "logos-nix": "logos-nix_645",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33545,7 +33856,7 @@
     },
     "nix-bundle-dir_108": {
       "inputs": {
-        "logos-nix": "logos-nix_644",
+        "logos-nix": "logos-nix_646",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33576,7 +33887,7 @@
     },
     "nix-bundle-dir_109": {
       "inputs": {
-        "logos-nix": "logos-nix_651",
+        "logos-nix": "logos-nix_653",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33635,7 +33946,7 @@
     },
     "nix-bundle-dir_110": {
       "inputs": {
-        "logos-nix": "logos-nix_655",
+        "logos-nix": "logos-nix_657",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33664,7 +33975,7 @@
     },
     "nix-bundle-dir_111": {
       "inputs": {
-        "logos-nix": "logos-nix_660",
+        "logos-nix": "logos-nix_662",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33693,7 +34004,7 @@
     },
     "nix-bundle-dir_112": {
       "inputs": {
-        "logos-nix": "logos-nix_661",
+        "logos-nix": "logos-nix_663",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33723,7 +34034,7 @@
     },
     "nix-bundle-dir_113": {
       "inputs": {
-        "logos-nix": "logos-nix_664",
+        "logos-nix": "logos-nix_666",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33753,7 +34064,7 @@
     },
     "nix-bundle-dir_114": {
       "inputs": {
-        "logos-nix": "logos-nix_667",
+        "logos-nix": "logos-nix_669",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33778,7 +34089,7 @@
     },
     "nix-bundle-dir_115": {
       "inputs": {
-        "logos-nix": "logos-nix_668",
+        "logos-nix": "logos-nix_670",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33804,7 +34115,7 @@
     },
     "nix-bundle-dir_116": {
       "inputs": {
-        "logos-nix": "logos-nix_673",
+        "logos-nix": "logos-nix_675",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33831,7 +34142,7 @@
     },
     "nix-bundle-dir_117": {
       "inputs": {
-        "logos-nix": "logos-nix_674",
+        "logos-nix": "logos-nix_676",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33859,7 +34170,7 @@
     },
     "nix-bundle-dir_118": {
       "inputs": {
-        "logos-nix": "logos-nix_677",
+        "logos-nix": "logos-nix_679",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33887,7 +34198,7 @@
     },
     "nix-bundle-dir_119": {
       "inputs": {
-        "logos-nix": "logos-nix_705",
+        "logos-nix": "logos-nix_707",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33947,7 +34258,7 @@
     },
     "nix-bundle-dir_120": {
       "inputs": {
-        "logos-nix": "logos-nix_706",
+        "logos-nix": "logos-nix_708",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -33979,7 +34290,7 @@
     },
     "nix-bundle-dir_121": {
       "inputs": {
-        "logos-nix": "logos-nix_713",
+        "logos-nix": "logos-nix_715",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34010,7 +34321,7 @@
     },
     "nix-bundle-dir_122": {
       "inputs": {
-        "logos-nix": "logos-nix_717",
+        "logos-nix": "logos-nix_719",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34040,7 +34351,7 @@
     },
     "nix-bundle-dir_123": {
       "inputs": {
-        "logos-nix": "logos-nix_722",
+        "logos-nix": "logos-nix_724",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34070,7 +34381,7 @@
     },
     "nix-bundle-dir_124": {
       "inputs": {
-        "logos-nix": "logos-nix_723",
+        "logos-nix": "logos-nix_725",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34101,7 +34412,7 @@
     },
     "nix-bundle-dir_125": {
       "inputs": {
-        "logos-nix": "logos-nix_726",
+        "logos-nix": "logos-nix_728",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34132,7 +34443,7 @@
     },
     "nix-bundle-dir_126": {
       "inputs": {
-        "logos-nix": "logos-nix_749",
+        "logos-nix": "logos-nix_751",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34164,7 +34475,7 @@
     },
     "nix-bundle-dir_127": {
       "inputs": {
-        "logos-nix": "logos-nix_750",
+        "logos-nix": "logos-nix_752",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34197,7 +34508,7 @@
     },
     "nix-bundle-dir_128": {
       "inputs": {
-        "logos-nix": "logos-nix_757",
+        "logos-nix": "logos-nix_759",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34229,7 +34540,7 @@
     },
     "nix-bundle-dir_129": {
       "inputs": {
-        "logos-nix": "logos-nix_761",
+        "logos-nix": "logos-nix_763",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34290,7 +34601,7 @@
     },
     "nix-bundle-dir_130": {
       "inputs": {
-        "logos-nix": "logos-nix_766",
+        "logos-nix": "logos-nix_768",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34321,7 +34632,7 @@
     },
     "nix-bundle-dir_131": {
       "inputs": {
-        "logos-nix": "logos-nix_767",
+        "logos-nix": "logos-nix_769",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34353,7 +34664,7 @@
     },
     "nix-bundle-dir_132": {
       "inputs": {
-        "logos-nix": "logos-nix_770",
+        "logos-nix": "logos-nix_772",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34385,7 +34696,7 @@
     },
     "nix-bundle-dir_133": {
       "inputs": {
-        "logos-nix": "logos-nix_777",
+        "logos-nix": "logos-nix_779",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34413,7 +34724,7 @@
     },
     "nix-bundle-dir_134": {
       "inputs": {
-        "logos-nix": "logos-nix_778",
+        "logos-nix": "logos-nix_780",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34442,7 +34753,7 @@
     },
     "nix-bundle-dir_135": {
       "inputs": {
-        "logos-nix": "logos-nix_785",
+        "logos-nix": "logos-nix_787",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34470,7 +34781,7 @@
     },
     "nix-bundle-dir_136": {
       "inputs": {
-        "logos-nix": "logos-nix_789",
+        "logos-nix": "logos-nix_791",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34497,7 +34808,7 @@
     },
     "nix-bundle-dir_137": {
       "inputs": {
-        "logos-nix": "logos-nix_794",
+        "logos-nix": "logos-nix_796",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34524,7 +34835,7 @@
     },
     "nix-bundle-dir_138": {
       "inputs": {
-        "logos-nix": "logos-nix_795",
+        "logos-nix": "logos-nix_797",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34552,7 +34863,7 @@
     },
     "nix-bundle-dir_139": {
       "inputs": {
-        "logos-nix": "logos-nix_798",
+        "logos-nix": "logos-nix_800",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -34610,7 +34921,7 @@
     },
     "nix-bundle-dir_140": {
       "inputs": {
-        "logos-nix": "logos-nix_801",
+        "logos-nix": "logos-nix_803",
         "nixpkgs": [
           "logoscore-cli",
           "nix-bundle-appimage",
@@ -34633,7 +34944,7 @@
     },
     "nix-bundle-dir_141": {
       "inputs": {
-        "logos-nix": "logos-nix_802",
+        "logos-nix": "logos-nix_804",
         "nixpkgs": [
           "logoscore-cli",
           "nix-bundle-dir",
@@ -34657,7 +34968,7 @@
     },
     "nix-bundle-dir_142": {
       "inputs": {
-        "logos-nix": "logos-nix_807",
+        "logos-nix": "logos-nix_809",
         "nixpkgs": [
           "logoscore-cli",
           "nix-bundle-logos-module-install",
@@ -34682,7 +34993,7 @@
     },
     "nix-bundle-dir_143": {
       "inputs": {
-        "logos-nix": "logos-nix_808",
+        "logos-nix": "logos-nix_810",
         "nixpkgs": [
           "logoscore-cli",
           "nix-bundle-logos-module-install",
@@ -34708,7 +35019,7 @@
     },
     "nix-bundle-dir_144": {
       "inputs": {
-        "logos-nix": "logos-nix_811",
+        "logos-nix": "logos-nix_813",
         "nixpkgs": [
           "logoscore-cli",
           "nix-bundle-logos-module-install",
@@ -34734,7 +35045,7 @@
     },
     "nix-bundle-dir_145": {
       "inputs": {
-        "logos-nix": "logos-nix_815",
+        "logos-nix": "logos-nix_817",
         "nixpkgs": [
           "package-manager",
           "nix-bundle-appimage",
@@ -34757,7 +35068,7 @@
     },
     "nix-bundle-dir_146": {
       "inputs": {
-        "logos-nix": "logos-nix_816",
+        "logos-nix": "logos-nix_818",
         "nixpkgs": [
           "package-manager",
           "nix-bundle-dir",
@@ -34834,7 +35145,7 @@
     },
     "nix-bundle-dir_17": {
       "inputs": {
-        "logos-nix": "logos-nix_110",
+        "logos-nix": "logos-nix_112",
         "nixpkgs": [
           "logos-module-builder",
           "logos-standalone-app",
@@ -34860,7 +35171,7 @@
     },
     "nix-bundle-dir_18": {
       "inputs": {
-        "logos-nix": "logos-nix_114",
+        "logos-nix": "logos-nix_116",
         "nixpkgs": [
           "logos-module-builder",
           "nix-bundle-lgx",
@@ -34885,7 +35196,7 @@
     },
     "nix-bundle-dir_19": {
       "inputs": {
-        "logos-nix": "logos-nix_119",
+        "logos-nix": "logos-nix_121",
         "nixpkgs": [
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -34940,7 +35251,7 @@
     },
     "nix-bundle-dir_20": {
       "inputs": {
-        "logos-nix": "logos-nix_120",
+        "logos-nix": "logos-nix_122",
         "nixpkgs": [
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -34966,7 +35277,7 @@
     },
     "nix-bundle-dir_21": {
       "inputs": {
-        "logos-nix": "logos-nix_123",
+        "logos-nix": "logos-nix_125",
         "nixpkgs": [
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -34977,11 +35288,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "lastModified": 1776974030,
+        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
         "type": "github"
       },
       "original": {
@@ -34992,7 +35303,7 @@
     },
     "nix-bundle-dir_22": {
       "inputs": {
-        "logos-nix": "logos-nix_144",
+        "logos-nix": "logos-nix_146",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -35020,7 +35331,7 @@
     },
     "nix-bundle-dir_23": {
       "inputs": {
-        "logos-nix": "logos-nix_145",
+        "logos-nix": "logos-nix_147",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -35049,7 +35360,7 @@
     },
     "nix-bundle-dir_24": {
       "inputs": {
-        "logos-nix": "logos-nix_152",
+        "logos-nix": "logos-nix_154",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -35077,7 +35388,7 @@
     },
     "nix-bundle-dir_25": {
       "inputs": {
-        "logos-nix": "logos-nix_156",
+        "logos-nix": "logos-nix_158",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -35104,7 +35415,7 @@
     },
     "nix-bundle-dir_26": {
       "inputs": {
-        "logos-nix": "logos-nix_161",
+        "logos-nix": "logos-nix_163",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -35131,7 +35442,7 @@
     },
     "nix-bundle-dir_27": {
       "inputs": {
-        "logos-nix": "logos-nix_162",
+        "logos-nix": "logos-nix_164",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -35159,7 +35470,7 @@
     },
     "nix-bundle-dir_28": {
       "inputs": {
-        "logos-nix": "logos-nix_165",
+        "logos-nix": "logos-nix_167",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -35187,7 +35498,7 @@
     },
     "nix-bundle-dir_29": {
       "inputs": {
-        "logos-nix": "logos-nix_204",
+        "logos-nix": "logos-nix_206",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35248,7 +35559,7 @@
     },
     "nix-bundle-dir_30": {
       "inputs": {
-        "logos-nix": "logos-nix_205",
+        "logos-nix": "logos-nix_207",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35281,7 +35592,7 @@
     },
     "nix-bundle-dir_31": {
       "inputs": {
-        "logos-nix": "logos-nix_212",
+        "logos-nix": "logos-nix_214",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35313,7 +35624,7 @@
     },
     "nix-bundle-dir_32": {
       "inputs": {
-        "logos-nix": "logos-nix_216",
+        "logos-nix": "logos-nix_218",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35344,7 +35655,7 @@
     },
     "nix-bundle-dir_33": {
       "inputs": {
-        "logos-nix": "logos-nix_221",
+        "logos-nix": "logos-nix_223",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35375,7 +35686,7 @@
     },
     "nix-bundle-dir_34": {
       "inputs": {
-        "logos-nix": "logos-nix_222",
+        "logos-nix": "logos-nix_224",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35407,7 +35718,7 @@
     },
     "nix-bundle-dir_35": {
       "inputs": {
-        "logos-nix": "logos-nix_225",
+        "logos-nix": "logos-nix_227",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35439,7 +35750,7 @@
     },
     "nix-bundle-dir_36": {
       "inputs": {
-        "logos-nix": "logos-nix_248",
+        "logos-nix": "logos-nix_250",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35472,7 +35783,7 @@
     },
     "nix-bundle-dir_37": {
       "inputs": {
-        "logos-nix": "logos-nix_249",
+        "logos-nix": "logos-nix_251",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35506,7 +35817,7 @@
     },
     "nix-bundle-dir_38": {
       "inputs": {
-        "logos-nix": "logos-nix_256",
+        "logos-nix": "logos-nix_258",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35539,7 +35850,7 @@
     },
     "nix-bundle-dir_39": {
       "inputs": {
-        "logos-nix": "logos-nix_260",
+        "logos-nix": "logos-nix_262",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35599,7 +35910,7 @@
     },
     "nix-bundle-dir_40": {
       "inputs": {
-        "logos-nix": "logos-nix_265",
+        "logos-nix": "logos-nix_267",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35631,7 +35942,7 @@
     },
     "nix-bundle-dir_41": {
       "inputs": {
-        "logos-nix": "logos-nix_266",
+        "logos-nix": "logos-nix_268",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35664,7 +35975,7 @@
     },
     "nix-bundle-dir_42": {
       "inputs": {
-        "logos-nix": "logos-nix_269",
+        "logos-nix": "logos-nix_271",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35697,7 +36008,7 @@
     },
     "nix-bundle-dir_43": {
       "inputs": {
-        "logos-nix": "logos-nix_276",
+        "logos-nix": "logos-nix_278",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35726,7 +36037,7 @@
     },
     "nix-bundle-dir_44": {
       "inputs": {
-        "logos-nix": "logos-nix_277",
+        "logos-nix": "logos-nix_279",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35756,7 +36067,7 @@
     },
     "nix-bundle-dir_45": {
       "inputs": {
-        "logos-nix": "logos-nix_284",
+        "logos-nix": "logos-nix_286",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35785,7 +36096,7 @@
     },
     "nix-bundle-dir_46": {
       "inputs": {
-        "logos-nix": "logos-nix_288",
+        "logos-nix": "logos-nix_290",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35813,7 +36124,7 @@
     },
     "nix-bundle-dir_47": {
       "inputs": {
-        "logos-nix": "logos-nix_293",
+        "logos-nix": "logos-nix_295",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35841,7 +36152,7 @@
     },
     "nix-bundle-dir_48": {
       "inputs": {
-        "logos-nix": "logos-nix_294",
+        "logos-nix": "logos-nix_296",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35870,7 +36181,7 @@
     },
     "nix-bundle-dir_49": {
       "inputs": {
-        "logos-nix": "logos-nix_297",
+        "logos-nix": "logos-nix_299",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35927,7 +36238,7 @@
     },
     "nix-bundle-dir_50": {
       "inputs": {
-        "logos-nix": "logos-nix_307",
+        "logos-nix": "logos-nix_309",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35952,7 +36263,7 @@
     },
     "nix-bundle-dir_51": {
       "inputs": {
-        "logos-nix": "logos-nix_308",
+        "logos-nix": "logos-nix_310",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -35978,7 +36289,7 @@
     },
     "nix-bundle-dir_52": {
       "inputs": {
-        "logos-nix": "logos-nix_335",
+        "logos-nix": "logos-nix_337",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36008,7 +36319,7 @@
     },
     "nix-bundle-dir_53": {
       "inputs": {
-        "logos-nix": "logos-nix_336",
+        "logos-nix": "logos-nix_338",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36039,7 +36350,7 @@
     },
     "nix-bundle-dir_54": {
       "inputs": {
-        "logos-nix": "logos-nix_343",
+        "logos-nix": "logos-nix_345",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36069,7 +36380,7 @@
     },
     "nix-bundle-dir_55": {
       "inputs": {
-        "logos-nix": "logos-nix_347",
+        "logos-nix": "logos-nix_349",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36098,7 +36409,7 @@
     },
     "nix-bundle-dir_56": {
       "inputs": {
-        "logos-nix": "logos-nix_352",
+        "logos-nix": "logos-nix_354",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36127,7 +36438,7 @@
     },
     "nix-bundle-dir_57": {
       "inputs": {
-        "logos-nix": "logos-nix_353",
+        "logos-nix": "logos-nix_355",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36157,7 +36468,7 @@
     },
     "nix-bundle-dir_58": {
       "inputs": {
-        "logos-nix": "logos-nix_356",
+        "logos-nix": "logos-nix_358",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36187,7 +36498,7 @@
     },
     "nix-bundle-dir_59": {
       "inputs": {
-        "logos-nix": "logos-nix_363",
+        "logos-nix": "logos-nix_365",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36242,7 +36553,7 @@
     },
     "nix-bundle-dir_60": {
       "inputs": {
-        "logos-nix": "logos-nix_364",
+        "logos-nix": "logos-nix_366",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36269,7 +36580,7 @@
     },
     "nix-bundle-dir_61": {
       "inputs": {
-        "logos-nix": "logos-nix_386",
+        "logos-nix": "logos-nix_388",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36299,7 +36610,7 @@
     },
     "nix-bundle-dir_62": {
       "inputs": {
-        "logos-nix": "logos-nix_387",
+        "logos-nix": "logos-nix_389",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36330,7 +36641,7 @@
     },
     "nix-bundle-dir_63": {
       "inputs": {
-        "logos-nix": "logos-nix_394",
+        "logos-nix": "logos-nix_396",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36360,7 +36671,7 @@
     },
     "nix-bundle-dir_64": {
       "inputs": {
-        "logos-nix": "logos-nix_398",
+        "logos-nix": "logos-nix_400",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36389,7 +36700,7 @@
     },
     "nix-bundle-dir_65": {
       "inputs": {
-        "logos-nix": "logos-nix_403",
+        "logos-nix": "logos-nix_405",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36418,7 +36729,7 @@
     },
     "nix-bundle-dir_66": {
       "inputs": {
-        "logos-nix": "logos-nix_404",
+        "logos-nix": "logos-nix_406",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36448,7 +36759,7 @@
     },
     "nix-bundle-dir_67": {
       "inputs": {
-        "logos-nix": "logos-nix_407",
+        "logos-nix": "logos-nix_409",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36478,7 +36789,7 @@
     },
     "nix-bundle-dir_68": {
       "inputs": {
-        "logos-nix": "logos-nix_429",
+        "logos-nix": "logos-nix_431",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36509,7 +36820,7 @@
     },
     "nix-bundle-dir_69": {
       "inputs": {
-        "logos-nix": "logos-nix_430",
+        "logos-nix": "logos-nix_432",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36570,7 +36881,7 @@
     },
     "nix-bundle-dir_70": {
       "inputs": {
-        "logos-nix": "logos-nix_437",
+        "logos-nix": "logos-nix_439",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36601,7 +36912,7 @@
     },
     "nix-bundle-dir_71": {
       "inputs": {
-        "logos-nix": "logos-nix_441",
+        "logos-nix": "logos-nix_443",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36631,7 +36942,7 @@
     },
     "nix-bundle-dir_72": {
       "inputs": {
-        "logos-nix": "logos-nix_446",
+        "logos-nix": "logos-nix_448",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36661,7 +36972,7 @@
     },
     "nix-bundle-dir_73": {
       "inputs": {
-        "logos-nix": "logos-nix_447",
+        "logos-nix": "logos-nix_449",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36692,7 +37003,7 @@
     },
     "nix-bundle-dir_74": {
       "inputs": {
-        "logos-nix": "logos-nix_450",
+        "logos-nix": "logos-nix_452",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36723,7 +37034,7 @@
     },
     "nix-bundle-dir_75": {
       "inputs": {
-        "logos-nix": "logos-nix_457",
+        "logos-nix": "logos-nix_459",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36750,7 +37061,7 @@
     },
     "nix-bundle-dir_76": {
       "inputs": {
-        "logos-nix": "logos-nix_458",
+        "logos-nix": "logos-nix_460",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36778,7 +37089,7 @@
     },
     "nix-bundle-dir_77": {
       "inputs": {
-        "logos-nix": "logos-nix_483",
+        "logos-nix": "logos-nix_485",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36810,7 +37121,7 @@
     },
     "nix-bundle-dir_78": {
       "inputs": {
-        "logos-nix": "logos-nix_484",
+        "logos-nix": "logos-nix_486",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36843,7 +37154,7 @@
     },
     "nix-bundle-dir_79": {
       "inputs": {
-        "logos-nix": "logos-nix_491",
+        "logos-nix": "logos-nix_493",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36905,7 +37216,7 @@
     },
     "nix-bundle-dir_80": {
       "inputs": {
-        "logos-nix": "logos-nix_495",
+        "logos-nix": "logos-nix_497",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36936,7 +37247,7 @@
     },
     "nix-bundle-dir_81": {
       "inputs": {
-        "logos-nix": "logos-nix_500",
+        "logos-nix": "logos-nix_502",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36967,7 +37278,7 @@
     },
     "nix-bundle-dir_82": {
       "inputs": {
-        "logos-nix": "logos-nix_501",
+        "logos-nix": "logos-nix_503",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -36999,7 +37310,7 @@
     },
     "nix-bundle-dir_83": {
       "inputs": {
-        "logos-nix": "logos-nix_504",
+        "logos-nix": "logos-nix_506",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37031,7 +37342,7 @@
     },
     "nix-bundle-dir_84": {
       "inputs": {
-        "logos-nix": "logos-nix_511",
+        "logos-nix": "logos-nix_513",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37059,7 +37370,7 @@
     },
     "nix-bundle-dir_85": {
       "inputs": {
-        "logos-nix": "logos-nix_512",
+        "logos-nix": "logos-nix_514",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37088,7 +37399,7 @@
     },
     "nix-bundle-dir_86": {
       "inputs": {
-        "logos-nix": "logos-nix_534",
+        "logos-nix": "logos-nix_536",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37120,7 +37431,7 @@
     },
     "nix-bundle-dir_87": {
       "inputs": {
-        "logos-nix": "logos-nix_535",
+        "logos-nix": "logos-nix_537",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37153,7 +37464,7 @@
     },
     "nix-bundle-dir_88": {
       "inputs": {
-        "logos-nix": "logos-nix_542",
+        "logos-nix": "logos-nix_544",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37185,7 +37496,7 @@
     },
     "nix-bundle-dir_89": {
       "inputs": {
-        "logos-nix": "logos-nix_546",
+        "logos-nix": "logos-nix_548",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37247,7 +37558,7 @@
     },
     "nix-bundle-dir_90": {
       "inputs": {
-        "logos-nix": "logos-nix_551",
+        "logos-nix": "logos-nix_553",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37278,7 +37589,7 @@
     },
     "nix-bundle-dir_91": {
       "inputs": {
-        "logos-nix": "logos-nix_552",
+        "logos-nix": "logos-nix_554",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37310,7 +37621,7 @@
     },
     "nix-bundle-dir_92": {
       "inputs": {
-        "logos-nix": "logos-nix_555",
+        "logos-nix": "logos-nix_557",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37342,7 +37653,7 @@
     },
     "nix-bundle-dir_93": {
       "inputs": {
-        "logos-nix": "logos-nix_577",
+        "logos-nix": "logos-nix_579",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37375,7 +37686,7 @@
     },
     "nix-bundle-dir_94": {
       "inputs": {
-        "logos-nix": "logos-nix_578",
+        "logos-nix": "logos-nix_580",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37409,7 +37720,7 @@
     },
     "nix-bundle-dir_95": {
       "inputs": {
-        "logos-nix": "logos-nix_585",
+        "logos-nix": "logos-nix_587",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37442,7 +37753,7 @@
     },
     "nix-bundle-dir_96": {
       "inputs": {
-        "logos-nix": "logos-nix_589",
+        "logos-nix": "logos-nix_591",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37474,7 +37785,7 @@
     },
     "nix-bundle-dir_97": {
       "inputs": {
-        "logos-nix": "logos-nix_594",
+        "logos-nix": "logos-nix_596",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37506,7 +37817,7 @@
     },
     "nix-bundle-dir_98": {
       "inputs": {
-        "logos-nix": "logos-nix_595",
+        "logos-nix": "logos-nix_597",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37539,7 +37850,7 @@
     },
     "nix-bundle-dir_99": {
       "inputs": {
-        "logos-nix": "logos-nix_598",
+        "logos-nix": "logos-nix_600",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -37601,7 +37912,7 @@
     },
     "nix-bundle-lgx_10": {
       "inputs": {
-        "logos-nix": "logos-nix_150",
+        "logos-nix": "logos-nix_152",
         "logos-package": "logos-package_17",
         "nix-bundle-dir": "nix-bundle-dir_24",
         "nixpkgs": [
@@ -37629,7 +37940,7 @@
     },
     "nix-bundle-lgx_11": {
       "inputs": {
-        "logos-nix": "logos-nix_154",
+        "logos-nix": "logos-nix_156",
         "logos-package": "logos-package_18",
         "nix-bundle-dir": "nix-bundle-dir_25",
         "nixpkgs": [
@@ -37657,7 +37968,7 @@
     },
     "nix-bundle-lgx_12": {
       "inputs": {
-        "logos-nix": "logos-nix_163",
+        "logos-nix": "logos-nix_165",
         "logos-package": "logos-package_20",
         "nix-bundle-dir": "nix-bundle-dir_28",
         "nixpkgs": [
@@ -37686,7 +37997,7 @@
     },
     "nix-bundle-lgx_13": {
       "inputs": {
-        "logos-nix": "logos-nix_210",
+        "logos-nix": "logos-nix_212",
         "logos-package": "logos-package_22",
         "nix-bundle-dir": "nix-bundle-dir_31",
         "nixpkgs": [
@@ -37718,7 +38029,7 @@
     },
     "nix-bundle-lgx_14": {
       "inputs": {
-        "logos-nix": "logos-nix_214",
+        "logos-nix": "logos-nix_216",
         "logos-package": "logos-package_23",
         "nix-bundle-dir": "nix-bundle-dir_32",
         "nixpkgs": [
@@ -37750,7 +38061,7 @@
     },
     "nix-bundle-lgx_15": {
       "inputs": {
-        "logos-nix": "logos-nix_223",
+        "logos-nix": "logos-nix_225",
         "logos-package": "logos-package_25",
         "nix-bundle-dir": "nix-bundle-dir_35",
         "nixpkgs": [
@@ -37783,7 +38094,7 @@
     },
     "nix-bundle-lgx_16": {
       "inputs": {
-        "logos-nix": "logos-nix_254",
+        "logos-nix": "logos-nix_256",
         "logos-package": "logos-package_27",
         "nix-bundle-dir": "nix-bundle-dir_38",
         "nixpkgs": [
@@ -37816,7 +38127,7 @@
     },
     "nix-bundle-lgx_17": {
       "inputs": {
-        "logos-nix": "logos-nix_258",
+        "logos-nix": "logos-nix_260",
         "logos-package": "logos-package_28",
         "nix-bundle-dir": "nix-bundle-dir_39",
         "nixpkgs": [
@@ -37849,7 +38160,7 @@
     },
     "nix-bundle-lgx_18": {
       "inputs": {
-        "logos-nix": "logos-nix_267",
+        "logos-nix": "logos-nix_269",
         "logos-package": "logos-package_30",
         "nix-bundle-dir": "nix-bundle-dir_42",
         "nixpkgs": [
@@ -37883,7 +38194,7 @@
     },
     "nix-bundle-lgx_19": {
       "inputs": {
-        "logos-nix": "logos-nix_282",
+        "logos-nix": "logos-nix_284",
         "logos-package": "logos-package_32",
         "nix-bundle-dir": "nix-bundle-dir_45",
         "nixpkgs": [
@@ -37942,7 +38253,7 @@
     },
     "nix-bundle-lgx_20": {
       "inputs": {
-        "logos-nix": "logos-nix_286",
+        "logos-nix": "logos-nix_288",
         "logos-package": "logos-package_33",
         "nix-bundle-dir": "nix-bundle-dir_46",
         "nixpkgs": [
@@ -37971,7 +38282,7 @@
     },
     "nix-bundle-lgx_21": {
       "inputs": {
-        "logos-nix": "logos-nix_295",
+        "logos-nix": "logos-nix_297",
         "logos-package": "logos-package_35",
         "nix-bundle-dir": "nix-bundle-dir_49",
         "nixpkgs": [
@@ -38001,7 +38312,7 @@
     },
     "nix-bundle-lgx_22": {
       "inputs": {
-        "logos-nix": "logos-nix_341",
+        "logos-nix": "logos-nix_343",
         "logos-package": "logos-package_38",
         "nix-bundle-dir": "nix-bundle-dir_54",
         "nixpkgs": [
@@ -38031,7 +38342,7 @@
     },
     "nix-bundle-lgx_23": {
       "inputs": {
-        "logos-nix": "logos-nix_345",
+        "logos-nix": "logos-nix_347",
         "logos-package": "logos-package_39",
         "nix-bundle-dir": "nix-bundle-dir_55",
         "nixpkgs": [
@@ -38061,7 +38372,7 @@
     },
     "nix-bundle-lgx_24": {
       "inputs": {
-        "logos-nix": "logos-nix_354",
+        "logos-nix": "logos-nix_356",
         "logos-package": "logos-package_41",
         "nix-bundle-dir": "nix-bundle-dir_58",
         "nixpkgs": [
@@ -38092,7 +38403,7 @@
     },
     "nix-bundle-lgx_25": {
       "inputs": {
-        "logos-nix": "logos-nix_392",
+        "logos-nix": "logos-nix_394",
         "logos-package": "logos-package_44",
         "nix-bundle-dir": "nix-bundle-dir_63",
         "nixpkgs": [
@@ -38122,7 +38433,7 @@
     },
     "nix-bundle-lgx_26": {
       "inputs": {
-        "logos-nix": "logos-nix_396",
+        "logos-nix": "logos-nix_398",
         "logos-package": "logos-package_45",
         "nix-bundle-dir": "nix-bundle-dir_64",
         "nixpkgs": [
@@ -38152,7 +38463,7 @@
     },
     "nix-bundle-lgx_27": {
       "inputs": {
-        "logos-nix": "logos-nix_405",
+        "logos-nix": "logos-nix_407",
         "logos-package": "logos-package_47",
         "nix-bundle-dir": "nix-bundle-dir_67",
         "nixpkgs": [
@@ -38183,7 +38494,7 @@
     },
     "nix-bundle-lgx_28": {
       "inputs": {
-        "logos-nix": "logos-nix_435",
+        "logos-nix": "logos-nix_437",
         "logos-package": "logos-package_49",
         "nix-bundle-dir": "nix-bundle-dir_70",
         "nixpkgs": [
@@ -38214,7 +38525,7 @@
     },
     "nix-bundle-lgx_29": {
       "inputs": {
-        "logos-nix": "logos-nix_439",
+        "logos-nix": "logos-nix_441",
         "logos-package": "logos-package_50",
         "nix-bundle-dir": "nix-bundle-dir_71",
         "nixpkgs": [
@@ -38275,7 +38586,7 @@
     },
     "nix-bundle-lgx_30": {
       "inputs": {
-        "logos-nix": "logos-nix_448",
+        "logos-nix": "logos-nix_450",
         "logos-package": "logos-package_52",
         "nix-bundle-dir": "nix-bundle-dir_74",
         "nixpkgs": [
@@ -38307,7 +38618,7 @@
     },
     "nix-bundle-lgx_31": {
       "inputs": {
-        "logos-nix": "logos-nix_489",
+        "logos-nix": "logos-nix_491",
         "logos-package": "logos-package_55",
         "nix-bundle-dir": "nix-bundle-dir_79",
         "nixpkgs": [
@@ -38339,7 +38650,7 @@
     },
     "nix-bundle-lgx_32": {
       "inputs": {
-        "logos-nix": "logos-nix_493",
+        "logos-nix": "logos-nix_495",
         "logos-package": "logos-package_56",
         "nix-bundle-dir": "nix-bundle-dir_80",
         "nixpkgs": [
@@ -38371,7 +38682,7 @@
     },
     "nix-bundle-lgx_33": {
       "inputs": {
-        "logos-nix": "logos-nix_502",
+        "logos-nix": "logos-nix_504",
         "logos-package": "logos-package_58",
         "nix-bundle-dir": "nix-bundle-dir_83",
         "nixpkgs": [
@@ -38404,7 +38715,7 @@
     },
     "nix-bundle-lgx_34": {
       "inputs": {
-        "logos-nix": "logos-nix_540",
+        "logos-nix": "logos-nix_542",
         "logos-package": "logos-package_61",
         "nix-bundle-dir": "nix-bundle-dir_88",
         "nixpkgs": [
@@ -38436,7 +38747,7 @@
     },
     "nix-bundle-lgx_35": {
       "inputs": {
-        "logos-nix": "logos-nix_544",
+        "logos-nix": "logos-nix_546",
         "logos-package": "logos-package_62",
         "nix-bundle-dir": "nix-bundle-dir_89",
         "nixpkgs": [
@@ -38468,7 +38779,7 @@
     },
     "nix-bundle-lgx_36": {
       "inputs": {
-        "logos-nix": "logos-nix_553",
+        "logos-nix": "logos-nix_555",
         "logos-package": "logos-package_64",
         "nix-bundle-dir": "nix-bundle-dir_92",
         "nixpkgs": [
@@ -38501,7 +38812,7 @@
     },
     "nix-bundle-lgx_37": {
       "inputs": {
-        "logos-nix": "logos-nix_583",
+        "logos-nix": "logos-nix_585",
         "logos-package": "logos-package_66",
         "nix-bundle-dir": "nix-bundle-dir_95",
         "nixpkgs": [
@@ -38534,7 +38845,7 @@
     },
     "nix-bundle-lgx_38": {
       "inputs": {
-        "logos-nix": "logos-nix_587",
+        "logos-nix": "logos-nix_589",
         "logos-package": "logos-package_67",
         "nix-bundle-dir": "nix-bundle-dir_96",
         "nixpkgs": [
@@ -38567,7 +38878,7 @@
     },
     "nix-bundle-lgx_39": {
       "inputs": {
-        "logos-nix": "logos-nix_596",
+        "logos-nix": "logos-nix_598",
         "logos-package": "logos-package_69",
         "nix-bundle-dir": "nix-bundle-dir_99",
         "nixpkgs": [
@@ -38631,7 +38942,7 @@
     },
     "nix-bundle-lgx_40": {
       "inputs": {
-        "logos-nix": "logos-nix_620",
+        "logos-nix": "logos-nix_622",
         "logos-package": "logos-package_72",
         "nix-bundle-dir": "nix-bundle-dir_106",
         "nixpkgs": [
@@ -38662,7 +38973,7 @@
     },
     "nix-bundle-lgx_41": {
       "inputs": {
-        "logos-nix": "logos-nix_649",
+        "logos-nix": "logos-nix_651",
         "logos-package": "logos-package_74",
         "nix-bundle-dir": "nix-bundle-dir_109",
         "nixpkgs": [
@@ -38692,7 +39003,7 @@
     },
     "nix-bundle-lgx_42": {
       "inputs": {
-        "logos-nix": "logos-nix_653",
+        "logos-nix": "logos-nix_655",
         "logos-package": "logos-package_75",
         "nix-bundle-dir": "nix-bundle-dir_110",
         "nixpkgs": [
@@ -38722,7 +39033,7 @@
     },
     "nix-bundle-lgx_43": {
       "inputs": {
-        "logos-nix": "logos-nix_662",
+        "logos-nix": "logos-nix_664",
         "logos-package": "logos-package_77",
         "nix-bundle-dir": "nix-bundle-dir_113",
         "nixpkgs": [
@@ -38753,7 +39064,7 @@
     },
     "nix-bundle-lgx_44": {
       "inputs": {
-        "logos-nix": "logos-nix_675",
+        "logos-nix": "logos-nix_677",
         "logos-package": "logos-package_79",
         "nix-bundle-dir": "nix-bundle-dir_118",
         "nixpkgs": [
@@ -38782,7 +39093,7 @@
     },
     "nix-bundle-lgx_45": {
       "inputs": {
-        "logos-nix": "logos-nix_711",
+        "logos-nix": "logos-nix_713",
         "logos-package": "logos-package_81",
         "nix-bundle-dir": "nix-bundle-dir_121",
         "nixpkgs": [
@@ -38813,7 +39124,7 @@
     },
     "nix-bundle-lgx_46": {
       "inputs": {
-        "logos-nix": "logos-nix_715",
+        "logos-nix": "logos-nix_717",
         "logos-package": "logos-package_82",
         "nix-bundle-dir": "nix-bundle-dir_122",
         "nixpkgs": [
@@ -38844,7 +39155,7 @@
     },
     "nix-bundle-lgx_47": {
       "inputs": {
-        "logos-nix": "logos-nix_724",
+        "logos-nix": "logos-nix_726",
         "logos-package": "logos-package_84",
         "nix-bundle-dir": "nix-bundle-dir_125",
         "nixpkgs": [
@@ -38876,7 +39187,7 @@
     },
     "nix-bundle-lgx_48": {
       "inputs": {
-        "logos-nix": "logos-nix_755",
+        "logos-nix": "logos-nix_757",
         "logos-package": "logos-package_86",
         "nix-bundle-dir": "nix-bundle-dir_128",
         "nixpkgs": [
@@ -38908,7 +39219,7 @@
     },
     "nix-bundle-lgx_49": {
       "inputs": {
-        "logos-nix": "logos-nix_759",
+        "logos-nix": "logos-nix_761",
         "logos-package": "logos-package_87",
         "nix-bundle-dir": "nix-bundle-dir_129",
         "nixpkgs": [
@@ -38970,7 +39281,7 @@
     },
     "nix-bundle-lgx_50": {
       "inputs": {
-        "logos-nix": "logos-nix_768",
+        "logos-nix": "logos-nix_770",
         "logos-package": "logos-package_89",
         "nix-bundle-dir": "nix-bundle-dir_132",
         "nixpkgs": [
@@ -39003,7 +39314,7 @@
     },
     "nix-bundle-lgx_51": {
       "inputs": {
-        "logos-nix": "logos-nix_783",
+        "logos-nix": "logos-nix_785",
         "logos-package": "logos-package_91",
         "nix-bundle-dir": "nix-bundle-dir_135",
         "nixpkgs": [
@@ -39032,7 +39343,7 @@
     },
     "nix-bundle-lgx_52": {
       "inputs": {
-        "logos-nix": "logos-nix_787",
+        "logos-nix": "logos-nix_789",
         "logos-package": "logos-package_92",
         "nix-bundle-dir": "nix-bundle-dir_136",
         "nixpkgs": [
@@ -39060,7 +39371,7 @@
     },
     "nix-bundle-lgx_53": {
       "inputs": {
-        "logos-nix": "logos-nix_796",
+        "logos-nix": "logos-nix_798",
         "logos-package": "logos-package_94",
         "nix-bundle-dir": "nix-bundle-dir_139",
         "nixpkgs": [
@@ -39089,7 +39400,7 @@
     },
     "nix-bundle-lgx_54": {
       "inputs": {
-        "logos-nix": "logos-nix_809",
+        "logos-nix": "logos-nix_811",
         "logos-package": "logos-package_96",
         "nix-bundle-dir": "nix-bundle-dir_144",
         "nixpkgs": [
@@ -39147,7 +39458,7 @@
     },
     "nix-bundle-lgx_7": {
       "inputs": {
-        "logos-nix": "logos-nix_108",
+        "logos-nix": "logos-nix_110",
         "logos-package": "logos-package_12",
         "nix-bundle-dir": "nix-bundle-dir_17",
         "nixpkgs": [
@@ -39174,7 +39485,7 @@
     },
     "nix-bundle-lgx_8": {
       "inputs": {
-        "logos-nix": "logos-nix_112",
+        "logos-nix": "logos-nix_114",
         "logos-package": "logos-package_13",
         "nix-bundle-dir": "nix-bundle-dir_18",
         "nixpkgs": [
@@ -39200,7 +39511,7 @@
     },
     "nix-bundle-lgx_9": {
       "inputs": {
-        "logos-nix": "logos-nix_121",
+        "logos-nix": "logos-nix_123",
         "logos-package": "logos-package_15",
         "nix-bundle-dir": "nix-bundle-dir_21",
         "nixpkgs": [
@@ -39212,11 +39523,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775836380,
-        "narHash": "sha256-XbBPcMuDFA/SxYVw9TIRQbhie5Vj5MqwdU+Gh1iR1LA=",
+        "lastModified": 1781872587,
+        "narHash": "sha256-zl9odZ1Tq7QBAYJVrXiLSC47FVYra3kIakb/TeGPoZI=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "9d8f8602b1574ec9ac4c9b31ae0c92570221c268",
+        "rev": "b49074a8e1157832002b11d3d254c1aaa4b96680",
         "type": "github"
       },
       "original": {
@@ -39256,7 +39567,7 @@
     },
     "nix-bundle-logos-module-install_10": {
       "inputs": {
-        "logos-nix": "logos-nix_442",
+        "logos-nix": "logos-nix_444",
         "logos-package-manager": "logos-package-manager_22",
         "nix-bundle-lgx": "nix-bundle-lgx_30",
         "nixpkgs": [
@@ -39287,7 +39598,7 @@
     },
     "nix-bundle-logos-module-install_11": {
       "inputs": {
-        "logos-nix": "logos-nix_496",
+        "logos-nix": "logos-nix_498",
         "logos-package-manager": "logos-package-manager_25",
         "nix-bundle-lgx": "nix-bundle-lgx_33",
         "nixpkgs": [
@@ -39319,7 +39630,7 @@
     },
     "nix-bundle-logos-module-install_12": {
       "inputs": {
-        "logos-nix": "logos-nix_547",
+        "logos-nix": "logos-nix_549",
         "logos-package-manager": "logos-package-manager_28",
         "nix-bundle-lgx": "nix-bundle-lgx_36",
         "nixpkgs": [
@@ -39351,7 +39662,7 @@
     },
     "nix-bundle-logos-module-install_13": {
       "inputs": {
-        "logos-nix": "logos-nix_590",
+        "logos-nix": "logos-nix_592",
         "logos-package-manager": "logos-package-manager_30",
         "nix-bundle-lgx": "nix-bundle-lgx_39",
         "nixpkgs": [
@@ -39384,7 +39695,7 @@
     },
     "nix-bundle-logos-module-install_14": {
       "inputs": {
-        "logos-nix": "logos-nix_614",
+        "logos-nix": "logos-nix_616",
         "logos-package-manager": "logos-package-manager_32",
         "nix-bundle-lgx": "nix-bundle-lgx_40",
         "nixpkgs": [
@@ -39414,7 +39725,7 @@
     },
     "nix-bundle-logos-module-install_15": {
       "inputs": {
-        "logos-nix": "logos-nix_656",
+        "logos-nix": "logos-nix_658",
         "logos-package-manager": "logos-package-manager_34",
         "nix-bundle-lgx": "nix-bundle-lgx_43",
         "nixpkgs": [
@@ -39444,7 +39755,7 @@
     },
     "nix-bundle-logos-module-install_16": {
       "inputs": {
-        "logos-nix": "logos-nix_669",
+        "logos-nix": "logos-nix_671",
         "logos-package-manager": "logos-package-manager_35",
         "nix-bundle-lgx": "nix-bundle-lgx_44",
         "nixpkgs": [
@@ -39472,7 +39783,7 @@
     },
     "nix-bundle-logos-module-install_17": {
       "inputs": {
-        "logos-nix": "logos-nix_718",
+        "logos-nix": "logos-nix_720",
         "logos-package-manager": "logos-package-manager_37",
         "nix-bundle-lgx": "nix-bundle-lgx_47",
         "nixpkgs": [
@@ -39503,7 +39814,7 @@
     },
     "nix-bundle-logos-module-install_18": {
       "inputs": {
-        "logos-nix": "logos-nix_762",
+        "logos-nix": "logos-nix_764",
         "logos-package-manager": "logos-package-manager_39",
         "nix-bundle-lgx": "nix-bundle-lgx_50",
         "nixpkgs": [
@@ -39535,7 +39846,7 @@
     },
     "nix-bundle-logos-module-install_19": {
       "inputs": {
-        "logos-nix": "logos-nix_790",
+        "logos-nix": "logos-nix_792",
         "logos-package-manager": "logos-package-manager_41",
         "nix-bundle-lgx": "nix-bundle-lgx_53",
         "nixpkgs": [
@@ -39593,7 +39904,7 @@
     },
     "nix-bundle-logos-module-install_20": {
       "inputs": {
-        "logos-nix": "logos-nix_803",
+        "logos-nix": "logos-nix_805",
         "logos-package-manager": "logos-package-manager_42",
         "nix-bundle-lgx": "nix-bundle-lgx_54",
         "nixpkgs": [
@@ -39619,7 +39930,7 @@
     },
     "nix-bundle-logos-module-install_3": {
       "inputs": {
-        "logos-nix": "logos-nix_115",
+        "logos-nix": "logos-nix_117",
         "logos-package-manager": "logos-package-manager_6",
         "nix-bundle-lgx": "nix-bundle-lgx_9",
         "nixpkgs": [
@@ -39630,11 +39941,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775839388,
-        "narHash": "sha256-0QH146bzL2kKBYJq2yA35iPwug55j2xjEyKCS7tjhvg=",
+        "lastModified": 1782134900,
+        "narHash": "sha256-v5A+e+1Sk1BXbOkaPkc9Pc2BOozCN1cH4onkcV/jnUQ=",
         "owner": "logos-co",
         "repo": "nix-bundle-logos-module-install",
-        "rev": "89cc9ea91275396d589c767d76926459ac77ef20",
+        "rev": "55de9a6fce755387224ececd0493f46b028ee0a3",
         "type": "github"
       },
       "original": {
@@ -39645,7 +39956,7 @@
     },
     "nix-bundle-logos-module-install_4": {
       "inputs": {
-        "logos-nix": "logos-nix_157",
+        "logos-nix": "logos-nix_159",
         "logos-package-manager": "logos-package-manager_8",
         "nix-bundle-lgx": "nix-bundle-lgx_12",
         "nixpkgs": [
@@ -39673,7 +39984,7 @@
     },
     "nix-bundle-logos-module-install_5": {
       "inputs": {
-        "logos-nix": "logos-nix_217",
+        "logos-nix": "logos-nix_219",
         "logos-package-manager": "logos-package-manager_10",
         "nix-bundle-lgx": "nix-bundle-lgx_15",
         "nixpkgs": [
@@ -39705,7 +40016,7 @@
     },
     "nix-bundle-logos-module-install_6": {
       "inputs": {
-        "logos-nix": "logos-nix_261",
+        "logos-nix": "logos-nix_263",
         "logos-package-manager": "logos-package-manager_12",
         "nix-bundle-lgx": "nix-bundle-lgx_18",
         "nixpkgs": [
@@ -39738,7 +40049,7 @@
     },
     "nix-bundle-logos-module-install_7": {
       "inputs": {
-        "logos-nix": "logos-nix_289",
+        "logos-nix": "logos-nix_291",
         "logos-package-manager": "logos-package-manager_14",
         "nix-bundle-lgx": "nix-bundle-lgx_21",
         "nixpkgs": [
@@ -39767,7 +40078,7 @@
     },
     "nix-bundle-logos-module-install_8": {
       "inputs": {
-        "logos-nix": "logos-nix_348",
+        "logos-nix": "logos-nix_350",
         "logos-package-manager": "logos-package-manager_17",
         "nix-bundle-lgx": "nix-bundle-lgx_24",
         "nixpkgs": [
@@ -39797,7 +40108,7 @@
     },
     "nix-bundle-logos-module-install_9": {
       "inputs": {
-        "logos-nix": "logos-nix_399",
+        "logos-nix": "logos-nix_401",
         "logos-package-manager": "logos-package-manager_20",
         "nix-bundle-lgx": "nix-bundle-lgx_27",
         "nixpkgs": [
@@ -52593,6 +52904,38 @@
         "type": "github"
       }
     },
+    "nixpkgs_818": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_819": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_82": {
       "locked": {
         "lastModified": 1759036355,
@@ -52904,11 +53247,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780954572,
-        "narHash": "sha256-JPa5FPbZrjcyJNzae/97dG5NulfWqGuieJRaH7VZFNU=",
+        "lastModified": 1782225255,
+        "narHash": "sha256-pb7p1NFlne9I+oIUMbk9+MgvSl8lLMwCaNFMK8li5Hc=",
         "owner": "logos-co",
         "repo": "openmetrics-module",
-        "rev": "af0a81d07d91926802d2f8e2b3dfe8ad9f5eb767",
+        "rev": "c50e9d39262a5fe17443a79a25f6437b19123416",
         "type": "github"
       },
       "original": {
@@ -52919,7 +53262,7 @@
     },
     "package-manager": {
       "inputs": {
-        "logos-nix": "logos-nix_812",
+        "logos-nix": "logos-nix_814",
         "logos-package": "logos-package_97",
         "nix-bundle-appimage": "nix-bundle-appimage_46",
         "nix-bundle-dir": "nix-bundle-dir_146",
@@ -52974,7 +53317,7 @@
     },
     "process-stats_10": {
       "inputs": {
-        "logos-nix": "logos-nix_365",
+        "logos-nix": "logos-nix_367",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -53000,7 +53343,7 @@
     },
     "process-stats_11": {
       "inputs": {
-        "logos-nix": "logos-nix_388",
+        "logos-nix": "logos-nix_390",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -53030,7 +53373,7 @@
     },
     "process-stats_12": {
       "inputs": {
-        "logos-nix": "logos-nix_431",
+        "logos-nix": "logos-nix_433",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -53061,7 +53404,7 @@
     },
     "process-stats_13": {
       "inputs": {
-        "logos-nix": "logos-nix_459",
+        "logos-nix": "logos-nix_461",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -53088,7 +53431,7 @@
     },
     "process-stats_14": {
       "inputs": {
-        "logos-nix": "logos-nix_485",
+        "logos-nix": "logos-nix_487",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -53120,7 +53463,7 @@
     },
     "process-stats_15": {
       "inputs": {
-        "logos-nix": "logos-nix_513",
+        "logos-nix": "logos-nix_515",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -53148,7 +53491,7 @@
     },
     "process-stats_16": {
       "inputs": {
-        "logos-nix": "logos-nix_536",
+        "logos-nix": "logos-nix_538",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -53180,7 +53523,7 @@
     },
     "process-stats_17": {
       "inputs": {
-        "logos-nix": "logos-nix_579",
+        "logos-nix": "logos-nix_581",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -53213,7 +53556,7 @@
     },
     "process-stats_18": {
       "inputs": {
-        "logos-nix": "logos-nix_607",
+        "logos-nix": "logos-nix_609",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -53242,7 +53585,7 @@
     },
     "process-stats_19": {
       "inputs": {
-        "logos-nix": "logos-nix_645",
+        "logos-nix": "logos-nix_647",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -53302,7 +53645,7 @@
     },
     "process-stats_20": {
       "inputs": {
-        "logos-nix": "logos-nix_707",
+        "logos-nix": "logos-nix_709",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -53333,7 +53676,7 @@
     },
     "process-stats_21": {
       "inputs": {
-        "logos-nix": "logos-nix_751",
+        "logos-nix": "logos-nix_753",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -53365,7 +53708,7 @@
     },
     "process-stats_22": {
       "inputs": {
-        "logos-nix": "logos-nix_779",
+        "logos-nix": "logos-nix_781",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -53393,7 +53736,7 @@
     },
     "process-stats_3": {
       "inputs": {
-        "logos-nix": "logos-nix_104",
+        "logos-nix": "logos-nix_106",
         "nixpkgs": [
           "logos-module-builder",
           "logos-standalone-app",
@@ -53419,7 +53762,7 @@
     },
     "process-stats_4": {
       "inputs": {
-        "logos-nix": "logos-nix_146",
+        "logos-nix": "logos-nix_148",
         "nixpkgs": [
           "logoscore-cli",
           "logos-capability-module",
@@ -53447,7 +53790,7 @@
     },
     "process-stats_5": {
       "inputs": {
-        "logos-nix": "logos-nix_206",
+        "logos-nix": "logos-nix_208",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -53479,7 +53822,7 @@
     },
     "process-stats_6": {
       "inputs": {
-        "logos-nix": "logos-nix_250",
+        "logos-nix": "logos-nix_252",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -53512,7 +53855,7 @@
     },
     "process-stats_7": {
       "inputs": {
-        "logos-nix": "logos-nix_278",
+        "logos-nix": "logos-nix_280",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -53541,7 +53884,7 @@
     },
     "process-stats_8": {
       "inputs": {
-        "logos-nix": "logos-nix_311",
+        "logos-nix": "logos-nix_313",
         "nixpkgs": [
           "logoscore-cli",
           "logos-liblogos",
@@ -53566,7 +53909,7 @@
     },
     "process-stats_9": {
       "inputs": {
-        "logos-nix": "logos-nix_337",
+        "logos-nix": "logos-nix_339",
         "nixpkgs": [
           "logoscore-cli",
           "logos-test-modules",
@@ -53611,11 +53954,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782012058,
-        "narHash": "sha256-9mWUnReOUXfKjZuJAL/bAFH3LUyECTRtXgSNVjRw3UY=",
+        "lastModified": 1782271078,
+        "narHash": "sha256-Ukpyd+syDTr+ky+nI+SbUnWySfiqNRzA3gzFZYWepeg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8534567325bd8a8d2928e6afd81e0a87d19efd3c",
+        "rev": "b7286019daa89e4e192c8913c3ec7002976034d0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     logos-module-builder.url = "github:logos-co/logos-module-builder";
-    libp2p.url = "github:vacp2p/nim-libp2p/feat/cbind/user-provided-xprs";
+    libp2p.url = "github:vacp2p/nim-libp2p";
 
     openmetrics-module = {
       url = "github:logos-co/openmetrics-module";

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     logos-module-builder.url = "github:logos-co/logos-module-builder";
-    libp2p.url = "github:vacp2p/nim-libp2p/chore/cbind/metrics";
+    libp2p.url = "github:vacp2p/nim-libp2p/feat/cbind/user-provided-xprs";
 
     openmetrics-module = {
       url = "github:logos-co/openmetrics-module";

--- a/src/kademlia.cpp
+++ b/src/kademlia.cpp
@@ -35,9 +35,7 @@ StdLogosResult Libp2pModuleImpl::kadGetValue(const std::string& key, int64_t quo
                 quorum,
                 &Libp2pModuleImpl::promiseBufferCallback, p);
         },
-        [](const SyncResult& r) -> StdLogosResult {
-            return {true, std::string(r.buffer.begin(), r.buffer.end()), ""};
-        });
+        bufferToResult);
 }
 
 StdLogosResult Libp2pModuleImpl::kadAddProvider(const std::string& cid) {

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -110,13 +110,12 @@ Libp2pModuleImpl::Libp2pModuleImpl(const Libp2pModuleOptions& options)
     m_libp2pConfig.mount_kad = options.mountKad ? 1 : 0;
     m_libp2pConfig.mount_service_discovery = options.mountServiceDiscovery ? 1 : 0;
 
-    auto keyResult = newPrivateKey();
-    if (!keyResult.success) {
-        fprintf(stderr, "libp2p_new_private_key failed: %s\n", keyResult.error.c_str());
+    auto keyResult = generatePrivateKeyRaw();
+    if (!keyResult.ok) {
+        fprintf(stderr, "libp2p_new_private_key failed: %s\n", keyResult.message.c_str());
         return;
     }
-    std::string keyStr = keyResult.value.get<std::string>();
-    m_privKey.assign(keyStr.begin(), keyStr.end());
+    m_privKey = std::move(keyResult.buffer);
 
     m_libp2pConfig.priv_key.data = m_privKey.data();
     m_libp2pConfig.priv_key.dataLen = static_cast<int>(m_privKey.size());
@@ -204,7 +203,7 @@ StdLogosResult Libp2pModuleImpl::publicKey() {
         bufferToResult);
 }
 
-StdLogosResult Libp2pModuleImpl::newPrivateKey() {
+SyncResult Libp2pModuleImpl::generatePrivateKeyRaw() {
     // Doesn't need a ctx, so it bypasses callSync's ctx check.
     auto* p = new SyncPromise();
     auto f = p->get_future();
@@ -212,9 +211,13 @@ StdLogosResult Libp2pModuleImpl::newPrivateKey() {
                                      &Libp2pModuleImpl::promiseBufferCallback, p);
     if (ret != RET_OK) {
         delete p;
-        return {false, {}, "Failed to generate private key (ret=" + std::to_string(ret) + ")"};
+        return {false, "Failed to generate private key (ret=" + std::to_string(ret) + ")", {}, nullptr};
     }
-    auto r = awaitResult(f);
+    return awaitResult(f);
+}
+
+StdLogosResult Libp2pModuleImpl::newPrivateKey() {
+    auto r = generatePrivateKeyRaw();
     if (!r.ok) return {false, {}, r.message};
     return bufferToResult(r);
 }

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -201,9 +201,7 @@ StdLogosResult Libp2pModuleImpl::publicKey() {
         [&](SyncPromise* p) {
             return libp2p_public_key(ctx, &Libp2pModuleImpl::promiseBufferCallback, p);
         },
-        [](const SyncResult& r) -> StdLogosResult {
-            return {true, std::string(r.buffer.begin(), r.buffer.end()), ""};
-        });
+        bufferToResult);
 }
 
 StdLogosResult Libp2pModuleImpl::newPrivateKey() {
@@ -218,7 +216,7 @@ StdLogosResult Libp2pModuleImpl::newPrivateKey() {
     }
     auto r = awaitResult(f);
     if (!r.ok) return {false, {}, r.message};
-    return {true, std::string(r.buffer.begin(), r.buffer.end()), ""};
+    return bufferToResult(r);
 }
 
 StdLogosResult Libp2pModuleImpl::toCid(const std::string& key) {

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -154,6 +154,12 @@ inline SyncResult awaitResult(std::future<SyncResult>& f, int timeoutMs = 10000)
     return {false, "timeout", {}, nullptr};
 }
 
+// Wraps a resolved buffer as a successful result. The value is a raw byte
+// container (not UTF-8 text), matching publicKey/kadGetValue/stream reads.
+inline StdLogosResult bufferToResult(const SyncResult& r) {
+    return {true, std::string(r.buffer.begin(), r.buffer.end()), ""};
+}
+
 // Non-throwing JSON parse — malformed cbinding output yields a failed result
 // instead of propagating an exception.
 inline StdLogosResult parseJsonResponse(const std::string& s, const char* errPrefix) {
@@ -262,7 +268,6 @@ public:
     StdLogosResult discoUnregisterInterest(const std::string& serviceId);
     StdLogosResult discoLookup(const std::string& serviceId, const std::string& serviceData);
     StdLogosResult discoRandomLookup();
-    // Builds and signs the node's own Extended Peer Record; returns the encoded bytes.
     StdLogosResult createXpr(const std::vector<std::string>& addrs,
                              const std::vector<std::pair<std::string, std::string>>& services,
                              uint64_t seqNo);

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -262,6 +262,10 @@ public:
     StdLogosResult discoUnregisterInterest(const std::string& serviceId);
     StdLogosResult discoLookup(const std::string& serviceId, const std::string& serviceData);
     StdLogosResult discoRandomLookup();
+    // Builds and signs the node's own Extended Peer Record; returns the encoded bytes.
+    StdLogosResult createXpr(const std::vector<std::string>& addrs,
+                             const std::vector<std::pair<std::string, std::string>>& services,
+                             uint64_t seqNo);
 
     StdLogosResult peerstoreGetPeers();
     StdLogosResult peerstoreGetPeerInfo(const std::string& peerId);

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -154,10 +154,36 @@ inline SyncResult awaitResult(std::future<SyncResult>& f, int timeoutMs = 10000)
     return {false, "timeout", {}, nullptr};
 }
 
-// Wraps a resolved buffer as a successful result. The value is a raw byte
-// container (not UTF-8 text), matching publicKey/kadGetValue/stream reads.
+inline std::string base64Encode(const std::vector<uint8_t>& data) {
+    static constexpr char kAlphabet[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    std::string out;
+    out.reserve((data.size() + 2) / 3 * 4);
+    size_t i = 0;
+    for (; i + 3 <= data.size(); i += 3) {
+        uint32_t n = (data[i] << 16) | (data[i + 1] << 8) | data[i + 2];
+        out.push_back(kAlphabet[(n >> 18) & 0x3f]);
+        out.push_back(kAlphabet[(n >> 12) & 0x3f]);
+        out.push_back(kAlphabet[(n >> 6) & 0x3f]);
+        out.push_back(kAlphabet[n & 0x3f]);
+    }
+    if (i < data.size()) {
+        uint32_t n = data[i] << 16;
+        bool hasTwo = i + 1 < data.size();
+        if (hasTwo) n |= data[i + 1] << 8;
+        out.push_back(kAlphabet[(n >> 18) & 0x3f]);
+        out.push_back(kAlphabet[(n >> 12) & 0x3f]);
+        out.push_back(hasTwo ? kAlphabet[(n >> 6) & 0x3f] : '=');
+        out.push_back('=');
+    }
+    return out;
+}
+
+// Wraps a resolved buffer as a successful result. Buffers are raw bytes
+// (publicKey/kadGetValue/stream reads), so they're base64-encoded to keep
+// `value` a valid UTF-8 JSON string.
 inline StdLogosResult bufferToResult(const SyncResult& r) {
-    return {true, std::string(r.buffer.begin(), r.buffer.end()), ""};
+    return {true, base64Encode(r.buffer), ""};
 }
 
 // Non-throwing JSON parse — malformed cbinding output yields a failed result
@@ -320,6 +346,8 @@ private:
     std::mutex m_queueMutex;
     std::condition_variable m_queueCond;
     std::unordered_map<std::string, std::queue<std::string>> m_topicQueues;
+
+    SyncResult generatePrivateKeyRaw();
 
     static void promiseCallback(int ret, const char* msg, size_t len, void* userData);
     static void promiseBufferCallback(int ret, const uint8_t* data, size_t dataLen,

--- a/src/service_discovery.cpp
+++ b/src/service_discovery.cpp
@@ -82,9 +82,8 @@ StdLogosResult Libp2pModuleImpl::discoRandomLookup() {
         });
 }
 
-/// Builds and signs the node's own Extended Peer Record (XPR) with its private
-/// key, returning the protobuf-encoded signed bytes. Empty `addrs` falls back
-/// to the node's listen addresses; `seqNo` of 0 defaults to the current time.
+/// Builds and signs the node's own Extended Peer Record, returning the signed
+/// protobuf bytes. Empty `addrs` uses the listen addresses; `seqNo` 0 uses now.
 StdLogosResult Libp2pModuleImpl::createXpr(
     const std::vector<std::string>& addrs,
     const std::vector<std::pair<std::string, std::string>>& services,
@@ -112,7 +111,5 @@ StdLogosResult Libp2pModuleImpl::createXpr(
                 serviceInfos.empty() ? nullptr : serviceInfos.data(), serviceInfos.size(),
                 seqNo, &Libp2pModuleImpl::promiseBufferCallback, p);
         },
-        [](const SyncResult& r) -> StdLogosResult {
-            return {true, std::string(r.buffer.begin(), r.buffer.end()), ""};
-        });
+        bufferToResult);
 }

--- a/src/service_discovery.cpp
+++ b/src/service_discovery.cpp
@@ -81,3 +81,38 @@ StdLogosResult Libp2pModuleImpl::discoRandomLookup() {
             return parseJsonResponse(r.message, "discoRandomLookup");
         });
 }
+
+/// Builds and signs the node's own Extended Peer Record (XPR) with its private
+/// key, returning the protobuf-encoded signed bytes. Empty `addrs` falls back
+/// to the node's listen addresses; `seqNo` of 0 defaults to the current time.
+StdLogosResult Libp2pModuleImpl::createXpr(
+    const std::vector<std::string>& addrs,
+    const std::vector<std::pair<std::string, std::string>>& services,
+    uint64_t seqNo)
+{
+    std::vector<const char*> addrPtrs;
+    addrPtrs.reserve(addrs.size());
+    for (const auto& addr : addrs) {
+        addrPtrs.push_back(addr.c_str());
+    }
+
+    std::vector<Libp2pServiceInfo> serviceInfos;
+    serviceInfos.reserve(services.size());
+    for (const auto& [id, data] : services) {
+        serviceInfos.push_back(Libp2pServiceInfo{
+            .id = const_cast<char*>(id.c_str()),
+            .data = data.empty() ? nullptr : reinterpret_cast<const uint8_t*>(data.data()),
+            .dataLen = data.size()});
+    }
+
+    return callSyncWith("Failed to create XPR",
+        [&](SyncPromise* p) {
+            return libp2p_create_xpr(
+                ctx, addrPtrs.empty() ? nullptr : addrPtrs.data(), addrPtrs.size(),
+                serviceInfos.empty() ? nullptr : serviceInfos.data(), serviceInfos.size(),
+                seqNo, &Libp2pModuleImpl::promiseBufferCallback, p);
+        },
+        [](const SyncResult& r) -> StdLogosResult {
+            return {true, std::string(r.buffer.begin(), r.buffer.end()), ""};
+        });
+}

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -75,9 +75,7 @@ StdLogosResult Libp2pModuleImpl::streamReadExactly(uint64_t streamId, uint64_t l
             return libp2p_stream_readExactly(ctx, s, len,
                                              &Libp2pModuleImpl::promiseBufferCallback, p);
         },
-        [](const SyncResult& r) -> StdLogosResult {
-            return {true, std::string(r.buffer.begin(), r.buffer.end()), ""};
-        });
+        bufferToResult);
 }
 
 StdLogosResult Libp2pModuleImpl::streamReadLp(uint64_t streamId, uint64_t maxSize) {
@@ -86,9 +84,7 @@ StdLogosResult Libp2pModuleImpl::streamReadLp(uint64_t streamId, uint64_t maxSiz
             return libp2p_stream_readLp(ctx, s, maxSize,
                                         &Libp2pModuleImpl::promiseBufferCallback, p);
         },
-        [](const SyncResult& r) -> StdLogosResult {
-            return {true, std::string(r.buffer.begin(), r.buffer.end()), ""};
-        });
+        bufferToResult);
 }
 
 StdLogosResult Libp2pModuleImpl::streamWrite(uint64_t streamId, const std::string& data) {

--- a/tests/integration.cpp
+++ b/tests/integration.cpp
@@ -76,7 +76,7 @@ LOGOS_TEST(integration_reconnect_after_disconnect) {
 
     auto readResult = nodeA.streamReadExactly(streamId, PING_SIZE);
     LOGOS_ASSERT_TRUE(readResult.success);
-    LOGOS_ASSERT_TRUE(readResult.value.get<std::string>() == payload);
+    LOGOS_ASSERT_TRUE(base64Decode(readResult.value.get<std::string>()) == payload);
 
     LOGOS_ASSERT_TRUE(nodeA.streamCloseWithEOF(streamId).success);
     LOGOS_ASSERT_TRUE(nodeA.streamRelease(streamId).success);
@@ -119,11 +119,11 @@ LOGOS_TEST(integration_multiple_streams_on_same_connection) {
 
     auto read1 = nodeA.streamReadExactly(stream1, PING_SIZE);
     LOGOS_ASSERT_TRUE(read1.success);
-    LOGOS_ASSERT_TRUE(read1.value.get<std::string>() == payload1);
+    LOGOS_ASSERT_TRUE(base64Decode(read1.value.get<std::string>()) == payload1);
 
     auto read2 = nodeA.streamReadExactly(stream2, PING_SIZE);
     LOGOS_ASSERT_TRUE(read2.success);
-    LOGOS_ASSERT_TRUE(read2.value.get<std::string>() == payload2);
+    LOGOS_ASSERT_TRUE(base64Decode(read2.value.get<std::string>()) == payload2);
 
     LOGOS_ASSERT_TRUE(nodeA.streamCloseWithEOF(stream1).success);
     LOGOS_ASSERT_TRUE(nodeA.streamRelease(stream1).success);
@@ -159,7 +159,7 @@ LOGOS_TEST(integration_direct_dial_stream_exchange) {
 
     auto readResult = nodeA.streamReadExactly(streamId, PING_SIZE);
     LOGOS_ASSERT_TRUE(readResult.success);
-    LOGOS_ASSERT_TRUE(readResult.value.get<std::string>() == payload);
+    LOGOS_ASSERT_TRUE(base64Decode(readResult.value.get<std::string>()) == payload);
 
     LOGOS_ASSERT_TRUE(nodeA.streamCloseWithEOF(streamId).success);
     LOGOS_ASSERT_TRUE(nodeA.streamRelease(streamId).success);
@@ -205,7 +205,7 @@ LOGOS_TEST(integration_circuit_relay_routing) {
 
     auto readResult = nodeA.streamReadExactly(streamId, PING_SIZE);
     LOGOS_ASSERT_TRUE(readResult.success);
-    LOGOS_ASSERT_TRUE(readResult.value.get<std::string>() == payload);
+    LOGOS_ASSERT_TRUE(base64Decode(readResult.value.get<std::string>()) == payload);
 
     LOGOS_ASSERT_TRUE(nodeA.streamCloseWithEOF(streamId).success);
     LOGOS_ASSERT_TRUE(nodeA.streamRelease(streamId).success);
@@ -241,7 +241,7 @@ LOGOS_TEST(integration_lp_stream_exchange) {
 
     auto readResult = nodeA.streamReadLp(streamId, 4096);
     LOGOS_ASSERT_TRUE(readResult.success);
-    LOGOS_ASSERT_TRUE(readResult.value.get<std::string>() == payload);
+    LOGOS_ASSERT_TRUE(base64Decode(readResult.value.get<std::string>()) == payload);
 
     LOGOS_ASSERT_TRUE(nodeA.streamCloseWithEOF(streamId).success);
     LOGOS_ASSERT_TRUE(nodeA.streamRelease(streamId).success);
@@ -278,7 +278,7 @@ LOGOS_TEST(integration_quic_ping_round_trip) {
 
     auto readResult = nodeA.streamReadExactly(streamId, PING_SIZE);
     LOGOS_ASSERT_TRUE(readResult.success);
-    LOGOS_ASSERT_TRUE(readResult.value.get<std::string>() == payload);
+    LOGOS_ASSERT_TRUE(base64Decode(readResult.value.get<std::string>()) == payload);
 
     LOGOS_ASSERT_TRUE(nodeA.streamCloseWithEOF(streamId).success);
     LOGOS_ASSERT_TRUE(nodeA.streamRelease(streamId).success);

--- a/tests/integration_kad.cpp
+++ b/tests/integration_kad.cpp
@@ -20,7 +20,7 @@ LOGOS_TEST(kad_put_get) {
     auto result = nodeB.kadGetValue(key, quorum);
     LOGOS_ASSERT_TRUE(result.success);
 
-    std::string record = result.value.get<std::string>();
+    std::string record = base64Decode(result.value.get<std::string>());
     LOGOS_ASSERT_TRUE(record == value);
 
     LOGOS_ASSERT_TRUE(nodeA.stop().success);

--- a/tests/integration_service_discovery.cpp
+++ b/tests/integration_service_discovery.cpp
@@ -175,18 +175,19 @@ LOGOS_TEST(create_xpr) {
         {"file-share", ""},
     };
 
-    // Explicit addrs and a fixed seqNo exercise the address marshalling and the
-    // caller-provided-seqNo branch.
     auto res = node.createXpr(addrs, services, 42);
     LOGOS_ASSERT_TRUE(res.success);
     LOGOS_ASSERT_FALSE(res.value.get<std::string>().empty());
 
-    // Empty addrs falls back to the node's listen addresses; seqNo 0 defaults
-    // to the current unix time. Distinct inputs yield distinct signed bytes.
+    // Only seqNo changes, so a differing payload isolates the seqNo branch.
+    auto resSeq = node.createXpr(addrs, services, 43);
+    LOGOS_ASSERT_TRUE(resSeq.success);
+    LOGOS_ASSERT_TRUE(res.value.get<std::string>() != resSeq.value.get<std::string>());
+
+    // Empty addrs falls back to listen addresses; seqNo 0 uses current time.
     auto resDefaults = node.createXpr({}, {}, 0);
     LOGOS_ASSERT_TRUE(resDefaults.success);
     LOGOS_ASSERT_FALSE(resDefaults.value.get<std::string>().empty());
-    LOGOS_ASSERT_TRUE(res.value.get<std::string>() != resDefaults.value.get<std::string>());
 
     LOGOS_ASSERT_TRUE(node.stop().success);
 }

--- a/tests/integration_service_discovery.cpp
+++ b/tests/integration_service_discovery.cpp
@@ -163,3 +163,30 @@ LOGOS_TEST(disco_random_lookup) {
     LOGOS_ASSERT_TRUE(nodeA.stop().success);
     LOGOS_ASSERT_TRUE(nodeB.stop().success);
 }
+
+LOGOS_TEST(create_xpr) {
+    Libp2pModuleImpl node(discoOptions());
+    LOGOS_ASSERT_TRUE(node.start().success);
+
+    auto [peerId, addrs] = getPeerInfoPair(node);
+
+    std::vector<std::pair<std::string, std::string>> services = {
+        {"chat", std::string{0x01, 0x02, 0x03}},
+        {"file-share", ""},
+    };
+
+    // Explicit addrs and a fixed seqNo exercise the address marshalling and the
+    // caller-provided-seqNo branch.
+    auto res = node.createXpr(addrs, services, 42);
+    LOGOS_ASSERT_TRUE(res.success);
+    LOGOS_ASSERT_FALSE(res.value.get<std::string>().empty());
+
+    // Empty addrs falls back to the node's listen addresses; seqNo 0 defaults
+    // to the current unix time. Distinct inputs yield distinct signed bytes.
+    auto resDefaults = node.createXpr({}, {}, 0);
+    LOGOS_ASSERT_TRUE(resDefaults.success);
+    LOGOS_ASSERT_FALSE(resDefaults.value.get<std::string>().empty());
+    LOGOS_ASSERT_TRUE(res.value.get<std::string>() != resDefaults.value.get<std::string>());
+
+    LOGOS_ASSERT_TRUE(node.stop().success);
+}

--- a/tests/sync.cpp
+++ b/tests/sync.cpp
@@ -1,5 +1,6 @@
 #include <logos_test.h>
 #include <plugin.h>
+#include "test_helpers.h"
 
 LOGOS_TEST(sync_connect_disconnect_peer) {
     Libp2pModuleImpl plugin;
@@ -169,7 +170,7 @@ LOGOS_TEST(sync_kad_get_put_value) {
 
     auto res = plugin.kadGetValue(key, 1);
     LOGOS_ASSERT_TRUE(res.success);
-    LOGOS_ASSERT_TRUE(res.value.get<std::string>() == value);
+    LOGOS_ASSERT_TRUE(base64Decode(res.value.get<std::string>()) == value);
 
     LOGOS_ASSERT_TRUE(plugin.stop().success);
 }

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -1,9 +1,35 @@
 #pragma once
 
+#include <cstdint>
 #include <plugin.h>
 #include <string>
 #include <utility>
 #include <vector>
+
+inline std::string base64Decode(const std::string& in) {
+    static constexpr char kAlphabet[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    int lookup[256];
+    for (int& v : lookup) v = -1;
+    for (int i = 0; i < 64; ++i) lookup[static_cast<unsigned char>(kAlphabet[i])] = i;
+
+    std::string out;
+    out.reserve(in.size() / 4 * 3);
+    uint32_t buf = 0;
+    int bits = 0;
+    for (char c : in) {
+        if (c == '=') break;
+        int val = lookup[static_cast<unsigned char>(c)];
+        if (val < 0) continue;
+        buf = (buf << 6) | static_cast<uint32_t>(val);
+        bits += 6;
+        if (bits >= 8) {
+            bits -= 8;
+            out.push_back(static_cast<char>((buf >> bits) & 0xff));
+        }
+    }
+    return out;
+}
 
 inline std::pair<std::string, std::vector<std::string>> getPeerInfoPair(Libp2pModuleImpl& node) {
     auto res = node.peerInfo();


### PR DESCRIPTION
## Summary

Exposes a `createXpr` method on the libp2p module so callers can build and sign the node's own Extended Peer Record (XPR) on demand, rather than relying solely on the records produced internally by service discovery.

This is the C-binding side of the change; it points the `libp2p` flake input at the matching `feat/cbind/user-provided-xprs` branch of `nim-libp2p`, which provides the underlying `libp2p_create_xpr` FFI entry point.

## Changes

- `src/plugin.h` / `src/service_discovery.cpp`: add `createXpr(addrs, services, seqNo)`. It marshals the service list into `Libp2pServiceInfo` and calls `libp2p_create_xpr`, returning the signed protobuf bytes. Empty `addrs` falls back to the node's listen addresses; a `seqNo` of `0` defaults to the current time.
- `src/plugin.h`: extract the repeated buffer→result conversion into a shared `bufferToResult` helper, and route `createXpr`, `publicKey`, `newPrivateKey`, `kadGetValue`, and the stream reads through it (previously six copies of the same line).
- `tests/integration_service_discovery.cpp`: add the `create_xpr` integration test, covering the explicit-addrs path, the empty-addrs/`seqNo`-0 default path, and a seqNo-only change that isolates the seqNo branch and asserts it alters the signed bytes.
- `examples/service_discovery.cpp` / `examples/README.md`: demonstrate building a signed XPR from the advertiser node, print its size, surface the failure path, and document the new capability.
- `flake.nix` / `flake.lock`: bump the `libp2p` input from `chore/cbind/metrics` to `feat/cbind/user-provided-xprs`.

## On the returned value

The XPR result is raw signed protobuf bytes — opaque binary, not UTF-8 text. It is carried as a `std::string` used purely as a byte container, the same convention every other binary-returning method uses (`publicKey`, `newPrivateKey`, `kadGetValue`, stream reads), now centralized in `bufferToResult`. Callers should treat it as bytes; the example prints only `.size()`, never the content.

## Notes

Depends on the `nim-libp2p` `feat/cbind/user-provided-xprs` branch being merged; the flake input must be re-pointed to its final ref before this lands.
