### PR TITLE
chore: dedup the sync-over-async bridge, split plugin.h, surface init failure

### DIFF
--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -8,11 +8,9 @@ void Libp2pModuleImpl::promisePeerInfoCallback(
     int ret, const Libp2pPeerInfo* info,
     const char* msg, size_t len, void* userData)
 {
-    auto* p = static_cast<SyncPromise*>(userData);
-    SyncResult r;
-    r.ok = (ret == RET_OK);
+    auto r = basicResult(ret, msg, len);
 
-    if (ret == RET_OK && info) {
+    if (r.ok && info) {
         json j;
         j["peerId"] = info->peerId ? info->peerId : "";
         json addrs = json::array();
@@ -22,24 +20,19 @@ void Libp2pModuleImpl::promisePeerInfoCallback(
             }
         }
         j["addrs"] = addrs;
-        r.message = j.dump();
-    } else {
-        r.message = (msg && len > 0) ? std::string(msg, len) : std::string();
+        r.data = std::move(j);
     }
 
-    p->set_value(std::move(r));
-    delete p;
+    finishPromise(static_cast<SyncPromise*>(userData), std::move(r));
 }
 
 void Libp2pModuleImpl::promisePeerStoreEntryCallback(
     int ret, const Libp2pPeerStoreEntry* entry,
     const char* msg, size_t len, void* userData)
 {
-    auto* p = static_cast<SyncPromise*>(userData);
-    SyncResult r;
-    r.ok = (ret == RET_OK);
+    auto r = basicResult(ret, msg, len);
 
-    if (ret == RET_OK && entry) {
+    if (r.ok && entry) {
         json j;
         j["peerId"] = entry->peerId ? entry->peerId : "";
         json addrs = json::array();
@@ -69,46 +62,36 @@ void Libp2pModuleImpl::promisePeerStoreEntryCallback(
         j["publicKey"] = publicKey;
         j["agentVersion"] = entry->agentVersion ? entry->agentVersion : "";
         j["protoVersion"] = entry->protoVersion ? entry->protoVersion : "";
-        r.message = j.dump();
-    } else {
-        r.message = (msg && len > 0) ? std::string(msg, len) : std::string();
+        r.data = std::move(j);
     }
 
-    p->set_value(std::move(r));
-    delete p;
+    finishPromise(static_cast<SyncPromise*>(userData), std::move(r));
 }
 
 void Libp2pModuleImpl::promisePeersCallback(
     int ret, const char** peerIds, size_t peerIdsLen,
     const char* msg, size_t len, void* userData)
 {
-    auto* p = static_cast<SyncPromise*>(userData);
-    SyncResult r;
-    r.ok = (ret == RET_OK);
+    auto r = basicResult(ret, msg, len);
 
-    if (ret == RET_OK && peerIds && peerIdsLen > 0) {
+    if (r.ok && peerIds && peerIdsLen > 0) {
         json arr = json::array();
         for (size_t i = 0; i < peerIdsLen; ++i) {
             if (peerIds[i]) arr.push_back(peerIds[i]);
         }
-        r.message = arr.dump();
-    } else {
-        r.message = (msg && len > 0) ? std::string(msg, len) : std::string();
+        r.data = std::move(arr);
     }
 
-    p->set_value(std::move(r));
-    delete p;
+    finishPromise(static_cast<SyncPromise*>(userData), std::move(r));
 }
 
 void Libp2pModuleImpl::promiseProvidersCallback(
     int ret, const Libp2pPeerInfo* providers, size_t providersLen,
     const char* msg, size_t len, void* userData)
 {
-    auto* p = static_cast<SyncPromise*>(userData);
-    SyncResult r;
-    r.ok = (ret == RET_OK);
+    auto r = basicResult(ret, msg, len);
 
-    if (ret == RET_OK && providers && providersLen > 0) {
+    if (r.ok && providers && providersLen > 0) {
         json arr = json::array();
         for (size_t i = 0; i < providersLen; ++i) {
             json peer;
@@ -122,29 +105,22 @@ void Libp2pModuleImpl::promiseProvidersCallback(
             peer["addrs"] = addrs;
             arr.push_back(peer);
         }
-        r.message = arr.dump();
-    } else {
-        r.message = (msg && len > 0) ? std::string(msg, len) : std::string();
+        r.data = std::move(arr);
     }
 
-    p->set_value(std::move(r));
-    delete p;
+    finishPromise(static_cast<SyncPromise*>(userData), std::move(r));
 }
 
 void Libp2pModuleImpl::promiseConnectionCallback(
     int ret, libp2p_stream_t* stream,
     const char* msg, size_t len, void* userData)
 {
-    auto* p = static_cast<SyncPromise*>(userData);
-    SyncResult r;
-    r.ok = (ret == RET_OK);
-    r.message = (msg && len > 0) ? std::string(msg, len) : std::string();
-    if (ret == RET_OK && stream) {
-        r.extra = stream;
+    auto r = basicResult(ret, msg, len);
+    if (r.ok && stream) {
+        r.stream = stream;
     }
 
-    p->set_value(std::move(r));
-    delete p;
+    finishPromise(static_cast<SyncPromise*>(userData), std::move(r));
 }
 
 void Libp2pModuleImpl::promiseReservationCallback(
@@ -152,33 +128,26 @@ void Libp2pModuleImpl::promiseReservationCallback(
     const char* msg, size_t len, void* userData)
 {
     (void)expireTime;
-    auto* p = static_cast<SyncPromise*>(userData);
-    SyncResult r;
-    r.ok = (ret == RET_OK);
+    auto r = basicResult(ret, msg, len);
 
-    if (ret == RET_OK && addrs && addrsLen > 0) {
+    if (r.ok && addrs && addrsLen > 0) {
         json arr = json::array();
         for (size_t i = 0; i < addrsLen; ++i) {
             if (addrs[i]) arr.push_back(addrs[i]);
         }
-        r.message = arr.dump();
-    } else {
-        r.message = (msg && len > 0) ? std::string(msg, len) : std::string();
+        r.data = std::move(arr);
     }
 
-    p->set_value(std::move(r));
-    delete p;
+    finishPromise(static_cast<SyncPromise*>(userData), std::move(r));
 }
 
 void Libp2pModuleImpl::promiseRandomRecordsCallback(
     int ret, const Libp2pExtendedPeerRecord* records, size_t recordsLen,
     const char* msg, size_t len, void* userData)
 {
-    auto* p = static_cast<SyncPromise*>(userData);
-    SyncResult r;
-    r.ok = (ret == RET_OK);
+    auto r = basicResult(ret, msg, len);
 
-    if (ret == RET_OK && records && recordsLen > 0) {
+    if (r.ok && records && recordsLen > 0) {
         json arr = json::array();
         for (size_t i = 0; i < recordsLen; ++i) {
             json rec;
@@ -211,13 +180,10 @@ void Libp2pModuleImpl::promiseRandomRecordsCallback(
             rec["services"] = services;
             arr.push_back(rec);
         }
-        r.message = arr.dump();
-    } else {
-        r.message = (msg && len > 0) ? std::string(msg, len) : std::string();
+        r.data = std::move(arr);
     }
 
-    p->set_value(std::move(r));
-    delete p;
+    finishPromise(static_cast<SyncPromise*>(userData), std::move(r));
 }
 
 void Libp2pModuleImpl::topicHandler(

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+extern "C" {
+#include "lib/libp2p.h"
+}
+
+struct Libp2pModuleOptions {
+    std::vector<std::string> addrs = {};
+    std::vector<std::pair<std::string, std::vector<std::string>>> bootstrapNodes = {};
+    int transport = LIBP2P_TRANSPORT_TCP;
+    bool autonat = false;
+    bool autonatV2 = false;
+    bool autonatV2Server = false;
+    bool circuitRelay = false;
+    bool circuitRelayClient = false;
+    int maxConnections = 50;
+    int maxInConnections = 25;
+    int maxOutConnections = 25;
+    int maxConnsPerPeer = 1;
+    bool gossipsubTriggerSelf = true;
+    bool mountGossipsub = true;
+    bool mountKad = true;
+    bool mountServiceDiscovery = true;
+
+    /// Builds options from the LIBP2P_MODULE_CONFIG deployment config (codegen
+    /// default-constructs a loaded module). See readme; absent/invalid → defaults.
+    static Libp2pModuleOptions load();
+};
+
+namespace libp2p_module_config {
+
+/// Reads LIBP2P_MODULE_CONFIG: inline JSON when the first non-space char is '{',
+/// otherwise a path to a JSON file. Returns "" when unset or unreadable.
+inline std::string readSource() {
+    const char* cfg = std::getenv("LIBP2P_MODULE_CONFIG");
+    if (!cfg || !*cfg) {
+        return "";
+    }
+    std::string value(cfg);
+    auto firstChar = value.find_first_not_of(" \t\r\n");
+    if (firstChar != std::string::npos && value[firstChar] == '{') {
+        return value;
+    }
+    std::ifstream f(value);
+    if (!f) {
+        fprintf(stderr, "libp2p_module: cannot read config file %s\n", value.c_str());
+        return "";
+    }
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+inline int parseTransport(const nlohmann::json& j, int fallback) {
+    auto it = j.find("transport");
+    if (it == j.end() || !it->is_string()) {
+        return fallback;
+    }
+    std::string t = it->get<std::string>();
+    if (t == "tcp") return LIBP2P_TRANSPORT_TCP;
+    if (t == "quic" || t == "quic-v1") return LIBP2P_TRANSPORT_QUIC;
+    return fallback;
+}
+
+/// Overlays present keys onto `o`. Throws nlohmann type_error on a wrong-typed
+/// field; load() catches it and falls back to defaults.
+inline void apply(const nlohmann::json& j, Libp2pModuleOptions& o) {
+    if (!j.is_object()) {
+        return;
+    }
+    o.addrs = j.value("addrs", o.addrs);
+    if (auto it = j.find("bootstrapNodes"); it != j.end() && it->is_array()) {
+        o.bootstrapNodes.clear();
+        for (const auto& n : *it) {
+            o.bootstrapNodes.emplace_back(n.value("peerId", std::string{}),
+                                          n.value("addrs", std::vector<std::string>{}));
+        }
+    }
+    o.transport = parseTransport(j, o.transport);
+    o.autonat = j.value("autonat", o.autonat);
+    o.autonatV2 = j.value("autonatV2", o.autonatV2);
+    o.autonatV2Server = j.value("autonatV2Server", o.autonatV2Server);
+    o.circuitRelay = j.value("circuitRelay", o.circuitRelay);
+    o.circuitRelayClient = j.value("circuitRelayClient", o.circuitRelayClient);
+    o.maxConnections = j.value("maxConnections", o.maxConnections);
+    o.maxInConnections = j.value("maxInConnections", o.maxInConnections);
+    o.maxOutConnections = j.value("maxOutConnections", o.maxOutConnections);
+    o.maxConnsPerPeer = j.value("maxConnsPerPeer", o.maxConnsPerPeer);
+    o.gossipsubTriggerSelf = j.value("gossipsubTriggerSelf", o.gossipsubTriggerSelf);
+    o.mountGossipsub = j.value("mountGossipsub", o.mountGossipsub);
+    o.mountKad = j.value("mountKad", o.mountKad);
+    o.mountServiceDiscovery = j.value("mountServiceDiscovery", o.mountServiceDiscovery);
+}
+
+} // namespace libp2p_module_config
+
+inline Libp2pModuleOptions Libp2pModuleOptions::load() {
+    std::string raw = libp2p_module_config::readSource();
+    if (raw.empty()) {
+        return {};
+    }
+    auto j = nlohmann::json::parse(raw, nullptr, false);
+    if (j.is_discarded()) {
+        fprintf(stderr, "libp2p_module: ignoring invalid LIBP2P_MODULE_CONFIG\n");
+        return {};
+    }
+    Libp2pModuleOptions opts;
+    try {
+        libp2p_module_config::apply(j, opts);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "libp2p_module: ignoring invalid LIBP2P_MODULE_CONFIG: %s\n", e.what());
+        return {};
+    }
+    return opts;
+}

--- a/src/custom_handlers.cpp
+++ b/src/custom_handlers.cpp
@@ -25,10 +25,8 @@ void Libp2pModuleImpl::protocolHandler(
 void Libp2pModuleImpl::mountCompleteCallback(int ret, const char* msg, size_t len,
                                               void* userData) {
     auto* hCtx = static_cast<ProtocolHandlerCtx*>(userData);
-    SyncResult r;
-    r.ok = (ret == RET_OK);
-    r.message = (msg && len > 0) ? std::string(msg, len) : std::string();
-    hCtx->mountPromise->set_value(std::move(r));
+    if (!hCtx || !hCtx->mountPromise) return;
+    hCtx->mountPromise->set_value(basicResult(ret, msg, len));
     delete hCtx->mountPromise;
     hCtx->mountPromise = nullptr;
 }

--- a/src/kademlia.cpp
+++ b/src/kademlia.cpp
@@ -10,10 +10,7 @@ StdLogosResult Libp2pModuleImpl::kadFindNode(const std::string& peerId) {
             return libp2p_kad_find_node(ctx, peerId.c_str(),
                                         &Libp2pModuleImpl::promisePeersCallback, p);
         },
-        [](const SyncResult& r) -> StdLogosResult {
-            if (r.message.empty()) return {true, json::array(), ""};
-            return parseJsonResponse(r.message, "kadFindNode");
-        });
+        [](const SyncResult& r) { return jsonResult(r, json::array()); });
 }
 
 StdLogosResult Libp2pModuleImpl::kadPutValue(const std::string& key, const std::string& value) {
@@ -67,10 +64,7 @@ StdLogosResult Libp2pModuleImpl::kadGetProviders(const std::string& cid) {
             return libp2p_kad_get_providers(ctx, cid.c_str(),
                                             &Libp2pModuleImpl::promiseProvidersCallback, p);
         },
-        [](const SyncResult& r) -> StdLogosResult {
-            if (r.message.empty()) return {true, json::array(), ""};
-            return parseJsonResponse(r.message, "kadGetProviders");
-        });
+        [](const SyncResult& r) { return jsonResult(r, json::array()); });
 }
 
 StdLogosResult Libp2pModuleImpl::kadGetRandomRecords() {
@@ -79,8 +73,5 @@ StdLogosResult Libp2pModuleImpl::kadGetRandomRecords() {
             return libp2p_kad_random_records(ctx,
                                              &Libp2pModuleImpl::promiseRandomRecordsCallback, p);
         },
-        [](const SyncResult& r) -> StdLogosResult {
-            if (r.message.empty()) return {true, json::array(), ""};
-            return parseJsonResponse(r.message, "kadGetRandomRecords");
-        });
+        [](const SyncResult& r) { return jsonResult(r, json::array()); });
 }

--- a/src/metric.h
+++ b/src/metric.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+// One metrics series, mirroring the JSON that nim-libp2p's libp2p_collect_metrics
+// emits. Cbind sends labels as `[{"name":..,"value":..}, ...]`; we flatten into
+// a map because openmetrics-module's renderer expects `labels` as a flat
+// `{key:value}` object (openmetrics_format.cpp:82). `timestamp` is Unix
+// milliseconds from the registry; 0 means "unset" and is dropped on output.
+struct Metric {
+    std::string name;
+    std::string type;
+    std::string help;
+    std::map<std::string, std::string> labels;
+    double value = 0.0;
+    int64_t timestamp = 0;
+};
+
+inline void from_json(const nlohmann::json& j, Metric& m) {
+    j.at("name").get_to(m.name);
+    j.at("type").get_to(m.type);
+    j.at("help").get_to(m.help);
+    j.at("value").get_to(m.value);
+    m.labels.clear();
+    if (auto it = j.find("labels"); it != j.end() && it->is_array()) {
+        for (const auto& lp : *it) {
+            m.labels.emplace(lp.at("name").get<std::string>(),
+                             lp.at("value").get<std::string>());
+        }
+    }
+    if (auto it = j.find("timestamp"); it != j.end() && it->is_number_integer()) {
+        m.timestamp = it->get<int64_t>();
+    } else {
+        m.timestamp = 0;
+    }
+}
+
+inline void to_json(nlohmann::json& j, const Metric& m) {
+    j = nlohmann::json{
+        {"name", m.name},
+        {"type", m.type},
+        {"help", m.help},
+        {"labels", m.labels},
+        {"value", m.value},
+    };
+    if (m.timestamp != 0) j["timestamp"] = m.timestamp;
+}

--- a/src/peerstore.cpp
+++ b/src/peerstore.cpp
@@ -10,10 +10,7 @@ StdLogosResult Libp2pModuleImpl::peerstoreGetPeers() {
             return libp2p_peerstore_get_peers(ctx,
                                                &Libp2pModuleImpl::promisePeersCallback, p);
         },
-        [](const SyncResult& r) -> StdLogosResult {
-            if (r.message.empty()) return {true, json::array(), ""};
-            return parseJsonResponse(r.message, "peerstoreGetPeers");
-        });
+        [](const SyncResult& r) { return jsonResult(r, json::array()); });
 }
 
 StdLogosResult Libp2pModuleImpl::peerstoreGetPeerInfo(const std::string& peerId) {
@@ -22,10 +19,7 @@ StdLogosResult Libp2pModuleImpl::peerstoreGetPeerInfo(const std::string& peerId)
             return libp2p_peerstore_get_peer_info(ctx, peerId.c_str(),
                                                    &Libp2pModuleImpl::promisePeerStoreEntryCallback, p);
         },
-        [](const SyncResult& r) -> StdLogosResult {
-            if (r.message.empty()) return {true, json::object(), ""};
-            return parseJsonResponse(r.message, "peerstoreGetPeerInfo");
-        });
+        [](const SyncResult& r) { return jsonResult(r, json::object()); });
 }
 
 StdLogosResult Libp2pModuleImpl::peerstoreAddPeer(

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -119,6 +119,7 @@ Libp2pModuleImpl::Libp2pModuleImpl(const Libp2pModuleOptions& options)
     if (!r.ok) {
         m_initError = "libp2p_new failed: " + r.message;
         fprintf(stderr, "libp2p_new failed: %s\n", r.message.c_str());
+        ctx = nullptr;
     }
 
     if (!ctx) {

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -17,25 +17,16 @@ std::string defaultListenAddr(int transport) {
 }
 
 void Libp2pModuleImpl::promiseCallback(int ret, const char* msg, size_t len, void* userData) {
-    auto* p = static_cast<SyncPromise*>(userData);
-    SyncResult r;
-    r.ok = (ret == RET_OK);
-    r.message = (msg && len > 0) ? std::string(msg, len) : std::string();
-    p->set_value(std::move(r));
-    delete p;
+    finishPromise(static_cast<SyncPromise*>(userData), basicResult(ret, msg, len));
 }
 
 void Libp2pModuleImpl::promiseBufferCallback(int ret, const uint8_t* data, size_t dataLen,
                                              const char* msg, size_t len, void* userData) {
-    auto* p = static_cast<SyncPromise*>(userData);
-    SyncResult r;
-    r.ok = (ret == RET_OK);
-    r.message = (msg && len > 0) ? std::string(msg, len) : std::string();
+    auto r = basicResult(ret, msg, len);
     if (data && dataLen > 0) {
         r.buffer.assign(data, data + dataLen);
     }
-    p->set_value(std::move(r));
-    delete p;
+    finishPromise(static_cast<SyncPromise*>(userData), std::move(r));
 }
 
 void Libp2pModuleImpl::emitEventSafe(const std::string& name, const std::string& data) const {
@@ -69,8 +60,6 @@ Libp2pModuleImpl::Libp2pModuleImpl(const Libp2pModuleOptions& options)
     if (m_addrs.empty()) {
         m_addrs.push_back(defaultListenAddr(options.transport));
     }
-    m_libp2pConfig.addrs = m_addrsPtr.data();
-    m_libp2pConfig.addrsLen = static_cast<int>(m_addrsPtr.size());
 
     m_addrsPtr.reserve(m_addrs.size());
     for (const auto& addr : m_addrs) {
@@ -112,6 +101,7 @@ Libp2pModuleImpl::Libp2pModuleImpl(const Libp2pModuleOptions& options)
 
     auto keyResult = newPrivateKey();
     if (!keyResult.success) {
+        m_initError = "private key generation failed: " + keyResult.error;
         fprintf(stderr, "libp2p_new_private_key failed: %s\n", keyResult.error.c_str());
         return;
     }
@@ -126,12 +116,14 @@ Libp2pModuleImpl::Libp2pModuleImpl(const Libp2pModuleOptions& options)
 
     ctx = libp2p_new(&m_libp2pConfig, &Libp2pModuleImpl::promiseCallback, p);
 
-    auto r = awaitResult(f, 5000);
+    auto r = awaitResult(f, kNewContextTimeoutMs);
     if (!r.ok) {
+        m_initError = "libp2p_new failed: " + r.message;
         fprintf(stderr, "libp2p_new failed: %s\n", r.message.c_str());
     }
 
     if (!ctx) {
+        if (m_initError.empty()) m_initError = "libp2p_new returned null context";
         fprintf(stderr, "libp2p_new returned null context\n");
     }
 }
@@ -178,7 +170,7 @@ Libp2pModuleImpl::~Libp2pModuleImpl() {
 
             libp2p_destroy(ctx, &Libp2pModuleImpl::promiseCallback, p);
 
-            awaitResult(f, 5000);
+            awaitResult(f, kDestroyTimeoutMs);
             ctx = nullptr;
         }
     } catch (...) {}
@@ -194,6 +186,15 @@ StdLogosResult Libp2pModuleImpl::stop() {
     return callSync("Failed to stop libp2p", [&](SyncPromise* p) {
         return libp2p_stop(ctx, &Libp2pModuleImpl::promiseCallback, p);
     });
+}
+
+bool Libp2pModuleImpl::ok() {
+    return ctx != nullptr;
+}
+
+StdLogosResult Libp2pModuleImpl::status() {
+    if (ctx) return {true, {}, ""};
+    return {false, {}, m_initError.empty() ? "libp2p not initialized" : m_initError};
 }
 
 StdLogosResult Libp2pModuleImpl::publicKey() {
@@ -266,7 +267,7 @@ StdLogosResult Libp2pModuleImpl::connectPeer(
         return libp2p_connect(ctx, peerId.c_str(), addrPtrs.data(),
                               static_cast<int>(addrPtrs.size()), timeoutMs,
                               &Libp2pModuleImpl::promiseCallback, p);
-    });
+    }, awaitTimeoutFor(timeoutMs));
 }
 
 StdLogosResult Libp2pModuleImpl::disconnectPeer(const std::string& peerId) {
@@ -281,7 +282,7 @@ StdLogosResult Libp2pModuleImpl::peerInfo() {
         [&](SyncPromise* p) {
             return libp2p_peerinfo(ctx, &Libp2pModuleImpl::promisePeerInfoCallback, p);
         },
-        [](const SyncResult& r) { return parseJsonResponse(r.message, "peerInfo"); });
+        [](const SyncResult& r) { return jsonResult(r, json::object()); });
 }
 
 StdLogosResult Libp2pModuleImpl::connectedPeers(int64_t direction) {
@@ -290,10 +291,7 @@ StdLogosResult Libp2pModuleImpl::connectedPeers(int64_t direction) {
             return libp2p_connected_peers(ctx, direction,
                                           &Libp2pModuleImpl::promisePeersCallback, p);
         },
-        [](const SyncResult& r) -> StdLogosResult {
-            if (r.message.empty()) return {true, json::array(), ""};
-            return parseJsonResponse(r.message, "connectedPeers");
-        });
+        [](const SyncResult& r) { return jsonResult(r, json::array()); });
 }
 
 StdLogosResult Libp2pModuleImpl::dial(const std::string& peerId, const std::string& proto) {
@@ -303,8 +301,7 @@ StdLogosResult Libp2pModuleImpl::dial(const std::string& peerId, const std::stri
                                &Libp2pModuleImpl::promiseConnectionCallback, p);
         },
         [this](const SyncResult& r) -> StdLogosResult {
-            auto* stream = static_cast<libp2p_stream_t*>(r.extra);
-            if (stream) return {true, addStream(stream), ""};
+            if (r.stream) return {true, addStream(r.stream), ""};
             return {true, 0, ""};
         });
 }
