### PR TITLE
fix: encode service data consistently in disco lookup

### DIFF
--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -133,28 +133,7 @@ void Libp2pModuleImpl::promiseRandomRecordsCallback(
     if (r.ok && records && recordsLen > 0) {
         json arr = json::array();
         for (size_t i = 0; i < recordsLen; ++i) {
-            json rec;
-            rec["peerId"] = records[i].peerId ? records[i].peerId : "";
-            rec["seqNo"] = records[i].seqNo;
-            rec["addrs"] = cStrArrayToJson(records[i].addrs, records[i].addrsLen);
-
-            json services = json::array();
-            if (records[i].services) {
-                for (size_t s = 0; s < records[i].servicesLen; ++s) {
-                    json svc;
-                    svc["id"] = records[i].services[s].id ? records[i].services[s].id : "";
-                    if (records[i].services[s].data && records[i].services[s].dataLen > 0) {
-                        svc["data"] = std::string(
-                            reinterpret_cast<const char*>(records[i].services[s].data),
-                            records[i].services[s].dataLen);
-                    } else {
-                        svc["data"] = "";
-                    }
-                    services.push_back(svc);
-                }
-            }
-            rec["services"] = services;
-            arr.push_back(rec);
+            arr.push_back(extendedRecordToJson(records[i]));
         }
         r.data = std::move(arr);
     }


### PR DESCRIPTION
## Summary

`promiseRandomRecordsCallback` (the `discoLookup` / `discoRandomLookup` path) re-implemented the `Libp2pExtendedPeerRecord` → JSON conversion inline and had diverged from `extendedRecordToJson` (the `decodeXpr` path) on how each service's `data` field is encoded:

- `extendedRecordToJson` base64-encodes `data`, because service data is arbitrary bytes that may not be valid UTF-8 (see `src/service_discovery.cpp`).
- The inline loop in `promiseRandomRecordsCallback` stored the **raw bytes** straight into a JSON string.

This caused two problems:

1. **Inconsistent API surface** — `services[].data` came back base64 from `decodeXpr` but raw from `discoLookup` / `discoRandomLookup`, so a consumer couldn't decode it uniformly.
2. **Latent crash** — `nlohmann::json::dump()` throws `type_error.316` on invalid UTF-8. Raw binary service data flowing through the lookup path (via `emitEventSafe` or result serialization) would fault; `decodeXpr` was immune because it base64-encodes first.

The fix reuses the already-in-scope `extendedRecordToJson` inside `promiseRandomRecordsCallback` instead of the duplicated inline loop, making the encoding consistent (base64 everywhere) and removing the crash in one change.

## Behavior change

This intentionally changes the wire format of `discoLookup` / `discoRandomLookup`: `services[].data` is now base64-encoded instead of raw bytes. Downstream consumers that relied on the raw form must base64-decode.

## Testing

Sandbox cannot fully build (dependency toolchain mismatch), so this is a code-review + reasoning change. Existing tests in `tests/integration_service_discovery.cpp` that exercise `discoLookup` / `discoRandomLookup` only assert records are non-empty / `peerId` matches — none assert on the raw `data` value, so no test changes were needed.