### PR TITLE
fix(flake): expose Boost in devShell so examples configure

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -173,9 +173,19 @@
         value = (module.packages.${system} or {}) // (sanitizerPackages.${system} or {});
       }) systems);
 
+      mergedDevShells = forEachSystem (system:
+        let pkgs = import nixpkgs { inherit system; };
+        in (module.devShells.${system} or {}) // {
+          default = pkgs.mkShell {
+            inputsFrom = [ module.devShells.${system}.default ];
+            buildInputs = [ pkgs.boost.dev ];
+          };
+        });
+
     in module // {
       apps = mergedApps;
       checks = module.checks or {};
       packages = mergedPackages;
+      devShells = mergedDevShells;
     };
 }


### PR DESCRIPTION
Address issue reported here: https://github.com/logos-co/logos-docs/pull/362#discussion_r3477153624

Override the default devShell to add boost.dev from the flake's pinned nixpkgs (logos-module-builder.inputs.nixpkgs), matching the Boost that logos-protocol was built against, so find_dependency(Boost) resolves.