### PR TITLE
fix: build base64Decode lookup table once

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,5 +1,6 @@
 #include "utils.h"
 
+#include <array>
 #include <stdexcept>
 
 std::string base64Encode(const std::vector<uint8_t>& data) {
@@ -28,11 +29,14 @@ std::string base64Encode(const std::vector<uint8_t>& data) {
 }
 
 std::string base64Decode(const std::string& in) {
-    static constexpr char kAlphabet[] =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    int lookup[256];
-    for (int& v : lookup) v = -1;
-    for (int i = 0; i < 64; ++i) lookup[static_cast<unsigned char>(kAlphabet[i])] = i;
+    static const auto lookup = [] {
+        static constexpr char kAlphabet[] =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        std::array<int, 256> t;
+        t.fill(-1);
+        for (int i = 0; i < 64; ++i) t[static_cast<unsigned char>(kAlphabet[i])] = i;
+        return t;
+    }();
 
     if (in.size() % 4 != 0) {
         throw std::invalid_argument("base64Decode: length is not a multiple of 4");


### PR DESCRIPTION
## Summary

`base64Decode` (`src/utils.cpp`) rebuilt its 256-entry decode table on every call — a 256-slot init loop plus a 64-slot fill, all recomputed from the fixed base64 alphabet each invocation.

The table is a pure function of the alphabet, so this is wasted work. `decodeXpr` is the only caller and decode is off any hot path, so the impact is minor; the fix is a free cleanup that makes intent explicit.

Now the table is built once via a function-local `static const std::array<int, 256>` initialized by an immediately-invoked lambda. C++11 static-local semantics guarantee thread-safe one-time initialization. Added `#include <array>`; the decode loop is otherwise unchanged.

## Verification

- Round-tripped `""`, `f`, `fo`, `foo`, `foob`, `fooba`, `foobar`, and a binary payload through `base64Encode` → `base64Decode` — all equal.
- Confirmed the malformed-input paths still throw: length-not-multiple-of-4, `invalid character`, `misplaced padding`, `non-canonical trailing bits`.
- Compiles clean under `-Wall -Wextra -std=c++17`.