@@ -325,10 +322,7 @@ StdLogosResult Libp2pModuleImpl::circuitRelayReserve(
                                                 static_cast<int>(addrPtrs.size()),
                                                 &Libp2pModuleImpl::promiseReservationCallback, p);
         },
-        [](const SyncResult& r) -> StdLogosResult {
-            if (r.message.empty()) return {true, json::array(), ""};
-            return parseJsonResponse(r.message, "circuitRelayReserve");
-        });
+        [](const SyncResult& r) { return jsonResult(r, json::array()); });
 }
 
 StdLogosResult Libp2pModuleImpl::dialCircuitRelay(
@@ -343,8 +337,7 @@ StdLogosResult Libp2pModuleImpl::dialCircuitRelay(
                                              &Libp2pModuleImpl::promiseConnectionCallback, p);
         },
         [this](const SyncResult& r) -> StdLogosResult {
-            auto* stream = static_cast<libp2p_stream_t*>(r.extra);
-            if (stream) return {true, addStream(stream), ""};
+            if (r.stream) return {true, addStream(r.stream), ""};
             return {true, 0, ""};
         });
 }

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -1,17 +1,16 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
+#include <climits>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <fstream>
 #include <functional>
-#include <map>
 #include <future>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
-#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -26,186 +25,66 @@ extern "C" {
 #include "lib/libp2p.h"
 }
 
