### PR TITLE
fix(tsan): guard emitEvent against the worker-thread data race

### DIFF
--- a/src/custom_handlers.cpp
+++ b/src/custom_handlers.cpp
@@ -39,6 +39,7 @@ StdLogosResult Libp2pModuleImpl::mountProtocol(const std::string& proto) {
     // Without emitEvent, protocolHandler would register a stream that no caller
     // could ever read, close, or release — leaking the stream.
     if (!emitEvent) return {false, {}, "emitEvent must be set before mounting a protocol"};
+    publishEmitEvent();
 
     auto handlerCtx = std::make_unique<ProtocolHandlerCtx>();
     handlerCtx->instance = this;

--- a/src/gossipsub.cpp
+++ b/src/gossipsub.cpp
@@ -43,6 +43,7 @@ void Libp2pModuleImpl::gossipsubResultCallback(int ret, const char* msg, size_t 
 
 StdLogosResult Libp2pModuleImpl::gossipsubSubscribe(const std::string& topic) {
     if (!ctx) return {false, {}, "No libp2p context"};
+    publishEmitEvent();
 
     auto subCtx = std::make_unique<SubscribeCtx>();
     subCtx->instance = this;
@@ -67,6 +68,7 @@ StdLogosResult Libp2pModuleImpl::gossipsubSubscribe(const std::string& topic) {
 
 StdLogosResult Libp2pModuleImpl::gossipsubUnsubscribe(const std::string& topic) {
     if (!ctx) return {false, {}, "No libp2p context"};
+    publishEmitEvent();
 
     SubscribeCtx* ctxPtr = nullptr;
     {

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -38,10 +38,21 @@ void Libp2pModuleImpl::promiseBufferCallback(int ret, const uint8_t* data, size_
     delete p;
 }
 
+void Libp2pModuleImpl::publishEmitEvent() {
+    std::unique_lock<std::shared_mutex> lock(m_emitEventLock);
+    m_emitEventSnapshot = emitEvent;
+}
+
 void Libp2pModuleImpl::emitEventSafe(const std::string& name, const std::string& data) const {
-    if (emitEvent) {
-        emitEvent(name, data);
+    EmitEventFn fn;
+    {
+        std::shared_lock<std::shared_mutex> lock(m_emitEventLock);
+        fn = m_emitEventSnapshot;
     }
+    if (!fn) {
+        return;
+    }
+    fn(name, data);
 }
 
 Libp2pModuleImpl::Libp2pModuleImpl(const Libp2pModuleOptions& options)
@@ -185,6 +196,7 @@ Libp2pModuleImpl::~Libp2pModuleImpl() {
 }
 
 StdLogosResult Libp2pModuleImpl::start() {
+    publishEmitEvent();
     return callSync("Failed to start libp2p", [&](SyncPromise* p) {
         return libp2p_start(ctx, &Libp2pModuleImpl::promiseCallback, p);
     });
@@ -248,6 +260,7 @@ void Libp2pModuleImpl::eventCallback(int ret, const char* msg, size_t len, void*
 
 bool Libp2pModuleImpl::setEventCallback() {
     if (!ctx) return false;
+    publishEmitEvent();
     libp2p_set_event_callback(ctx, &Libp2pModuleImpl::eventCallback, this);
     return true;
 }

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -340,6 +340,12 @@ private:
     static void mountCompleteCallback(int ret, const char* msg, size_t len, void* userData);
     static void eventCallback(int ret, const char* msg, size_t len, void* userData);
 
+    using EmitEventFn = std::function<void(const std::string& eventName, const std::string& data)>;
+
+    // Lock-guarded snapshot of `emitEvent`, taken on the caller thread before any worker can emit, so worker threads never read the public field unsynchronized.
+    mutable std::shared_mutex m_emitEventLock;
+    EmitEventFn m_emitEventSnapshot;
+    void publishEmitEvent();
     void emitEventSafe(const std::string& name, const std::string& data) const;
 
     // Wraps the new-promise / invoke / await / clean-up dance shared by every


### PR DESCRIPTION
## Summary

`emitEvent` is a public `std::function` set by the host and then invoked from libp2p worker threads (`eventCallback`, `topicHandler`, `protocolHandler`, `gossipsubResultCallback`). It was read without synchronization, so a reassignment after callbacks can fire is a data race — TSAN-visible, and the reason for this branch. This guards the read path.

## What changed

- Added a lock-guarded snapshot `m_emitEventSnapshot` (under `m_emitEventLock`), published on the caller thread via `publishEmitEvent()` at every point a worker can begin emitting: `start()`, `setEventCallback()`, and `mountProtocol()` (`src/plugin.cpp`, `src/custom_handlers.cpp`).
- `emitEventSafe()` now copies the snapshot under a `shared_lock` and invokes it *after* releasing the lock, so a re-entrant callback can't deadlock against `publishEmitEvent()`'s `unique_lock` (`src/plugin.cpp`).
- The public `emitEvent` field is unchanged, so the existing `node.emitEvent = ...` assignment in tests and examples keeps working; worker threads now read only the snapshot, never the field.
- Added an `EmitEventFn` alias to dedupe the repeated function signature (`src/plugin.h`).

## Why a snapshot instead of locking the field directly

The host assigns `emitEvent` directly through the public field, so a write can't take a lock. Snapshotting on the caller thread before any worker starts emitting establishes a clean happens-before: workers read only the guarded copy. The "set once before start" contract still holds; the additional publishes in `setEventCallback`/`mountProtocol` re-snapshot defensively if the host sets it late.

## Testing

The guard pattern was compiled in isolation (`g++ -std=c++17 -Wall -Wextra`) — clean. The full module build requires the libp2p toolchain (`LOGOS_MODULE_BUILDER_ROOT`), which is not available in this environment.
