### PR TITLE
feat(servicedisco): add discoLookup data to expected output

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -27,7 +27,31 @@ use cases using the `logos-libp2p-module`.
   - Anchoring a DHT with a bootstrap node
   - Advertising a named service (`discoStartAdvertising`)
   - Registering interest and looking it up from another node (`discoRegisterInterest` / `discoLookup`)
-  - Resolving the advertiser's peer record (peerId, seqNo, addrs)
+  - Resolving the advertiser's peer record (peerId, seqNo, addrs, services)
+
+  `discoLookup` (and `discoRandomLookup`) return a JSON array of peer records. Each record describes one advertiser:
+
+  ```json
+  [
+    {
+      "peerId": "16Uiu2HAm...",
+      "seqNo": 1718000000,
+      "addrs": ["/ip4/127.0.0.1/tcp/40001"],
+      "services": [
+        { "id": "demo-service", "data": "version=1" }
+      ]
+    }
+  ]
+  ```
+
+  | Field      | Type             | Description                                                        |
+  | ---------- | ---------------- | ------------------------------------------------------------------ |
+  | `peerId`   | string           | The advertiser's peer ID.                                          |
+  | `seqNo`    | unsigned integer | Monotonic sequence number of the peer record; higher is newer.     |
+  | `addrs`    | array of strings | The advertiser's multiaddrs.                                       |
+  | `services` | array of objects | Services the peer advertises, each `{ "id", "data" }`.             |
+
+  `services[].data` is the opaque payload passed to `discoStartAdvertising`, returned verbatim as a string (empty when advertised without data).
 
 ## Building
 Enter the development shell and configure cmake
@@ -52,3 +76,21 @@ After building, run the executable from the build directory:
 ./build/examples/example_service_discovery
 ```
 
+For service discovery, a successful run prints the records returned by `discoLookup`:
+
+```text
+Starting nodes...
+Advertiser: advertising demo-service
+Discoverer: registering interest in demo-service
+Discoverer: looking up demo-service
+Discoverer found 1 peer(s) advertising demo-service
+  peer: 16Uiu2HAm... seq: 1718000000
+    addr: /ip4/127.0.0.1/tcp/40001
+    service: demo-service data: version=1
+Discoverer matched the advertiser: 16Uiu2HAm...
+Advertiser: random lookup
+Random lookup returned 1 peer(s)
+Discoverer: unregistering interest in demo-service
+Advertiser: stopping advertising demo-service
+Done
+```

--- a/examples/service_discovery.cpp
+++ b/examples/service_discovery.cpp
@@ -15,6 +15,21 @@ static std::pair<std::string, std::vector<std::string>> peerInfoOf(Libp2pModuleI
     return {peerId, addrs};
 }
 
+static void printRecord(const nlohmann::json& rec)
+{
+    printf("  peer: %s seq: %llu\n",
+           rec["peerId"].get<std::string>().c_str(),
+           (unsigned long long)rec["seqNo"].get<uint64_t>());
+    for (const auto& addr : rec["addrs"]) {
+        printf("    addr: %s\n", addr.get<std::string>().c_str());
+    }
+    for (const auto& svc : rec["services"]) {
+        printf("    service: %s data: %s\n",
+               svc["id"].get<std::string>().c_str(),
+               svc["data"].get<std::string>().c_str());
+    }
+}
+
 static nlohmann::json lookupUntilFound(Libp2pModuleImpl& node,
                                        const std::string& serviceId,
                                        const std::string& serviceData,
@@ -100,10 +115,7 @@ int main()
 
     printf("Discoverer found %zu peer(s) advertising %s\n", records.size(), serviceId.c_str());
     for (const auto& rec : records) {
-        printf("  peer: %s seq: %llu addrs: %zu\n",
-               rec["peerId"].get<std::string>().c_str(),
-               (unsigned long long)rec["seqNo"].get<uint64_t>(),
-               rec["addrs"].size());
+        printRecord(rec);
     }
 
     std::string advertiserId = peerInfoOf(advertiser).first;


### PR DESCRIPTION
## Summary

Closes #51.

When devs run the service discovery example, the printed output told them *how many* peers were found but not *what* a discovery record actually contains — the `services` field was dropped entirely, and `examples/README.md` had no documentation of the `discoLookup` return shape. This left "what info can I expect from service discovery?" unanswered, which is the question issue #51 (item 6 of the docs review) raised.

This makes the `discoLookup` data visible in two places:

- `examples/service_discovery.cpp` — extracts a `printRecord` helper that prints the full record: `peerId`, `seqNo`, every `addr`, and each advertised `service` (`id` + `data`). Previously only `peerId`, `seqNo`, and an addr *count* were printed, and `services` was silently ignored.
- `examples/README.md` — documents the record schema returned by `discoLookup` / `discoRandomLookup` (JSON sample + a field table for `peerId` / `seqNo` / `addrs` / `services`), and adds an expected-console-output block for the example.

Docs/example only — no library or API changes.

## Testing

Not built locally — the sandbox can't compile the cbind-dependent module. The new `printRecord` uses only `nlohmann::json` accessors already used elsewhere in the same example, so it's consistent with existing code, but a `cmake --build` is worth running before merge.