-struct Libp2pModuleOptions {
-    std::vector<std::string> addrs = {};
-    std::vector<std::pair<std::string, std::vector<std::string>>> bootstrapNodes = {};
-    int transport = LIBP2P_TRANSPORT_TCP;
-    bool autonat = false;
-    bool autonatV2 = false;
-    bool autonatV2Server = false;
-    bool circuitRelay = false;
-    bool circuitRelayClient = false;
-    int maxConnections = 50;
-    int maxInConnections = 25;
-    int maxOutConnections = 25;
-    int maxConnsPerPeer = 1;
-    bool gossipsubTriggerSelf = true;
-    bool mountGossipsub = true;
-    bool mountKad = true;
-    bool mountServiceDiscovery = true;
+#include "config.h"
+#include "metric.h"
 
-    /// Builds options from the LIBP2P_MODULE_CONFIG deployment config (codegen
-    /// default-constructs a loaded module). See readme; absent/invalid → defaults.
-    static Libp2pModuleOptions load();
-};
-
-namespace libp2p_module_config {
-
-/// Reads LIBP2P_MODULE_CONFIG: inline JSON when the first non-space char is '{',
-/// otherwise a path to a JSON file. Returns "" when unset or unreadable.
-inline std::string readSource() {
-    const char* cfg = std::getenv("LIBP2P_MODULE_CONFIG");
-    if (!cfg || !*cfg) {
-        return "";
-    }
-    std::string value(cfg);
-    auto firstChar = value.find_first_not_of(" \t\r\n");
-    if (firstChar != std::string::npos && value[firstChar] == '{') {
-        return value;
-    }
-    std::ifstream f(value);
-    if (!f) {
-        fprintf(stderr, "libp2p_module: cannot read config file %s\n", value.c_str());
-        return "";
-    }
-    std::ostringstream ss;
-    ss << f.rdbuf();
-    return ss.str();
-}
-
-inline int parseTransport(const nlohmann::json& j, int fallback) {
-    auto it = j.find("transport");
-    if (it == j.end() || !it->is_string()) {
-        return fallback;
-    }
-    std::string t = it->get<std::string>();
-    if (t == "tcp") return LIBP2P_TRANSPORT_TCP;
-    if (t == "quic" || t == "quic-v1") return LIBP2P_TRANSPORT_QUIC;
-    return fallback;
-}
-
-/// Overlays present keys onto `o`. Throws nlohmann type_error on a wrong-typed
-/// field; load() catches it and falls back to defaults.
-inline void apply(const nlohmann::json& j, Libp2pModuleOptions& o) {
-    if (!j.is_object()) {
-        return;
-    }
-    o.addrs = j.value("addrs", o.addrs);
-    if (auto it = j.find("bootstrapNodes"); it != j.end() && it->is_array()) {
-        o.bootstrapNodes.clear();
-        for (const auto& n : *it) {
-            o.bootstrapNodes.emplace_back(n.value("peerId", std::string{}),
-                                          n.value("addrs", std::vector<std::string>{}));
-        }
-    }
-    o.transport = parseTransport(j, o.transport);
-    o.autonat = j.value("autonat", o.autonat);
-    o.autonatV2 = j.value("autonatV2", o.autonatV2);
-    o.autonatV2Server = j.value("autonatV2Server", o.autonatV2Server);
-    o.circuitRelay = j.value("circuitRelay", o.circuitRelay);
-    o.circuitRelayClient = j.value("circuitRelayClient", o.circuitRelayClient);
-    o.maxConnections = j.value("maxConnections", o.maxConnections);
-    o.maxInConnections = j.value("maxInConnections", o.maxInConnections);
-    o.maxOutConnections = j.value("maxOutConnections", o.maxOutConnections);
-    o.maxConnsPerPeer = j.value("maxConnsPerPeer", o.maxConnsPerPeer);
-    o.gossipsubTriggerSelf = j.value("gossipsubTriggerSelf", o.gossipsubTriggerSelf);
-    o.mountGossipsub = j.value("mountGossipsub", o.mountGossipsub);
-    o.mountKad = j.value("mountKad", o.mountKad);
-    o.mountServiceDiscovery = j.value("mountServiceDiscovery", o.mountServiceDiscovery);
-}
-
-} // namespace libp2p_module_config
-
-inline Libp2pModuleOptions Libp2pModuleOptions::load() {
-    std::string raw = libp2p_module_config::readSource();
-    if (raw.empty()) {
-        return {};
-    }
-    auto j = nlohmann::json::parse(raw, nullptr, false);
-    if (j.is_discarded()) {
-        fprintf(stderr, "libp2p_module: ignoring invalid LIBP2P_MODULE_CONFIG\n");
-        return {};
-    }
-    Libp2pModuleOptions opts;
-    try {
-        libp2p_module_config::apply(j, opts);
-    } catch (const std::exception& e) {
-        fprintf(stderr, "libp2p_module: ignoring invalid LIBP2P_MODULE_CONFIG: %s\n", e.what());
-        return {};
-    }
-    return opts;
-}
+// Timeouts (milliseconds) for the sync-over-async libp2p bridge.
+inline constexpr int kDefaultOpTimeoutMs = 10000;
+inline constexpr int kNewContextTimeoutMs = 5000;
+inline constexpr int kDestroyTimeoutMs = 5000;
+// Added on top of a caller-supplied op timeout so the C++ await outlives the
+// libp2p operation it wraps instead of racing it.
+inline constexpr int kAwaitSlackMs = 5000;
 
 // Result type for internal sync-over-async operations.
 struct SyncResult {
     bool ok = false;
     std::string message;
     std::vector<uint8_t> buffer;
-    void* extra = nullptr;
+    nlohmann::json data;
+    libp2p_stream_t* stream = nullptr;
 };
 
 using SyncPromise = std::promise<SyncResult>;
 
