### PR TITLE
fix: remove dead generatePrivateKeyRaw declaration

### DIFF
--- a/src/plugin.h
+++ b/src/plugin.h
@@ -239,8 +239,6 @@ private:
     void destroyHandle(libp2p_ctx_t* handle);
     StdLogosResult nodeInfoBoundPorts();
 
-    SyncResult generatePrivateKeyRaw();
-
     static void promiseCallback(int ret, const char* msg, size_t len, void* userData);
     static void promiseBufferCallback(int ret, const uint8_t* data, size_t dataLen,
                                       const char* msg, size_t len, void* userData);


### PR DESCRIPTION
## Summary

Removes the dead member declaration `SyncResult generatePrivateKeyRaw();` from `src/plugin.h`.

The method was declared but never defined anywhere and never called — the only reference in the codebase was the declaration itself. Actual key generation is handled by `SyncResult generatePrivateKey(int scheme);` (defined in `src/plugin.cpp`).

A declared-but-undefined member is harmless to the build (never ODR-used), but it advertises an API that doesn't exist and would mislead future readers. No behavior change.

## Verification

- `rg -n "generatePrivateKeyRaw"` returns nothing after the deletion.
- Any TU including `plugin.h` still compiles — the removed symbol was never referenced.