### PR TITLE
fix(ci): bump QUIC ping connect deadline to 5s under tsan

### DIFF
--- a/tests/integration.cpp
+++ b/tests/integration.cpp
@@ -262,7 +262,8 @@ LOGOS_TEST(integration_quic_ping_round_trip) {
     LOGOS_ASSERT_TRUE(nodeB.start().success);
 
     auto [peerIdB, addrsB] = getPeerInfoPair(nodeB);
-    LOGOS_ASSERT_TRUE(nodeA.connectPeer(peerIdB, addrsB, 500).success);
+    // QUIC's TLS handshake under ThreadSanitizer can exceed a 500ms deadline.
+    LOGOS_ASSERT_TRUE(nodeA.connectPeer(peerIdB, addrsB, 5000).success);
 
     auto dialResult = nodeA.dial(peerIdB, "/ipfs/ping/1.0.0");
     LOGOS_ASSERT_TRUE(dialResult.success);


### PR DESCRIPTION
## Summary

The QUIC ping round-trip integration test (`integration_quic_ping_round_trip`) connects with a 500ms deadline. Under ThreadSanitizer the QUIC TLS handshake routinely takes longer than that, so `nodeA.connectPeer(...)` flakes in the tsan CI job.

This bumps the deadline to 5000ms for that single QUIC test and documents why with an inline comment. The TCP `connectPeer(..., 500)` calls in the other integration tests are left untouched — only the QUIC handshake is affected.

This change was originally carried as a drive-by in #68 (`feat: decode XPR`), where it was unrelated to the feature and undocumented in the description. It is extracted here so the timeout fix is bisectable on its own.

## Testing

Test-only change. `tests/integration.cpp` — the affected test still exercises the same ping round-trip; only the connect deadline is relaxed for QUIC.