+// Resolves and reclaims a heap SyncPromise. Every libp2p callback owns its
+// promise and ends by handing the result back through here.
+inline void finishPromise(SyncPromise* p, SyncResult r) {
+    p->set_value(std::move(r));
+    delete p;
+}
+
+// Seeds a SyncResult from the (ret, msg) pair every cbinding callback receives.
+inline SyncResult basicResult(int ret, const char* msg, size_t len) {
+    SyncResult r;
+    r.ok = (ret == RET_OK);
+    r.message = (msg && len > 0) ? std::string(msg, len) : std::string();
+    return r;
+}
+
 // Awaits a future with timeout. Returns a failed result on timeout.
-inline SyncResult awaitResult(std::future<SyncResult>& f, int timeoutMs = 10000) {
+inline SyncResult awaitResult(std::future<SyncResult>& f, int timeoutMs = kDefaultOpTimeoutMs) {
     if (f.wait_for(std::chrono::milliseconds(timeoutMs)) == std::future_status::ready) {
         return f.get();
     }
-    return {false, "timeout", {}, nullptr};
+    SyncResult r;
+    r.message = "timeout";
+    return r;
 }
 
-// Non-throwing JSON parse — malformed cbinding output yields a failed result
-// instead of propagating an exception.
-inline StdLogosResult parseJsonResponse(const std::string& s, const char* errPrefix) {
-    auto j = nlohmann::json::parse(s, nullptr, false);
-    if (j.is_discarded()) {
-        return {false, {}, std::string(errPrefix) + ": invalid JSON"};
-    }
-    return {true, j, ""};
+// Await long enough to outlast a caller-supplied op timeout, falling back to the
+// default when the op carries no timeout of its own.
+inline int awaitTimeoutFor(int64_t opTimeoutMs) {
+    if (opTimeoutMs <= 0) return kDefaultOpTimeoutMs;
+    int64_t v = opTimeoutMs + kAwaitSlackMs;
+    return v > INT_MAX ? INT_MAX : static_cast<int>(v);
 }
 
-// One metrics series, mirroring the JSON that nim-libp2p's libp2p_collect_metrics
-// emits. Cbind sends labels as `[{"name":..,"value":..}, ...]`; we flatten into
-// a map because openmetrics-module's renderer expects `labels` as a flat
-// `{key:value}` object (openmetrics_format.cpp:82). `timestamp` is Unix
-// milliseconds from the registry; 0 means "unset" and is dropped on output.
-struct Metric {
-    std::string name;
-    std::string type;
-    std::string help;
-    std::map<std::string, std::string> labels;
-    double value = 0.0;
-    int64_t timestamp = 0;
-};
-
-inline void from_json(const nlohmann::json& j, Metric& m) {
-    j.at("name").get_to(m.name);
-    j.at("type").get_to(m.type);
-    j.at("help").get_to(m.help);
-    j.at("value").get_to(m.value);
-    m.labels.clear();
-    if (auto it = j.find("labels"); it != j.end() && it->is_array()) {
-        for (const auto& lp : *it) {
-            m.labels.emplace(lp.at("name").get<std::string>(),
-                             lp.at("value").get<std::string>());
-        }
-    }
-    if (auto it = j.find("timestamp"); it != j.end() && it->is_number_integer()) {
-        m.timestamp = it->get<int64_t>();
-    } else {
-        m.timestamp = 0;
-    }
-}
-
-inline void to_json(nlohmann::json& j, const Metric& m) {
-    j = nlohmann::json{
-        {"name", m.name},
-        {"type", m.type},
-        {"help", m.help},
-        {"labels", m.labels},
-        {"value", m.value},
-    };
-    if (m.timestamp != 0) j["timestamp"] = m.timestamp;
+// Maps a resolved SyncResult's structured payload into a result, substituting an
+// empty default when the callback produced no data (e.g. ok with zero items).
+inline StdLogosResult jsonResult(const SyncResult& r, nlohmann::json emptyDefault) {
+    if (r.data.is_null()) return {true, std::move(emptyDefault), ""};
+    return {true, r.data, ""};
 }
 
 class Libp2pModuleImpl {
@@ -214,6 +93,9 @@ public:
     ~Libp2pModuleImpl();
 
     std::function<void(const std::string& eventName, const std::string& data)> emitEvent;
+
+    bool ok();
+    StdLogosResult status();
 
     StdLogosResult start();
     StdLogosResult stop();
@@ -280,6 +162,10 @@ private:
     libp2p_ctx_t* ctx = nullptr;
     libp2p_config_t m_libp2pConfig = {};
 
+    // Set when construction fails; surfaced through status() since the
+    // constructor cannot signal failure to the codegen default-constructor.
+    std::string m_initError;
+
     // Address storage (kept alive for libp2p_config_t pointers)
     std::vector<std::string> m_addrs;
     std::vector<const char*> m_addrsPtr;
@@ -345,15 +231,17 @@ private:
     // Wraps the new-promise / invoke / await / clean-up dance shared by every
     // sync-over-async libp2p op. `invoke(SyncPromise*)` calls the cbinding and
     // returns its sync ret. The Transform overload maps the resolved SyncResult
-    // into the final StdLogosResult.
+    // into the final StdLogosResult. `awaitMs` bounds the wait; ops carrying a
+    // caller timeout pass awaitTimeoutFor(theirTimeout) so the await outlasts it.
     template <class Invoke>
-    StdLogosResult callSync(const char* errPrefix, Invoke&& invoke) {
+    StdLogosResult callSync(const char* errPrefix, Invoke&& invoke, int awaitMs = kDefaultOpTimeoutMs) {
         return callSyncWith(errPrefix, std::forward<Invoke>(invoke),
-            [](const SyncResult&) -> StdLogosResult { return {true, {}, ""}; });
+            [](const SyncResult&) -> StdLogosResult { return {true, {}, ""}; }, awaitMs);
     }
 
     template <class Invoke, class Transform>
-    StdLogosResult callSyncWith(const char* errPrefix, Invoke&& invoke, Transform&& transform) {
+    StdLogosResult callSyncWith(const char* errPrefix, Invoke&& invoke, Transform&& transform,
+                                int awaitMs = kDefaultOpTimeoutMs) {
         if (!ctx) return {false, {}, "No libp2p context"};
         auto* p = new SyncPromise();
         auto f = p->get_future();
@@ -368,7 +256,7 @@ private:
             return {false, {}, std::string(errPrefix) +
                 " (ret=" + std::to_string(ret) + ")"};
         }
-        auto r = awaitResult(f);
+        auto r = awaitResult(f, awaitMs);
         if (!r.ok) return {false, {}, r.message};
         return transform(r);
     }

--- a/src/service_discovery.cpp
+++ b/src/service_discovery.cpp
@@ -64,10 +64,7 @@ StdLogosResult Libp2pModuleImpl::discoLookup(
                 serviceData.size(),
                 &Libp2pModuleImpl::promiseRandomRecordsCallback, p);
         },
-        [](const SyncResult& r) -> StdLogosResult {
-            if (r.message.empty()) return {true, json::array(), ""};
-            return parseJsonResponse(r.message, "discoLookup");
-        });
+        [](const SyncResult& r) { return jsonResult(r, json::array()); });
 }
 
 StdLogosResult Libp2pModuleImpl::discoRandomLookup() {
@@ -76,8 +73,5 @@ StdLogosResult Libp2pModuleImpl::discoRandomLookup() {
             return libp2p_service_disco_random_lookup(ctx,
                                                      &Libp2pModuleImpl::promiseRandomRecordsCallback, p);
         },
-        [](const SyncResult& r) -> StdLogosResult {
-            if (r.message.empty()) return {true, json::array(), ""};
-            return parseJsonResponse(r.message, "discoRandomLookup");
-        });
+        [](const SyncResult& r) { return jsonResult(r, json::array()); });
 }


