### PR TITLE
feat: add INFO-level logs for service discovery events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ logos_module(
         src/stream.cpp
         src/gossipsub.cpp
         src/service_discovery.cpp
+        src/utils.cpp
         src/custom_handlers.cpp
         src/peerstore.cpp
         src/metrics.cpp

--- a/src/service_discovery.cpp
+++ b/src/service_discovery.cpp
@@ -1,18 +1,9 @@
 #include "plugin.h"
+#include "utils.h"
 
-#include <chrono>
 #include <cstring>
-#include <ctime>
 
 using json = nlohmann::json;
-
-static std::string nowTimestamp() {
-    auto now = std::chrono::system_clock::now();
-    std::time_t t = std::chrono::system_clock::to_time_t(now);
-    char buf[32];
-    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", std::localtime(&t));
-    return buf;
-}
 
 StdLogosResult Libp2pModuleImpl::discoStart() {
     return callSync("Failed to start discovery", [&](SyncPromise* p) {

--- a/src/service_discovery.cpp
+++ b/src/service_discovery.cpp
@@ -1,8 +1,18 @@
 #include "plugin.h"
 
+#include <chrono>
 #include <cstring>
+#include <ctime>
 
 using json = nlohmann::json;
+
+static std::string nowTimestamp() {
+    auto now = std::chrono::system_clock::now();
+    std::time_t t = std::chrono::system_clock::to_time_t(now);
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", std::localtime(&t));
+    return buf;
+}
 
 StdLogosResult Libp2pModuleImpl::discoStart() {
     return callSync("Failed to start discovery", [&](SyncPromise* p) {
@@ -39,6 +49,7 @@ StdLogosResult Libp2pModuleImpl::discoStopAdvertising(const std::string& service
 }
 
 StdLogosResult Libp2pModuleImpl::discoRegisterInterest(const std::string& serviceId) {
+    fprintf(stderr, "[INFO] %s service-discovery: starting interest for service '%s'\n", nowTimestamp().c_str(), serviceId.c_str());
     return callSync("Failed to register interest", [&](SyncPromise* p) {
         return libp2p_service_disco_register_interest(ctx, serviceId.c_str(),
                                                       &Libp2pModuleImpl::promiseCallback, p);
@@ -64,7 +75,16 @@ StdLogosResult Libp2pModuleImpl::discoLookup(
                 serviceData.size(),
                 &Libp2pModuleImpl::promiseRandomRecordsCallback, p);
         },
-        [](const SyncResult& r) { return jsonResult(r, json::array()); });
+        [&serviceId](const SyncResult& r) {
+            auto result = jsonResult(r, json::array());
+            if (result.success && result.value.is_array()) {
+                for (const auto& entry : result.value) {
+                    fprintf(stderr, "[INFO] %s service-discovery: found peer '%s' offering service '%s'\n",
+                            nowTimestamp().c_str(), entry.value("peerId", "<unknown>").c_str(), serviceId.c_str());
+                }
+            }
+            return result;
+        });
 }
 
 StdLogosResult Libp2pModuleImpl::discoRandomLookup() {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,12 @@
+#include "utils.h"
+
+#include <chrono>
+#include <ctime>
+
+std::string nowTimestamp() {
+    auto now = std::chrono::system_clock::now();
+    std::time_t t = std::chrono::system_clock::to_time_t(now);
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", std::localtime(&t));
+    return buf;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <string>
+
+std::string nowTimestamp();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ if(LIBP2P_PATH)
             ../src/stream.cpp
             ../src/gossipsub.cpp
             ../src/service_discovery.cpp
+            ../src/utils.cpp
             ../src/custom_handlers.cpp
             ../src/peerstore.cpp
             ../src/metrics.cpp


### PR DESCRIPTION
Adds two INFO-level log lines to help measure and trace service discovery:

- `[INFO] <timestamp> service-discovery: starting interest for service '<serviceId>'`  
  logged when `discoRegisterInterest` is called

- `[INFO] <timestamp> service-discovery: found peer '<peerId>' offering service '<serviceId>'`  
  logged when `discoLookup` returns a result with peers

These logs make it possible to measure discovery latency as the time between the two log lines, addressing the discussion around how to track "time to discover" for simulation scenarios.