### PR TITLE
chore: extract shared marshaling helpers into utils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ logos_module(
     NAME libp2p_module
     SOURCES
         src/plugin.h
+        src/utils.h
+        src/utils.cpp
         src/plugin.cpp
         src/callbacks.cpp
         src/kademlia.cpp

--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -1,7 +1,5 @@
 #include "plugin.h"
 
-#include <cstring>
-
 using json = nlohmann::json;
 
 void Libp2pModuleImpl::promisePeerInfoCallback(
@@ -11,16 +9,7 @@ void Libp2pModuleImpl::promisePeerInfoCallback(
     auto r = basicResult(ret, msg, len);
 
     if (r.ok && info) {
-        json j;
-        j["peerId"] = info->peerId ? info->peerId : "";
-        json addrs = json::array();
-        if (info->addrs) {
-            for (size_t i = 0; i < info->addrsLen; ++i) {
-                if (info->addrs[i]) addrs.push_back(info->addrs[i]);
-            }
-        }
-        j["addrs"] = addrs;
-        r.data = std::move(j);
+        r.data = peerInfoToJson(*info);
     }
 
     finishPromise(static_cast<SyncPromise*>(userData), std::move(r));
@@ -35,31 +24,9 @@ void Libp2pModuleImpl::promisePeerStoreEntryCallback(
     if (r.ok && entry) {
         json j;
         j["peerId"] = entry->peerId ? entry->peerId : "";
-        json addrs = json::array();
-        if (entry->addrs) {
-            for (size_t i = 0; i < entry->addrsLen; ++i) {
-                if (entry->addrs[i]) addrs.push_back(entry->addrs[i]);
-            }
-        }
-        j["addrs"] = addrs;
-        json protocols = json::array();
-        if (entry->protocols) {
-            for (size_t i = 0; i < entry->protocolsLen; ++i) {
-                if (entry->protocols[i]) protocols.push_back(entry->protocols[i]);
-            }
-        }
-        j["protocols"] = protocols;
-        std::string publicKey;
-        if (entry->publicKey && entry->publicKeyLen > 0) {
-            static constexpr char digits[] = "0123456789abcdef";
-            publicKey.resize(entry->publicKeyLen * 2);
-            for (size_t i = 0; i < entry->publicKeyLen; ++i) {
-                uint8_t b = entry->publicKey[i];
-                publicKey[2 * i]     = digits[b >> 4];
-                publicKey[2 * i + 1] = digits[b & 0x0f];
-            }
-        }
-        j["publicKey"] = publicKey;
+        j["addrs"] = cStrArrayToJson(entry->addrs, entry->addrsLen);
+        j["protocols"] = cStrArrayToJson(entry->protocols, entry->protocolsLen);
+        j["publicKey"] = hexEncode(entry->publicKey, entry->publicKeyLen);
         j["agentVersion"] = entry->agentVersion ? entry->agentVersion : "";
         j["protoVersion"] = entry->protoVersion ? entry->protoVersion : "";
         r.data = std::move(j);
@@ -75,11 +42,7 @@ void Libp2pModuleImpl::promisePeersCallback(
     auto r = basicResult(ret, msg, len);
 
     if (r.ok && peerIds && peerIdsLen > 0) {
-        json arr = json::array();
-        for (size_t i = 0; i < peerIdsLen; ++i) {
-            if (peerIds[i]) arr.push_back(peerIds[i]);
-        }
-        r.data = std::move(arr);
+        r.data = cStrArrayToJson(peerIds, peerIdsLen);
     }
 
     finishPromise(static_cast<SyncPromise*>(userData), std::move(r));
@@ -94,16 +57,7 @@ void Libp2pModuleImpl::promiseProvidersCallback(
     if (r.ok && providers && providersLen > 0) {
         json arr = json::array();
         for (size_t i = 0; i < providersLen; ++i) {
-            json peer;
-            peer["peerId"] = providers[i].peerId ? providers[i].peerId : "";
-            json addrs = json::array();
-            if (providers[i].addrs) {
-                for (size_t j2 = 0; j2 < providers[i].addrsLen; ++j2) {
-                    if (providers[i].addrs[j2]) addrs.push_back(providers[i].addrs[j2]);
-                }
-            }
-            peer["addrs"] = addrs;
-            arr.push_back(peer);
+            arr.push_back(peerInfoToJson(providers[i]));
         }
         r.data = std::move(arr);
     }
@@ -131,11 +85,7 @@ void Libp2pModuleImpl::promiseReservationCallback(
     auto r = basicResult(ret, msg, len);
 
     if (r.ok && addrs && addrsLen > 0) {
-        json arr = json::array();
-        for (size_t i = 0; i < addrsLen; ++i) {
-            if (addrs[i]) arr.push_back(addrs[i]);
-        }
-        r.data = std::move(arr);
+        r.data = cStrArrayToJson(addrs, addrsLen);
     }
 
     finishPromise(static_cast<SyncPromise*>(userData), std::move(r));
@@ -153,14 +103,7 @@ void Libp2pModuleImpl::promiseRandomRecordsCallback(
             json rec;
             rec["peerId"] = records[i].peerId ? records[i].peerId : "";
             rec["seqNo"] = records[i].seqNo;
-
-            json addrs = json::array();
-            if (records[i].addrs) {
-                for (size_t a = 0; a < records[i].addrsLen; ++a) {
-                    if (records[i].addrs[a]) addrs.push_back(records[i].addrs[a]);
-                }
-            }
-            rec["addrs"] = addrs;
+            rec["addrs"] = cStrArrayToJson(records[i].addrs, records[i].addrsLen);
 
             json services = json::array();
             if (records[i].services) {

--- a/src/peerstore.cpp
+++ b/src/peerstore.cpp
@@ -27,13 +27,8 @@ StdLogosResult Libp2pModuleImpl::peerstoreAddPeer(
     const std::vector<std::string>& addrs,
     const std::vector<std::string>& protos)
 {
-    std::vector<const char*> addrsPtr;
-    addrsPtr.reserve(addrs.size());
-    for (const auto& a : addrs) addrsPtr.push_back(a.c_str());
-
-    std::vector<const char*> protosPtr;
-    protosPtr.reserve(protos.size());
-    for (const auto& s : protos) protosPtr.push_back(s.c_str());
+    auto addrsPtr = toCStringPtrs(addrs);
+    auto protosPtr = toCStringPtrs(protos);
 
     return callSync("Failed to add peer", [&](SyncPromise* p) {
         return libp2p_peerstore_add_peer(
@@ -48,9 +43,7 @@ StdLogosResult Libp2pModuleImpl::peerstoreSetPeerAddresses(
     const std::string& peerId,
     const std::vector<std::string>& addrs)
 {
-    std::vector<const char*> addrsPtr;
-    addrsPtr.reserve(addrs.size());
-    for (const auto& a : addrs) addrsPtr.push_back(a.c_str());
+    auto addrsPtr = toCStringPtrs(addrs);
 
     return callSync("Failed to set peer addresses", [&](SyncPromise* p) {
         return libp2p_peerstore_set_peer_addresses(
@@ -64,9 +57,7 @@ StdLogosResult Libp2pModuleImpl::peerstoreSetPeerProtocols(
     const std::string& peerId,
     const std::vector<std::string>& protos)
 {
-    std::vector<const char*> protosPtr;
-    protosPtr.reserve(protos.size());
-    for (const auto& s : protos) protosPtr.push_back(s.c_str());
+    auto protosPtr = toCStringPtrs(protos);
 
     return callSync("Failed to set peer protocols", [&](SyncPromise* p) {
         return libp2p_peerstore_set_peer_protocols(

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -273,11 +273,7 @@ StdLogosResult Libp2pModuleImpl::connectPeer(
     const std::vector<std::string>& multiaddrs,
     int64_t timeoutMs)
 {
-    std::vector<const char*> addrPtrs;
-    addrPtrs.reserve(multiaddrs.size());
-    for (const auto& addr : multiaddrs) {
-        addrPtrs.push_back(addr.c_str());
-    }
+    auto addrPtrs = toCStringPtrs(multiaddrs);
     return callSync("Failed to connect", [&](SyncPromise* p) {
         return libp2p_connect(ctx, peerId.c_str(), addrPtrs.data(),
                               static_cast<int>(addrPtrs.size()), timeoutMs,
@@ -325,11 +321,7 @@ StdLogosResult Libp2pModuleImpl::circuitRelayReserve(
     const std::string& relayPeerId,
     const std::vector<std::string>& relayAddrs)
 {
-    std::vector<const char*> addrPtrs;
-    addrPtrs.reserve(relayAddrs.size());
-    for (const auto& addr : relayAddrs) {
-        addrPtrs.push_back(addr.c_str());
-    }
+    auto addrPtrs = toCStringPtrs(relayAddrs);
     return callSyncWith("Failed to reserve relay",
         [&](SyncPromise* p) {
             return libp2p_circuit_relay_reserve(ctx, relayPeerId.c_str(),

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -27,6 +27,7 @@ extern "C" {
 
 #include "config.h"
 #include "metric.h"
+#include "utils.h"
 
 // Timeouts (milliseconds) for the sync-over-async libp2p bridge.
 inline constexpr int kDefaultOpTimeoutMs = 10000;
@@ -70,31 +71,6 @@ inline SyncResult awaitResult(std::future<SyncResult>& f, int timeoutMs = kDefau
     SyncResult r;
     r.message = "timeout";
     return r;
-}
-
-inline std::string base64Encode(const std::vector<uint8_t>& data) {
-    static constexpr char kAlphabet[] =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    std::string out;
-    out.reserve((data.size() + 2) / 3 * 4);
-    size_t i = 0;
-    for (; i + 3 <= data.size(); i += 3) {
-        uint32_t n = (data[i] << 16) | (data[i + 1] << 8) | data[i + 2];
-        out.push_back(kAlphabet[(n >> 18) & 0x3f]);
-        out.push_back(kAlphabet[(n >> 12) & 0x3f]);
-        out.push_back(kAlphabet[(n >> 6) & 0x3f]);
-        out.push_back(kAlphabet[n & 0x3f]);
-    }
-    if (i < data.size()) {
-        uint32_t n = data[i] << 16;
-        bool hasTwo = i + 1 < data.size();
-        if (hasTwo) n |= data[i + 1] << 8;
-        out.push_back(kAlphabet[(n >> 18) & 0x3f]);
-        out.push_back(kAlphabet[(n >> 12) & 0x3f]);
-        out.push_back(hasTwo ? kAlphabet[(n >> 6) & 0x3f] : '=');
-        out.push_back('=');
-    }
-    return out;
 }
 
 // Wraps a resolved buffer as a successful result. Buffers are raw bytes

--- a/src/service_discovery.cpp
+++ b/src/service_discovery.cpp
@@ -83,11 +83,7 @@ StdLogosResult Libp2pModuleImpl::createXpr(
     const std::vector<std::pair<std::string, std::string>>& services,
     uint64_t seqNo)
 {
-    std::vector<const char*> addrPtrs;
-    addrPtrs.reserve(addrs.size());
-    for (const auto& addr : addrs) {
-        addrPtrs.push_back(addr.c_str());
-    }
+    auto addrPtrs = toCStringPtrs(addrs);
 
     std::vector<Libp2pServiceInfo> serviceInfos;
     serviceInfos.reserve(services.size());

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,38 @@
+#include "utils.h"
+
+std::string base64Encode(const std::vector<uint8_t>& data) {
+    static constexpr char kAlphabet[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    std::string out;
+    out.reserve((data.size() + 2) / 3 * 4);
+    size_t i = 0;
+    for (; i + 3 <= data.size(); i += 3) {
+        uint32_t n = (data[i] << 16) | (data[i + 1] << 8) | data[i + 2];
+        out.push_back(kAlphabet[(n >> 18) & 0x3f]);
+        out.push_back(kAlphabet[(n >> 12) & 0x3f]);
+        out.push_back(kAlphabet[(n >> 6) & 0x3f]);
+        out.push_back(kAlphabet[n & 0x3f]);
+    }
+    if (i < data.size()) {
+        uint32_t n = data[i] << 16;
+        bool hasTwo = i + 1 < data.size();
+        if (hasTwo) n |= data[i + 1] << 8;
+        out.push_back(kAlphabet[(n >> 18) & 0x3f]);
+        out.push_back(kAlphabet[(n >> 12) & 0x3f]);
+        out.push_back(hasTwo ? kAlphabet[(n >> 6) & 0x3f] : '=');
+        out.push_back('=');
+    }
+    return out;
+}
+
+std::string hexEncode(const uint8_t* data, size_t len) {
+    static constexpr char kDigits[] = "0123456789abcdef";
+    std::string out;
+    if (!data) return out;
+    out.resize(len * 2);
+    for (size_t i = 0; i < len; ++i) {
+        out[2 * i]     = kDigits[data[i] >> 4];
+        out[2 * i + 1] = kDigits[data[i] & 0x0f];
+    }
+    return out;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+extern "C" {
+#include "lib/libp2p.h"
+}
+
+// Borrows each string's c_str() into the const char* array the cbinding layer
+// expects. The returned pointers alias `in`, which must outlive them.
+inline std::vector<const char*> toCStringPtrs(const std::vector<std::string>& in) {
+    std::vector<const char*> out;
+    out.reserve(in.size());
+    for (const auto& s : in) out.push_back(s.c_str());
+    return out;
+}
+
+// Collects a cbinding's (char** arr, len) pair into a JSON array, skipping nulls.
+inline nlohmann::json cStrArrayToJson(const char* const* arr, size_t len) {
+    nlohmann::json out = nlohmann::json::array();
+    if (!arr) return out;
+    for (size_t i = 0; i < len; ++i) {
+        if (arr[i]) out.push_back(arr[i]);
+    }
+    return out;
+}
+
+// Flattens a Libp2pPeerInfo into {peerId, addrs}, the shape every peer-bearing
+// callback returns.
+inline nlohmann::json peerInfoToJson(const Libp2pPeerInfo& info) {
+    nlohmann::json j;
+    j["peerId"] = info.peerId ? info.peerId : "";
+    j["addrs"] = cStrArrayToJson(info.addrs, info.addrsLen);
+    return j;
+}
+
+// Encodes raw bytes as base64.
+std::string base64Encode(const std::vector<uint8_t>& data);
+
+// Encodes raw bytes as lowercase hex.
+std::string hexEncode(const uint8_t* data, size_t len);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ if(LIBP2P_PATH)
     logos_test(
         NAME libp2p_module_tests
         MODULE_SOURCES
+            ../src/utils.cpp
             ../src/plugin.cpp
             ../src/callbacks.cpp
             ../src/kademlia.cpp


### PR DESCRIPTION
## Summary

Motivated by the review on #72 (`gmelodie`: "Can we extract this as well as other utilities to utils.cpp?"). Rather than move a single `nowTimestamp()`, this pulls the marshaling boilerplate that was copy-pasted across the cbinding layer into a new `src/utils.{h,cpp}` and reuses it everywhere it already existed. The diff is net-negative (+102 / −118): it removes more than it adds.

## What moved into `utils`

- `toCStringPtrs(vector<string>)` — the `vector<string>` → borrowed `vector<const char*>` loop, previously hand-written in 6 places (`plugin.cpp:connectPeer`/`circuitRelayReserve`, `peerstore.cpp` ×3, `service_discovery.cpp:createXpr`).
- `cStrArrayToJson(const char* const*, len)` — the "C string array → `json::array`, skip nulls" loop, previously inlined in 6 callbacks (`promisePeerStoreEntryCallback` ×2, `promisePeersCallback`, `promiseReservationCallback`, `promiseRandomRecordsCallback`, and via the peer-info helper below).
- `peerInfoToJson(Libp2pPeerInfo)` — the `{peerId, addrs}` shape that `promisePeerInfoCallback` and `promiseProvidersCallback` each built independently, so the wire format now has a single source of truth.
- `base64Encode` — relocated out of `plugin.h` (it was a header-inline definition) into `utils.cpp`.
- `hexEncode(uint8_t*, len)` — extracted from the hand-rolled nibble loop in `promisePeerStoreEntryCallback`.

## Notes

- Behavior-preserving: the outer `r.ok && … > 0` guards in each callback are untouched, so the empty-result-vs-null-data semantics handed to `jsonResult` are identical to before.
- `toCStringPtrs` returns pointers that alias the input vector; every call site passes a named local that outlives the cbinding call, exactly as the inline loops did.
- `src/utils.{h,cpp}` are wired into `CMakeLists.txt`; examples link the module library and pick up the symbols transitively.

## Testing

Verified each translation unit (and one example) compiles `-fsyntax-only` against the real `libp2p.h` / logos SDK / nlohmann headers. The full module build needs `LOGOS_MODULE_BUILDER_ROOT`, which isn't available locally, so CI should exercise the link step.