### PR DESCRIPTION
## Summary

Cleans up the C++ shim that bridges the Logos sync module API to nim-libp2p's async C bindings. No behavioural change for callers on success paths; empty/error results are preserved. Motivation was reducing the maintenance surface of the callback layer and closing a few sharp edges found while reading it.

## Correctness

- Drop a dead `m_libp2pConfig.addrs = m_addrsPtr.data()` in the constructor that ran while `m_addrsPtr` was still empty (it was immediately overwritten by the correct populate-then-assign block, but read as a bug).
- Stop a caller-supplied op timeout from being silently capped by the C++ await: `callSync`/`callSyncWith` now take an `awaitMs`, and `connectPeer` passes `awaitTimeoutFor(timeoutMs)` (op timeout + 5s slack, `INT_MAX`-clamped). Previously a 30s connect returned a spurious `"timeout"` at the hardcoded 10s await.
- Add the missing null guard to `mountCompleteCallback` (`!hCtx || !hCtx->mountPromise`) that every other callback already had.

## Surface init failure

The constructor is default-constructed by codegen and could not signal failure, leaving `ctx == nullptr` indistinguishable from "not started". Added `m_initError`, populated on each failure path (key-gen, `libp2p_new`, null ctx), exposed via two new accessors: `bool ok()` and `StdLogosResult status()`.

## Timeouts

Replaced the magic `10000`/`5000` literals with named constants: `kDefaultOpTimeoutMs`, `kNewContextTimeoutMs`, `kDestroyTimeoutMs`, `kAwaitSlackMs`.

## Dedup and structure

- New `finishPromise()` + `basicResult()` helpers collapse the identical seed/resolve/`delete p` boilerplate repeated across every `promise*Callback`.
- New `jsonResult(r, emptyDefault)` helper replaces the 8 copies of `if (r.message.empty()) ... else parseJsonResponse(...)`.
- Structured callbacks now write a `nlohmann::json` straight into `SyncResult::data` instead of `.dump()`-ing a string that ops re-parsed; the now-unused `parseJsonResponse` is removed.
- Replaced the type-unsafe `void* extra` with a typed `libp2p_stream_t* stream` field (`dial`/`dialCircuitRelay`).
- Split `plugin.h` (418 → 309 lines): config parsing moved to `src/config.h`, `Metric` (de)serialization to `src/metric.h`. `plugin.h` includes both, so the codegen `impl_header` contract and the existing tests are untouched.

## Testing

Could not run the test suite in the sandbox — the Logos test harness pulls in Qt, which isn't available here. All `src/` translation units were syntax-checked against the real `cbind/libp2p.h` and Logos SDK headers, and a probe TU confirms the moved symbols (`libp2p_module_config::apply`, `Libp2pModuleOptions::load`, `Metric`) and the new `ok()`/`status()` accessors resolve through `<plugin.h>`. Needs a CI run for the full integration + sanitizer suite.