### PR TITLE
docs: tutorial

### DIFF
--- a/.github/workflows/tutorial.yml
+++ b/.github/workflows/tutorial.yml
@@ -1,0 +1,109 @@
+name: Tutorial CI
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'tutorial/**'
+      - 'src/**'
+      - 'CMakeLists.txt'
+      - 'tutorial/CMakeLists.txt'
+  pull_request:
+    paths:
+      - 'tutorial/**'
+      - 'src/**'
+      - 'CMakeLists.txt'
+      - 'tutorial/CMakeLists.txt'
+  workflow_dispatch:
+
+concurrency:
+  group: tutorial-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NIX_CONFIG: |
+    experimental-features = nix-command flakes
+
+jobs:
+  compile-check:
+    name: Compile check (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux (x86_64-linux)
+            runner: ubuntu-latest
+            system: x86_64-linux
+
+          - name: macOS (aarch64-darwin)
+            runner: macos-latest
+            system: aarch64-darwin
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v12
+
+      - name: Setup Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v5
+
+      - name: Build tutorials inside Nix dev shell
+        run: |
+          nix develop --command ./tutorial/build_tutorials.sh
+
+  markdown-check:
+    name: Markdown freshness check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate markdown from tutorial sources
+        run: |
+          chmod +x ./tutorial/generate_markdown.sh
+          rm -rf ./tutorial/docs
+          ./tutorial/generate_markdown.sh
+
+      - name: Check git diff (no changes expected)
+        run: |
+          if ! git diff --quiet -- ./tutorial/docs/; then
+            echo "❌ Generated markdown does not match committed version."
+            echo ""
+            echo "Differences found:"
+            git diff -- ./tutorial/docs/
+            echo ""
+            echo "Run './tutorial/generate_markdown.sh' locally and commit the updated docs/"
+            exit 1
+          fi
+          echo "✅ Generated markdown matches committed version."
+
+  upload-docs:
+    name: Upload generated documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [compile-check, markdown-check]
+    if: github.ref == 'refs/heads/master' && success()
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate markdown
+        run: |
+          chmod +x ./tutorial/generate_markdown.sh
+          ./tutorial/generate_markdown.sh
+
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tutorial-docs
+          path: tutorial/docs/
+          retention-days: 30
+          if-no-files-found: error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,3 +27,4 @@ logos_module(
 )
 
 add_subdirectory(examples)
+add_subdirectory(tutorial)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It provides:
 - Sync and async APIs compatible with Qt
 
 Check the examples/ directory for complete usage demonstrations.
+For guided walkthroughs, see the [tutorials](./tutorial/README.md).
 
 ---
 

--- a/src/config.h
+++ b/src/config.h
@@ -11,7 +11,7 @@
 #include <nlohmann/json.hpp>
 
 extern "C" {
-#include "lib/libp2p.h"
+#include <libp2p.h>
 }
 
 #include "utils.h"

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -24,7 +24,7 @@
 #include "logos_result.h"
 
 extern "C" {
-#include "lib/libp2p.h"
+#include <libp2p.h>
 }
 
 #include "config.h"

--- a/src/utils.h
+++ b/src/utils.h
@@ -9,7 +9,7 @@
 #include <nlohmann/json.hpp>
 
 extern "C" {
-#include "lib/libp2p.h"
+#include <libp2p.h>
 }
 
 // Borrows each string's c_str() into the const char* array the cbinding layer

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -4,6 +4,24 @@
 
 file(GLOB TUTORIAL_SOURCES CONFIGURE_DEPENDS *.cpp)
 
+find_package(nlohmann_json REQUIRED)
+find_path(LIBP2P_INCLUDE_DIR
+    NAMES libp2p.h
+    PATHS ${PROJECT_SOURCE_DIR}/lib
+)
+if(NOT LIBP2P_INCLUDE_DIR)
+    message(FATAL_ERROR "libp2p.h not found. Build inside the Nix dev shell or provide libp2p headers.")
+endif()
+
+find_path(LOGOS_CPP_SDK_INCLUDE_DIR
+    NAMES logos_json.h logos_result.h
+    PATHS ENV LOGOS_CPP_SDK_ROOT
+    PATH_SUFFIXES include
+)
+if(NOT LOGOS_CPP_SDK_INCLUDE_DIR)
+    message(FATAL_ERROR "Logos C++ SDK headers not found. Build inside the Nix dev shell or provide LOGOS_CPP_SDK_ROOT.")
+endif()
+
 foreach(tutorial_src ${TUTORIAL_SOURCES})
     get_filename_component(tutorial_name ${tutorial_src} NAME_WE)
 
@@ -11,6 +29,7 @@ foreach(tutorial_src ${TUTORIAL_SOURCES})
 
     target_link_libraries(${tutorial_name} PRIVATE
         libp2p_module_module_plugin
+        nlohmann_json::nlohmann_json
     )
 
     target_include_directories(${tutorial_name} PRIVATE
@@ -18,6 +37,8 @@ foreach(tutorial_src ${TUTORIAL_SOURCES})
         ${PROJECT_SOURCE_DIR}/src
         ${PROJECT_SOURCE_DIR}/include
         ${PROJECT_SOURCE_DIR}/lib
+        ${LIBP2P_INCLUDE_DIR}
+        ${LOGOS_CPP_SDK_INCLUDE_DIR}
     )
 
     set_target_properties(${tutorial_name} PROPERTIES

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Tutorials for logos-libp2p-module
+# Build with: cmake -B build -S . && cmake --build build -j
+# Run with:   ./build/tutorial_<name>
+
+file(GLOB TUTORIAL_SOURCES CONFIGURE_DEPENDS *.cpp)
+
+foreach(tutorial_src ${TUTORIAL_SOURCES})
+    get_filename_component(tutorial_name ${tutorial_src} NAME_WE)
+
+    add_executable(${tutorial_name} ${tutorial_src})
+
+    target_link_libraries(${tutorial_name} PRIVATE
+        libp2p_module_module_plugin
+    )
+
+    target_include_directories(${tutorial_name} PRIVATE
+        ${PROJECT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/src
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/lib
+    )
+
+    set_target_properties(${tutorial_name} PROPERTIES
+        BUILD_RPATH "${CMAKE_BINARY_DIR}/modules"
+        INSTALL_RPATH "$ORIGIN/../lib"
+    )
+
+    install(TARGETS ${tutorial_name}
+            RUNTIME DESTINATION tutorial)
+endforeach()

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -1,0 +1,45 @@
+# logos-libp2p-module Tutorials
+
+
+Step-by-step tutorials for the `logos-libp2p-module` — from basic node lifecycle to NAT traversal with circuit relay.
+
+## Build once, run many
+
+The tutorials are compiled alongside the module. Build them **one time**, then run any tutorial immediately:
+
+```bash
+nix develop
+./tutorial/build_tutorials.sh
+
+# Run any tutorial:
+./build/tutorial_1_node_lifecycle
+./build/tutorial_3_connecting_peers
+# ...
+```
+
+No need to rebuild between runs unless the source code changes.
+
+## Workflow
+
+1. **Read** a tutorial page (start with [Tutorial 1](docs/tutorial_1_node_lifecycle.md))
+2. **Run** the matching binary to see it in action
+3. **Read the source** in the `.cpp` file for the full code
+
+## Prerequisites
+
+- `logos-libp2p-module` built with CMake (see root `README.md` for build instructions)
+- Nix development shell (`nix develop`) or equivalent dependencies
+
+## Regenerate Markdown
+
+The `docs/` folder is generated from `///` comments in the `.cpp` sources:
+
+```bash
+./tutorial/generate_markdown.sh
+```
+
+<div align="center">
+<br>
+<a href="docs/tutorial_1_node_lifecycle.md"><b>▶ START HERE — Tutorial 1: Node Lifecycle</b></a>
+<br><br>
+</div>

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -12,8 +12,8 @@ nix develop
 ./tutorial/build_tutorials.sh
 
 # Run any tutorial:
-./build/tutorial_1_node_lifecycle
-./build/tutorial_3_connecting_peers
+./build/tutorial/tutorial_1_node_lifecycle
+./build/tutorial/tutorial_3_connecting_peers
 # ...
 ```
 

--- a/tutorial/build_tutorials.sh
+++ b/tutorial/build_tutorials.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# build_tutorials.sh
+#
+# Builds all tutorial executables using the project's CMake build system.
+# Should be invoked within the Nix development shell (nix develop) so that
+# LOGOS_MODULE_BUILDER_ROOT, libp2p.so, and other dependencies are available.
+#
+# Usage:
+#   nix develop --command ./tutorial/build_tutorials.sh
+#   # or from inside the dev shell:
+#   ./tutorial/build_tutorials.sh
+#
+# The script cleans only the tutorial targets so existing test/example builds
+# remain intact.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${PROJECT_DIR}"
+
+# Build directory (same as the project's standard cmake build)
+BUILD_DIR="${PROJECT_DIR}/build"
+
+# Ensure cmake is configured
+if [ ! -f "${BUILD_DIR}/CMakeCache.txt" ]; then
+    echo "Configuring CMake..."
+    cmake -B "${BUILD_DIR}" -S "${PROJECT_DIR}"
+fi
+
+# Build only the tutorial targets
+echo "Building tutorials..."
+cmake --build "${BUILD_DIR}" --target \
+    tutorial_1_node_lifecycle \
+    tutorial_2_custom_config \
+    tutorial_3_connecting_peers \
+    tutorial_4_custom_protocol \
+    tutorial_5_kademlia_basics \
+    tutorial_6_kademlia_providers \
+    tutorial_7_gossipsub \
+    tutorial_8_service_discovery \
+    tutorial_9_peerstore \
+    tutorial_10_circuit_relay \
+    -j "$(nproc 2>/dev/null || echo 4)"
+
+echo ""
+echo "✅ All tutorials compiled successfully."
+echo ""
+echo "Binaries in: ${BUILD_DIR}/"
+ls -1 "${BUILD_DIR}"/tutorial_* 2>/dev/null

--- a/tutorial/build_tutorials.sh
+++ b/tutorial/build_tutorials.sh
@@ -25,29 +25,33 @@ cd "${PROJECT_DIR}"
 # Build directory (same as the project's standard cmake build)
 BUILD_DIR="${PROJECT_DIR}/build"
 
-# Ensure cmake is configured
-if [ ! -f "${BUILD_DIR}/CMakeCache.txt" ]; then
+# Ensure cmake is configured. A previous failed configure can leave a
+# CMakeCache.txt without a generated build system.
+if [ ! -f "${BUILD_DIR}/CMakeCache.txt" ] || [ ! -f "${BUILD_DIR}/Makefile" ]; then
     echo "Configuring CMake..."
     cmake -B "${BUILD_DIR}" -S "${PROJECT_DIR}"
 fi
 
-# Build only the tutorial targets
+# Discover and build only the tutorial targets. CMake target names match the
+# tutorial source basenames, e.g. tutorial_1_node_lifecycle.cpp.
 echo "Building tutorials..."
-cmake --build "${BUILD_DIR}" --target \
-    tutorial_1_node_lifecycle \
-    tutorial_2_custom_config \
-    tutorial_3_connecting_peers \
-    tutorial_4_custom_protocol \
-    tutorial_5_kademlia_basics \
-    tutorial_6_kademlia_providers \
-    tutorial_7_gossipsub \
-    tutorial_8_service_discovery \
-    tutorial_9_peerstore \
-    tutorial_10_circuit_relay \
+tutorial_targets=()
+for tutorial_src in "${SCRIPT_DIR}"/tutorial_*.cpp; do
+    [ -f "${tutorial_src}" ] || continue
+    tutorial_file="$(basename "${tutorial_src}")"
+    tutorial_targets+=("${tutorial_file%.cpp}")
+done
+
+if [ "${#tutorial_targets[@]}" -eq 0 ]; then
+    echo "No tutorial sources found in ${SCRIPT_DIR}" >&2
+    exit 1
+fi
+
+cmake --build "${BUILD_DIR}" --target "${tutorial_targets[@]}" \
     -j "$(nproc 2>/dev/null || echo 4)"
 
 echo ""
 echo "✅ All tutorials compiled successfully."
 echo ""
-echo "Binaries in: ${BUILD_DIR}/"
-ls -1 "${BUILD_DIR}"/tutorial_* 2>/dev/null
+echo "Binaries in: ${BUILD_DIR}/tutorial/"
+ls -1 "${BUILD_DIR}"/tutorial/tutorial_*

--- a/tutorial/build_tutorials.sh
+++ b/tutorial/build_tutorials.sh
@@ -7,7 +7,7 @@
 # LOGOS_MODULE_BUILDER_ROOT, libp2p.so, and other dependencies are available.
 #
 # Usage:
-#   nix develop --command ./tutorial/build_tutorials.sh
+#   nix --extra-experimental-features 'nix-command flakes' develop --command ./tutorial/build_tutorials.sh
 #   # or from inside the dev shell:
 #   ./tutorial/build_tutorials.sh
 #
@@ -30,6 +30,21 @@ BUILD_DIR="${PROJECT_DIR}/build"
 if [ ! -f "${BUILD_DIR}/CMakeCache.txt" ] || [ ! -f "${BUILD_DIR}/Makefile" ]; then
     echo "Configuring CMake..."
     cmake -B "${BUILD_DIR}" -S "${PROJECT_DIR}"
+else
+    cached_cxx="$(sed -n 's/^CMAKE_CXX_COMPILER:[^=]*=//p' "${BUILD_DIR}/CMakeCache.txt" | head -n1)"
+    cached_libp2p="$(sed -n 's/^LIBP2P_INCLUDE_DIR:[^=]*=//p' "${BUILD_DIR}/CMakeCache.txt" | head -n1)"
+    if [[ "${cached_cxx}" == /usr/bin/* && "${cached_libp2p}" == /nix/store/* ]]; then
+        cat >&2 <<EOF
+The existing CMake build uses the host compiler (${cached_cxx}) with Nix libp2p.
+That can produce tutorial binaries that load the host dynamic linker with Nix
+glibc and abort before main with "stack smashing detected".
+
+Recreate the build directory from inside the Nix development shell, then rerun:
+  rm -rf "${BUILD_DIR}"
+  nix --extra-experimental-features 'nix-command flakes' develop --command ./tutorial/build_tutorials.sh
+EOF
+        exit 1
+    fi
 fi
 
 # Discover and build only the tutorial targets. CMake target names match the

--- a/tutorial/docs/tutorial_10_circuit_relay.md
+++ b/tutorial/docs/tutorial_10_circuit_relay.md
@@ -208,6 +208,9 @@ The ping protocol works well for this.
 
     printf("\n=== Tutorial 10 Complete ===\n");
 
+    return 0;
+}
+
 ```
 
 ## Key Takeaways
@@ -225,8 +228,12 @@ The ping protocol works well for this.
 This concludes the tutorial series! You now have a solid
 foundation for building peer-to-peer applications with
 `logos-libp2p-module`.
-```cpp
-    return 0;
-}
-```
 
+## Run tutorial
+
+Run this tutorial:
+```bash
+./build/tutorial_10_circuit_relay
+---
+
+< [Peer Store Management](tutorial_9_peerstore.md)

--- a/tutorial/docs/tutorial_10_circuit_relay.md
+++ b/tutorial/docs/tutorial_10_circuit_relay.md
@@ -1,0 +1,232 @@
+# Tutorial 10: Circuit Relay – Connecting Through Firewalls
+
+Not all peers are directly reachable. Some are behind NAT, firewalls,
+or have no public IP. Circuit Relay solves this by having a
+**relay node** forward traffic between peers.
+
+## The Three-Node Pattern
+
+Circuit relay uses three roles:
+
+```
+  Client  <-->  Relay  <-->  Destination
+  (B)            (R)          (A)
+```
+
+- **Destination** (A) — The peer behind NAT that wants to be reachable.
+  It connects to the relay and reserves a slot.
+- **Relay** (R) — A publicly reachable node that forwards traffic.
+- **Client** (B) — A peer that wants to connect to A through R.
+
+## How it works
+
+1. The Destination connects to the Relay and calls
+   `circuitRelayReserve()` to request a relay slot.
+2. The Relay confirms the reservation and returns relay addresses.
+3. The Client dials the Destination via the Relay using
+   `dialCircuitRelay()`.
+4. The Relay transparently forwards stream data between them.
+
+> **Note**: Circuit relay adds latency and bandwidth overhead on the
+> relay node. Use it only when direct connections are impossible.
+```cpp
+#include <cstdio>
+#include <chrono>
+#include <thread>
+#include <string>
+#include <vector>
+#include "plugin.h"
+
+int main()
+{
+    printf("=== Tutorial 10: Circuit Relay ===\n\n");
+
+```
+
+## Step 1: Create three nodes
+
+- **Relay** (port 9890): publicly reachable, `circuitRelay: true`
+- **Destination** (port 9891): behind NAT
+- **Client** (port 9892): wants to connect to Destination
+
+The Relay and Destination must be connected before the reservation.
+The Client connects to the Relay before dialing the Destination.
+
+```cpp
+    // Relay node — must have circuitRelay enabled
+    Libp2pModuleOptions optsRelay;
+    optsRelay.addrs = {"/ip4/127.0.0.1/tcp/9890"};
+    optsRelay.circuitRelay = true;
+
+    // Destination node (behind NAT)
+    Libp2pModuleOptions optsDest;
+    optsDest.addrs = {"/ip4/127.0.0.1/tcp/9891"};
+
+    // Client node
+    Libp2pModuleOptions optsClient;
+    optsClient.addrs = {"/ip4/127.0.0.1/tcp/9892"};
+
+    Libp2pModuleImpl relay(optsRelay);
+    Libp2pModuleImpl dest(optsDest);
+    Libp2pModuleImpl client(optsClient);
+
+    printf("Starting nodes...\n");
+
+    if (!relay.start().success) {
+        fprintf(stderr, "Relay failed\n");
+        return 1;
+    }
+
+    if (!dest.start().success) {
+        fprintf(stderr, "Destination failed\n");
+        return 1;
+    }
+
+    if (!client.start().success) {
+        fprintf(stderr, "Client failed\n");
+        return 1;
+    }
+    printf("All three nodes started\n");
+
+```
+
+## Step 2: Get node addresses
+```cpp
+    auto infoRelay = relay.peerInfo().value;
+    std::string relayPeerId = infoRelay["peerId"].get<std::string>();
+    std::vector<std::string> relayAddrs;
+    for (const auto& a : infoRelay["addrs"])
+        relayAddrs.push_back(a.get<std::string>());
+
+    auto infoDest = dest.peerInfo().value;
+    std::string destPeerId = infoDest["peerId"].get<std::string>();
+
+    printf("Relay peer ID: %s\n", relayPeerId.c_str());
+    printf("Destination peer ID: %s\n", destPeerId.c_str());
+
+```
+
+## Step 3: Destination connects to the Relay and reserves a slot
+
+The Destination must connect to the Relay first, then call
+`circuitRelayReserve()` to request a reservation. The relay
+returns the addresses the Destination can be reached at (via relay).
+```cpp
+    printf("\nDestination connecting to relay...\n");
+    if (!dest.connectPeer(relayPeerId, relayAddrs, 5000).success) {
+        fprintf(stderr, "Destination failed to connect to relay\n");
+        return 1;
+    }
+    printf("Destination connected to relay\n");
+
+    printf("Destination requesting relay reservation...\n");
+    auto reserveRes = dest.circuitRelayReserve(relayPeerId, relayAddrs);
+    if (!reserveRes.success) {
+        fprintf(stderr, "Relay reservation failed: %s\n",
+                reserveRes.error.c_str());
+        return 1;
+    }
+
+    printf("Relay reservation successful!\n");
+    if (reserveRes.value.is_array()) {
+        printf("Relay addresses:\n");
+        for (const auto& addr : reserveRes.value) {
+            printf("  %s\n", addr.get<std::string>().c_str());
+        }
+    }
+
+```
+
+## Step 4: Client connects to the Relay, then dials Destination
+
+The Client connects to the Relay (same as any other peer), then
+uses `dialCircuitRelay()` to reach the Destination through the Relay.
+```cpp
+    printf("\nClient connecting to relay...\n");
+    if (!client.connectPeer(relayPeerId, relayAddrs, 5000).success) {
+        fprintf(stderr, "Client failed to connect to relay\n");
+        return 1;
+    }
+    printf("Client connected to relay\n");
+
+```
+
+Now the Client dials the Destination's peer ID through the relay.
+The multiaddr is the Destination's direct address (even though
+the traffic goes through the relay).
+```cpp
+    printf("Client dialing destination through relay...\n");
+
+    // Get the destination's address
+    std::string destAddr;
+    if (infoDest["addrs"].is_array() && infoDest["addrs"].size() > 0) {
+        destAddr = infoDest["addrs"][0].get<std::string>();
+    }
+
+```
+
+For circuit relay, we use a well-known protocol to test connectivity.
+The ping protocol works well for this.
+```cpp
+    auto dialRes = client.dialCircuitRelay(
+        destPeerId,
+        destAddr,
+        "/ipfs/ping/1.0.0");
+
+    if (!dialRes.success) {
+        fprintf(stderr, "Circuit relay dial failed: %s\n",
+                dialRes.error.c_str());
+        printf("\nNote: Circuit relay may need configuration tuning.\n");
+        printf("Ensure the relay node has circuitRelay=true and the\n");
+        printf("destination has connected and reserved a slot.\n");
+    } else {
+        uint64_t streamId = dialRes.value.get<uint64_t>();
+        printf("Circuit relay stream opened! id: %llu\n",
+               (unsigned long long)streamId);
+
+        /// Send a ping through the relay:
+        std::string payload(32, '\0');
+        for (int i = 0; i < 32; ++i) payload[i] = static_cast<char>(i);
+
+        if (!client.streamWrite(streamId, payload).success) {
+            fprintf(stderr, "Write failed\n");
+        } else {
+            printf("Sent %zu bytes through relay\n", payload.size());
+        }
+
+        client.streamClose(streamId);
+        client.streamRelease(streamId);
+    }
+
+```
+
+## Step 5: Clean up
+```cpp
+    relay.stop();
+    dest.stop();
+    client.stop();
+
+    printf("\n=== Tutorial 10 Complete ===\n");
+
+```
+
+## Key Takeaways
+
+  - Circuit Relay allows connecting peers behind NAT/firewalls
+  - Three roles: Destination (relayed), Relay (forwarder), Client
+  - `circuitRelay: true` enables relay mode on a node
+  - Destination calls `circuitRelayReserve()` to request a slot
+  - Client calls `dialCircuitRelay()` with dest peer ID + address
+  - Relay overhead should be considered; prefer direct connections
+    when possible
+  - The relay address returned by reserve may be needed by the
+    client for some configurations
+
+This concludes the tutorial series! You now have a solid
+foundation for building peer-to-peer applications with
+`logos-libp2p-module`.
+```cpp
+    return 0;
+}
+```
+

--- a/tutorial/docs/tutorial_10_circuit_relay.md
+++ b/tutorial/docs/tutorial_10_circuit_relay.md
@@ -236,16 +236,14 @@ foundation for building peer-to-peer applications with
 
 ## Run tutorial
 
-Build the module (one time):
 ```bash
-nix develop
-./tutorial/build_tutorials.sh
-```
-
-Run this tutorial:
-```bash
-./build/tutorial_10_circuit_relay
+./build/tutorial/tutorial_10_circuit_relay
 ```
 ---
 
-< [Peer Store Management](tutorial_9_peerstore.md)
+<table width="100%">
+  <tr>
+<td width="50%" align="left"><a href="tutorial_9_peerstore.md">&larr; Peer Store Management</a></td>
+<td width="50%"></td>
+  </tr>
+</table>

--- a/tutorial/docs/tutorial_10_circuit_relay.md
+++ b/tutorial/docs/tutorial_10_circuit_relay.md
@@ -32,6 +32,7 @@ Circuit relay uses three roles:
 ```cpp
 #include <cstdio>
 #include <chrono>
+#include <cstdint>
 #include <thread>
 #include <string>
 #include <vector>
@@ -61,10 +62,12 @@ The Client connects to the Relay before dialing the Destination.
     // Destination node (behind NAT)
     Libp2pModuleOptions optsDest;
     optsDest.addrs = {"/ip4/127.0.0.1/tcp/9891"};
+    optsDest.circuitRelayClient = true;
 
     // Client node
     Libp2pModuleOptions optsClient;
     optsClient.addrs = {"/ip4/127.0.0.1/tcp/9892"};
+    optsClient.circuitRelayClient = true;
 
     Libp2pModuleImpl relay(optsRelay);
     Libp2pModuleImpl dest(optsDest);
@@ -152,17 +155,16 @@ uses `dialCircuitRelay()` to reach the Destination through the Relay.
 ```
 
 Now the Client dials the Destination's peer ID through the relay.
-The multiaddr is the Destination's direct address (even though
-the traffic goes through the relay).
+The multiaddr comes from the reservation response, with `/p2p-circuit`
+appended so libp2p routes the stream through the Relay.
 ```cpp
     printf("Client dialing destination through relay...\n");
 
-    // Get the destination's address
-    std::string destAddr;
-    if (infoDest.contains("addrs") && infoDest["addrs"].is_array() && !infoDest["addrs"].empty()) {
-        destAddr = infoDest["addrs"][0].get<std::string>();
+    std::string relayDialAddr;
+    if (reserveRes.value.is_array() && !reserveRes.value.empty()) {
+        relayDialAddr = reserveRes.value[0].get<std::string>() + "/p2p-circuit";
     } else {
-        fprintf(stderr, "Destination has no known addresses to dial\n");
+        fprintf(stderr, "Reservation did not return relay addresses\n");
         return 1;
     }
 
@@ -173,7 +175,7 @@ The ping protocol works well for this.
 ```cpp
     auto dialRes = client.dialCircuitRelay(
         destPeerId,
-        destAddr,
+        relayDialAddr,
         "/ipfs/ping/1.0.0");
 
     if (!dialRes.success) {

--- a/tutorial/docs/tutorial_10_circuit_relay.md
+++ b/tutorial/docs/tutorial_10_circuit_relay.md
@@ -231,9 +231,16 @@ foundation for building peer-to-peer applications with
 
 ## Run tutorial
 
+Build the module (one time):
+```bash
+nix develop
+./tutorial/build_tutorials.sh
+```
+
 Run this tutorial:
 ```bash
 ./build/tutorial_10_circuit_relay
+```
 ---
 
 < [Peer Store Management](tutorial_9_peerstore.md)

--- a/tutorial/docs/tutorial_10_circuit_relay.md
+++ b/tutorial/docs/tutorial_10_circuit_relay.md
@@ -159,8 +159,11 @@ the traffic goes through the relay).
 
     // Get the destination's address
     std::string destAddr;
-    if (infoDest["addrs"].is_array() && infoDest["addrs"].size() > 0) {
+    if (infoDest.contains("addrs") && infoDest["addrs"].is_array() && !infoDest["addrs"].empty()) {
         destAddr = infoDest["addrs"][0].get<std::string>();
+    } else {
+        fprintf(stderr, "Destination has no known addresses to dial\n");
+        return 1;
     }
 
 ```
@@ -184,7 +187,7 @@ The ping protocol works well for this.
         printf("Circuit relay stream opened! id: %llu\n",
                (unsigned long long)streamId);
 
-        /// Send a ping through the relay:
+        // Send a ping through the relay:
         std::string payload(32, '\0');
         for (int i = 0; i < 32; ++i) payload[i] = static_cast<char>(i);
 

--- a/tutorial/docs/tutorial_1_node_lifecycle.md
+++ b/tutorial/docs/tutorial_1_node_lifecycle.md
@@ -25,6 +25,7 @@ called `Libp2pModuleImpl` that you can embed directly into your application.
 Every program starts by including the module's single public header:
 ```cpp
 #include <cstdio>
+#include <string>
 #include "plugin.h"
 
 ```

--- a/tutorial/docs/tutorial_1_node_lifecycle.md
+++ b/tutorial/docs/tutorial_1_node_lifecycle.md
@@ -119,16 +119,14 @@ In this tutorial you learned how to:
 
 ## Run tutorial
 
-Build the module (one time):
 ```bash
-nix develop
-./tutorial/build_tutorials.sh
-```
-
-Run this tutorial:
-```bash
-./build/tutorial_1_node_lifecycle
+./build/tutorial/tutorial_1_node_lifecycle
 ```
 ---
 
-[Custom Node Configuration](tutorial_2_custom_config.md) >
+<table width="100%">
+  <tr>
+<td width="50%"></td>
+<td width="50%" align="right"><a href="tutorial_2_custom_config.md">Custom Node Configuration &rarr;</a></td>
+  </tr>
+</table>

--- a/tutorial/docs/tutorial_1_node_lifecycle.md
+++ b/tutorial/docs/tutorial_1_node_lifecycle.md
@@ -103,6 +103,9 @@ Always clean up by stopping the node when you're done.
     node.stop();
     printf("Node stopped\n");
 
+    return 0;
+}
+
 ```
 
 ## Summary
@@ -113,10 +116,11 @@ In this tutorial you learned how to:
   - Query peer identity and listening addresses
   - Retrieve module metadata
 
-In the [next tutorial](tutorial_2_custom_config.md), we'll explore
-how to configure the node with a custom port and transport settings.
-```cpp
-    return 0;
-}
-```
+## Run tutorial
 
+Run this tutorial:
+```bash
+./build/tutorial_1_node_lifecycle
+---
+
+[Custom Node Configuration](tutorial_2_custom_config.md) >

--- a/tutorial/docs/tutorial_1_node_lifecycle.md
+++ b/tutorial/docs/tutorial_1_node_lifecycle.md
@@ -1,0 +1,122 @@
+# Tutorial 1: Creating and Starting a libp2p Node
+
+Welcome to the first `logos-libp2p-module` tutorial!
+
+This tutorial will guide you through the basics of creating, configuring,
+starting, and stopping a libp2p node using the Logos libp2p module.
+
+## Before You Start
+
+Make sure you can build the `logos-libp2p-module` project. See the
+project's `README.md` for build instructions using Nix or CMake.
+
+## What is libp2p?
+
+[libp2p](https://libp2p.io/) is a modular networking stack for building
+peer-to-peer applications. It provides transport-agnostic connectivity,
+peer identity, stream multiplexing, secure channels, and content routing
+— everything you need to build a decentralized network.
+
+The `logos-libp2p-module` wraps libp2p's C bindings into a C++ class
+called `Libp2pModuleImpl` that you can embed directly into your application.
+
+## Step 1: Include the module header and instantiate a node
+
+Every program starts by including the module's single public header:
+```cpp
+#include <cstdio>
+#include "plugin.h"
+
+```
+
+The main class we work with is `Libp2pModuleImpl`. Let's create one with
+default options:
+```cpp
+int main()
+{
+    // Create a libp2p node with default configuration.
+    // By default it listens on 127.0.0.1 with a random port (tcp/0).
+    Libp2pModuleImpl node;
+
+    printf("Node object created (not yet started)\n");
+
+```
+
+## Step 2: Start the node
+
+Calling `start()` creates the libp2p context, binds the configured
+address, and begins accepting connections.
+
+```cpp
+    if (!node.start().success) {
+        fprintf(stderr, "Failed to start node\n");
+        return 1;
+    }
+
+    printf("Node started successfully!\n");
+
+```
+
+## Step 3: Query node information
+
+Once the node is running, we can inspect its identity and
+network addresses using `peerInfo()`.
+
+```cpp
+    auto info = node.peerInfo();
+    if (info.success) {
+        // Extract the peer ID — a unique cryptographic identifier
+        std::string peerId = info.value["peerId"].get<std::string>();
+        printf("Peer ID: %s\n", peerId.c_str());
+
+        // List all multiaddresses the node is listening on
+        printf("Listening addresses:\n");
+        for (const auto& addr : info.value["addrs"]) {
+            printf("  %s\n", addr.get<std::string>().c_str());
+        }
+    }
+
+```
+
+We can also query specific fields using `getNodeInfo()`:
+
+```cpp
+    auto version = node.getNodeInfo("Version");
+    if (version.success) {
+        printf("Module version: %s\n",
+               version.value.get<std::string>().c_str());
+    }
+
+    auto peerIdResult = node.getNodeInfo("PeerId");
+    if (peerIdResult.success) {
+        printf("Peer ID (via getNodeInfo): %s\n",
+               peerIdResult.value.get<std::string>().c_str());
+    }
+
+```
+
+## Step 4: Stop the node
+
+Always clean up by stopping the node when you're done.
+
+```cpp
+    node.stop();
+    printf("Node stopped\n");
+
+```
+
+## Summary
+
+In this tutorial you learned how to:
+  - Create a `Libp2pModuleImpl` instance
+  - Start and stop a libp2p node
+  - Query peer identity and listening addresses
+  - Retrieve module metadata
+
+In the [next tutorial](tutorial_2_custom_config.md), we'll explore
+how to configure the node with a custom port and transport settings.
+```cpp
+    return 0;
+}
+```
+

--- a/tutorial/docs/tutorial_1_node_lifecycle.md
+++ b/tutorial/docs/tutorial_1_node_lifecycle.md
@@ -118,9 +118,16 @@ In this tutorial you learned how to:
 
 ## Run tutorial
 
+Build the module (one time):
+```bash
+nix develop
+./tutorial/build_tutorials.sh
+```
+
 Run this tutorial:
 ```bash
 ./build/tutorial_1_node_lifecycle
+```
 ---
 
 [Custom Node Configuration](tutorial_2_custom_config.md) >

--- a/tutorial/docs/tutorial_2_custom_config.md
+++ b/tutorial/docs/tutorial_2_custom_config.md
@@ -166,6 +166,12 @@ In this tutorial you learned:
 
 ## Run tutorial
 
+Build the module (one time):
+```bash
+nix develop
+./tutorial/build_tutorials.sh
+```
+
 Run this tutorial:
 ```bash
 ./build/tutorial_2_custom_config

--- a/tutorial/docs/tutorial_2_custom_config.md
+++ b/tutorial/docs/tutorial_2_custom_config.md
@@ -134,6 +134,9 @@ supplied via `Libp2pModuleOptions::fromJson()`.
     }
 
     nodeFromJson.stop();
+    
+    return 0;
+}
 
 ```
 
@@ -161,10 +164,12 @@ In this tutorial you learned:
   - How to pass options via C++ struct or JSON
   - How to verify the node's actual bound addresses
 
-In the [next tutorial](tutorial_3_connecting_peers.md), we'll connect
-two nodes and exchange data.
-```cpp
-    return 0;
-}
-```
+## Run tutorial
 
+Run this tutorial:
+```bash
+./build/tutorial_2_custom_config
+```
+---
+
+< [Creating and Starting a libp2p Node](tutorial_1_node_lifecycle.md) -- [Connecting Peers and Exchanging Data](tutorial_3_connecting_peers.md) >

--- a/tutorial/docs/tutorial_2_custom_config.md
+++ b/tutorial/docs/tutorial_2_custom_config.md
@@ -1,0 +1,170 @@
+# Tutorial 2: Custom Node Configuration
+
+In the [previous tutorial](tutorial_1_node_lifecycle.md), we created a
+node with default settings that binds to a random port. In this tutorial,
+we'll learn how to configure the node explicitly — setting a fixed port,
+changing transports, and passing options via both C++ structs and JSON.
+
+## Understanding Libp2pModuleOptions
+
+The `Libp2pModuleImpl` constructor accepts a `Libp2pModuleOptions` struct
+that lets you control every aspect of the node. Here are the most common
+configuration fields:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `addrs` | `vector<string>` | `["/ip4/127.0.0.1/tcp/0"]` | Listen addresses |
+| `transport` | `int` | `LIBP2P_TRANSPORT_TCP` | Transport protocol |
+| `maxConnections` | `int` | `50` | Max total connections |
+| `maxConnsPerPeer` | `int` | `1` | Max connections per peer |
+| `mountGossipsub` | `bool` | `true` | Enable GossipSub |
+| `mountKad` | `bool` | `true` | Enable Kademlia DHT |
+| `mountServiceDiscovery` | `bool` | `true` | Enable service discovery |
+
+## Binding to a fixed port
+
+By default nodes bind to port 0 (random). To listen on a specific port,
+provide a custom address in the `addrs` field.
+```cpp
+#include <cstdio>
+#include "plugin.h"
+
+int main()
+{
+```
+
+## Method 1: Configure via C++ struct
+
+The most explicit way to configure a node is by constructing
+`Libp2pModuleOptions` directly and passing it to the constructor.
+```cpp
+    Libp2pModuleOptions options;
+
+    // Listen on TCP port 9090 on all interfaces
+    options.addrs = {"/ip4/0.0.0.0/tcp/9090"};
+
+    // Limit to 10 total connections
+    options.maxConnections = 10;
+
+    // Allow up to 2 connections from the same peer
+    options.maxConnsPerPeer = 2;
+
+    // We don't need GossipSub or Kademlia for this basic example
+    options.mountGossipsub = false;
+    options.mountKad = false;
+    options.mountServiceDiscovery = false;
+
+    printf("Creating node with custom configuration...\n");
+    printf("  Listen address: %s\n", options.addrs[0].c_str());
+    printf("  Max connections: %d\n", options.maxConnections);
+    printf("  Max per peer: %d\n", options.maxConnsPerPeer);
+
+    Libp2pModuleImpl node(options);
+
+    if (!node.start().success) {
+        fprintf(stderr, "Failed to start node\n");
+        return 1;
+    }
+
+```
+
+Verify that the node is actually listening on the configured port:
+```cpp
+    auto info = node.peerInfo();
+    if (info.success) {
+        printf("\nNode is live!\n");
+        printf("  Peer ID: %s\n",
+               info.value["peerId"].get<std::string>().c_str());
+        for (const auto& addr : info.value["addrs"]) {
+            printf("  Listening on: %s\n",
+                   addr.get<std::string>().c_str());
+        }
+    }
+
+    node.stop();
+
+```
+
+## Method 2: Configure via JSON
+
+When integrating with larger systems (e.g. `logoscore`), you'll
+often receive configuration as JSON. The same options can be
+supplied via `Libp2pModuleOptions::fromJson()`.
+```cpp
+    printf("\n--- Method 2: JSON configuration ---\n");
+
+    std::string jsonConfig = R"({
+        "addrs": ["/ip4/127.0.0.1/tcp/9091"],
+        "maxConnections": 20,
+        "mountGossipsub": false,
+        "mountKad": false,
+        "mountServiceDiscovery": false
+    })";
+
+    bool parseOk;
+    std::string parseErr;
+    auto jsonOpts = Libp2pModuleOptions::fromJson(jsonConfig, parseOk, &parseErr);
+
+    if (!parseOk) {
+        fprintf(stderr, "Failed to parse JSON config: %s\n",
+                parseErr.c_str());
+        return 1;
+    }
+
+    printf("Parsed JSON config:\n");
+    printf("  Listen address: %s\n", jsonOpts.addrs[0].c_str());
+    printf("  Max connections: %d\n", jsonOpts.maxConnections);
+
+    Libp2pModuleImpl nodeFromJson(jsonOpts);
+
+    if (!nodeFromJson.start().success) {
+        fprintf(stderr, "Failed to start JSON-configured node\n");
+        return 1;
+    }
+
+    auto info2 = nodeFromJson.peerInfo();
+    if (info2.success) {
+        printf("\nJSON-configured node is live!\n");
+        printf("  Peer ID: %s\n",
+               info2.value["peerId"].get<std::string>().c_str());
+        for (const auto& addr : info2.value["addrs"]) {
+            printf("  Listening on: %s\n",
+                   addr.get<std::string>().c_str());
+        }
+    }
+
+    nodeFromJson.stop();
+
+```
+
+## Exercise: Try different configurations
+
+Experiment with these variations:
+
+```cpp
+// QUIC transport instead of TCP
+options.transport = LIBP2P_TRANSPORT_QUIC;
+options.addrs = {"/ip4/127.0.0.1/udp/9092/quic-v1"};
+
+// Listen on multiple addresses
+options.addrs = {
+    "/ip4/0.0.0.0/tcp/9093",
+    "/ip4/0.0.0.0/tcp/9094"
+};
+```
+
+## Summary
+
+In this tutorial you learned:
+  - How to configure a node with a fixed port
+  - How to control connection limits
+  - How to pass options via C++ struct or JSON
+  - How to verify the node's actual bound addresses
+
+In the [next tutorial](tutorial_3_connecting_peers.md), we'll connect
+two nodes and exchange data.
+```cpp
+    return 0;
+}
+```
+

--- a/tutorial/docs/tutorial_2_custom_config.md
+++ b/tutorial/docs/tutorial_2_custom_config.md
@@ -167,16 +167,14 @@ In this tutorial you learned:
 
 ## Run tutorial
 
-Build the module (one time):
 ```bash
-nix develop
-./tutorial/build_tutorials.sh
-```
-
-Run this tutorial:
-```bash
-./build/tutorial_2_custom_config
+./build/tutorial/tutorial_2_custom_config
 ```
 ---
 
-< [Creating and Starting a libp2p Node](tutorial_1_node_lifecycle.md) -- [Connecting Peers and Exchanging Data](tutorial_3_connecting_peers.md) >
+<table width="100%">
+  <tr>
+<td width="50%" align="left"><a href="tutorial_1_node_lifecycle.md">&larr; Creating and Starting a libp2p Node</a></td>
+<td width="50%" align="right"><a href="tutorial_3_connecting_peers.md">Connecting Peers and Exchanging Data &rarr;</a></td>
+  </tr>
+</table>

--- a/tutorial/docs/tutorial_2_custom_config.md
+++ b/tutorial/docs/tutorial_2_custom_config.md
@@ -27,6 +27,7 @@ By default nodes bind to port 0 (random). To listen on a specific port,
 provide a custom address in the `addrs` field.
 ```cpp
 #include <cstdio>
+#include <string>
 #include "plugin.h"
 
 int main()
@@ -134,7 +135,7 @@ supplied via `Libp2pModuleOptions::fromJson()`.
     }
 
     nodeFromJson.stop();
-    
+
     return 0;
 }
 

--- a/tutorial/docs/tutorial_3_connecting_peers.md
+++ b/tutorial/docs/tutorial_3_connecting_peers.md
@@ -210,6 +210,12 @@ Always close and release streams when done:
 
 ## Run tutorial
 
+Build the module (one time):
+```bash
+nix develop
+./tutorial/build_tutorials.sh
+```
+
 Run this tutorial:
 ```bash
 ./build/tutorial_3_connecting_peers

--- a/tutorial/docs/tutorial_3_connecting_peers.md
+++ b/tutorial/docs/tutorial_3_connecting_peers.md
@@ -213,16 +213,14 @@ Always close and release streams when done:
 
 ## Run tutorial
 
-Build the module (one time):
 ```bash
-nix develop
-./tutorial/build_tutorials.sh
-```
-
-Run this tutorial:
-```bash
-./build/tutorial_3_connecting_peers
+./build/tutorial/tutorial_3_connecting_peers
 ```
 ---
 
-< [Custom Node Configuration](tutorial_2_custom_config.md) -- [Custom Protocol Handlers](tutorial_4_custom_protocol.md) >
+<table width="100%">
+  <tr>
+<td width="50%" align="left"><a href="tutorial_2_custom_config.md">&larr; Custom Node Configuration</a></td>
+<td width="50%" align="right"><a href="tutorial_4_custom_protocol.md">Custom Protocol Handlers &rarr;</a></td>
+  </tr>
+</table>

--- a/tutorial/docs/tutorial_3_connecting_peers.md
+++ b/tutorial/docs/tutorial_3_connecting_peers.md
@@ -202,7 +202,18 @@ Always close and release streams when done:
     nodeB.stop();
 
     printf("\n=== Tutorial 3 Complete ===\n");
+    
     return 0;
 }
+
 ```
 
+## Run tutorial
+
+Run this tutorial:
+```bash
+./build/tutorial_3_connecting_peers
+```
+---
+
+< [Custom Node Configuration](tutorial_2_custom_config.md) -- [Custom Protocol Handlers](tutorial_4_custom_protocol.md) >

--- a/tutorial/docs/tutorial_3_connecting_peers.md
+++ b/tutorial/docs/tutorial_3_connecting_peers.md
@@ -1,0 +1,208 @@
+# Tutorial 3: Connecting Peers and Exchanging Data
+
+Now that we can create and configure nodes, let's make them talk to
+each other! In this tutorial we'll:
+
+  - Create two nodes
+  - Connect one to the other
+  - Dial a protocol and open a stream
+  - Exchange data over the stream
+
+## How libp2p Connections Work
+
+A libp2p connection is established in two steps:
+
+1. **Connect** — Establish a transport-level connection to a remote peer,
+   identified by its Peer ID and a multiaddress.
+
+2. **Dial** — Negotiate a protocol on top of the connection and open a
+   bidirectional stream. The stream is what you actually read from and
+   write to.
+
+Streams in `logos-libp2p-module` are identified by a numeric `streamId`
+that you get back from `dial()` and pass to read/write functions.
+
+## Stream Lifecycle
+
+A stream must follow this lifecycle:
+  1. `dial()` — Open a stream (returns a `streamId`)
+  2. `streamWrite()` / `streamWriteLp()` — Send data
+  3. `streamReadLp()` / `streamReadExactly()` — Receive data
+  4. `streamClose()` or `streamCloseWithEOF()` — Close gracefully
+  5. `streamRelease()` — Free server-side resources
+```cpp
+#include <cstdio>
+#include "plugin.h"
+
+int main()
+{
+    printf("=== Tutorial 3: Connecting Peers ===\n\n");
+
+```
+
+## Step 1: Create and start two nodes
+
+We create two nodes. Node A listens on port 9190, Node B on port 9191.
+For simplicity, both mount the built-in `/ipfs/ping/1.0.0` protocol
+(enabled by default — no extra config needed).
+```cpp
+    Libp2pModuleOptions optsA;
+    optsA.addrs = {"/ip4/127.0.0.1/tcp/9190"};
+
+    Libp2pModuleOptions optsB;
+    optsB.addrs = {"/ip4/127.0.0.1/tcp/9191"};
+    // Node B needs to know about node A to connect, but we'll pass
+    // that info after starting both nodes.
+
+    Libp2pModuleImpl nodeA(optsA);
+    Libp2pModuleImpl nodeB(optsB);
+
+    if (!nodeA.start().success) {
+        fprintf(stderr, "Node A failed to start\n");
+        return 1;
+    }
+    printf("Node A started\n");
+
+    if (!nodeB.start().success) {
+        fprintf(stderr, "Node B failed to start\n");
+        return 1;
+    }
+    printf("Node B started\n");
+
+```
+
+## Step 2: Get Node A's address info
+
+Node B needs to know where to find Node A. We get Node A's
+peer ID and listening addresses from `peerInfo()`.
+```cpp
+    auto infoA = nodeA.peerInfo();
+    if (!infoA.success) {
+        fprintf(stderr, "Failed to get node A info\n");
+        return 1;
+    }
+
+    std::string peerIdA = infoA.value["peerId"].get<std::string>();
+    std::vector<std::string> addrsA;
+    for (const auto& a : infoA.value["addrs"]) {
+        addrsA.push_back(a.get<std::string>());
+    }
+
+    printf("Node A peer ID: %s\n", peerIdA.c_str());
+    printf("Node A addresses:\n");
+    for (const auto& a : addrsA) {
+        printf("  %s\n", a.c_str());
+    }
+
+```
+
+## Step 3: Connect Node B to Node A
+
+`connectPeer()` establishes the transport connection. The timeout
+parameter is in milliseconds.
+```cpp
+    printf("\nConnecting Node B to Node A...\n");
+    if (!nodeB.connectPeer(peerIdA, addrsA, 5000).success) {
+        fprintf(stderr, "Failed to connect\n");
+        return 1;
+    }
+    printf("Connected!\n");
+
+```
+
+## Step 4: List connected peers
+
+We can verify the connection by listing connected peers on each node.
+The direction parameter `0` means "all connected peers".
+```cpp
+    auto peersA = nodeA.connectedPeers(0);
+    if (peersA.success) {
+        printf("\nNode A's connected peers:\n");
+        for (const auto& p : peersA.value) {
+            printf("  %s\n", p.get<std::string>().c_str());
+        }
+    }
+
+    auto peersB = nodeB.connectedPeers(0);
+    if (peersB.success) {
+        printf("Node B's connected peers:\n");
+        for (const auto& p : peersB.value) {
+            printf("  %s\n", p.get<std::string>().c_str());
+        }
+    }
+
+```
+
+## Step 5: Dial the ping protocol and exchange data
+
+Now let's use the Ping protocol — a simple built-in protocol where
+the client sends a payload and the server echoes it back.
+
+`dial()` opens a stream on the remote peer for a specific protocol.
+It returns the `streamId` we use for subsequent operations.
+```cpp
+    printf("\nDialing /ipfs/ping/1.0.0 on Node A...\n");
+    auto dialRes = nodeB.dial(peerIdA, "/ipfs/ping/1.0.0");
+    if (!dialRes.success) {
+        fprintf(stderr, "Dial failed: %s\n", dialRes.error.c_str());
+        return 1;
+    }
+
+    uint64_t streamId = dialRes.value.get<uint64_t>();
+    printf("Stream opened, id: %llu\n", (unsigned long long)streamId);
+
+```
+
+Write a 32-byte ping payload:
+```cpp
+    std::string payload(32, '\0');
+    for (int i = 0; i < 32; ++i) {
+        payload[i] = static_cast<char>(i);
+    }
+
+    printf("Sending %zu bytes...\n", payload.size());
+    if (!nodeB.streamWrite(streamId, payload).success) {
+        fprintf(stderr, "Write failed\n");
+        return 1;
+    }
+
+```
+
+Read the echo (32 bytes back):
+```cpp
+    auto readRes = nodeB.streamReadExactly(streamId, 32);
+    if (!readRes.success) {
+        fprintf(stderr, "Read failed: %s\n", readRes.error.c_str());
+        return 1;
+    }
+
+    std::string reply = readRes.value.get<std::string>();
+
+```
+
+Verify the echo matches:
+```cpp
+    if (reply == payload) {
+        printf("Ping successful — received matching echo back!\n");
+    } else {
+        fprintf(stderr, "Ping payload mismatch\n");
+        return 1;
+    }
+
+```
+
+## Step 6: Clean up the stream and nodes
+
+Always close and release streams when done:
+```cpp
+    nodeB.streamClose(streamId);
+    nodeB.streamRelease(streamId);
+
+    nodeA.stop();
+    nodeB.stop();
+
+    printf("\n=== Tutorial 3 Complete ===\n");
+    return 0;
+}
+```
+

--- a/tutorial/docs/tutorial_3_connecting_peers.md
+++ b/tutorial/docs/tutorial_3_connecting_peers.md
@@ -32,6 +32,9 @@ A stream must follow this lifecycle:
   5. `streamRelease()` — Free server-side resources
 ```cpp
 #include <cstdio>
+#include <cstdint>
+#include <string>
+#include <vector>
 #include "plugin.h"
 
 int main()
@@ -176,7 +179,7 @@ Read the echo (32 bytes back):
         return 1;
     }
 
-    std::string reply = readRes.value.get<std::string>();
+    std::string reply = base64Decode(readRes.value.get<std::string>());
 
 ```
 
@@ -202,7 +205,7 @@ Always close and release streams when done:
     nodeB.stop();
 
     printf("\n=== Tutorial 3 Complete ===\n");
-    
+
     return 0;
 }
 

--- a/tutorial/docs/tutorial_4_custom_protocol.md
+++ b/tutorial/docs/tutorial_4_custom_protocol.md
@@ -1,0 +1,249 @@
+# Tutorial 4: Custom Protocol Handlers
+
+In the [previous tutorial](tutorial_3_connecting_peers.md), we used the
+built-in Ping protocol to exchange data between peers. But real
+applications need their own protocols!
+
+This tutorial shows you how to mount a custom protocol on a node so
+that it can handle incoming streams from peers who dial that protocol.
+
+## How Custom Protocols Work
+
+A protocol in libp2p is identified by a **protocol ID string** — a
+`/`-separated path like `/myapp/chat/1.0.0`. When a remote peer dials
+this protocol ID, your node receives a new stream.
+
+To handle incoming streams you:
+  1. Call `mountProtocol()` to register a protocol ID
+  2. Set an `emitEvent` callback that listens for `"protocolStream"` events
+  3. Read from and write to the stream in the event handler
+
+The stream lifecycle on the server side is:
+  1. Receive `protocolStream` event with a `streamId`
+  2. Read data from the stream
+  3. Write data to the stream (optional)
+  4. Call `streamRelease()` when done with the stream
+
+> **Note**: Unlike the dialing side, the server side does **not** call
+> `streamClose()` — the peer that initiated the stream is responsible
+> for closing it.
+```cpp
+#include <cstdio>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include "plugin.h"
+
+using json = nlohmann::json;
+
+```
+
+## Defining our custom protocol
+
+We'll create an **echo protocol**: the server reads a length-prefixed
+message and echoes it back to the client. This is a common pattern
+for request-response protocols.
+
+```cpp
+const std::string kEchoProtocol = "/examples/echo/1.0.0";
+
+int main()
+{
+    printf("=== Tutorial 4: Custom Protocol Handlers ===\n\n");
+
+```
+
+## Step 1: Create and start two nodes
+```cpp
+    Libp2pModuleOptions optsA, optsB;
+    optsA.addrs = {"/ip4/127.0.0.1/tcp/9290"};
+    optsB.addrs = {"/ip4/127.0.0.1/tcp/9291"};
+
+    Libp2pModuleImpl nodeA(optsA);
+    Libp2pModuleImpl nodeB(optsB);
+
+    if (!nodeA.start().success) { fprintf(stderr, "Node A failed\n"); return 1; }
+    if (!nodeB.start().success) { fprintf(stderr, "Node B failed\n"); return 1; }
+    printf("Both nodes started\n");
+
+```
+
+## Step 2: Set up the protocol handler on Node A
+
+We define an `emitEvent` callback on Node A. Whenever a remote peer
+dials our protocol, a `"protocolStream"` event fires with a JSON
+payload containing the `streamId`.
+
+For simplicity, this example reads one message, echoes it, then
+releases the stream. A real application would likely spawn a
+background thread to handle concurrent streams.
+```cpp
+    struct ServerState {
+        std::mutex mtx;
+        std::condition_variable cv;
+        uint64_t streamId = 0;
+        bool ready = false;
+    };
+    ServerState server;
+
+    nodeA.emitEvent = [&](const std::string& name, const std::string& data) {
+        if (name != "protocolStream") return;
+
+        auto j = json::parse(data);
+        uint64_t sid = j["streamId"].get<uint64_t>();
+
+        {
+            std::lock_guard<std::mutex> lock(server.mtx);
+            server.streamId = sid;
+            server.ready = true;
+        }
+        server.cv.notify_one();
+    };
+
+```
+
+Register the echo protocol on Node A:
+```cpp
+    printf("Mounting protocol '%s' on Node A...\n", kEchoProtocol.c_str());
+    if (!nodeA.mountProtocol(kEchoProtocol).success) {
+        fprintf(stderr, "Failed to mount protocol\n");
+        return 1;
+    }
+
+```
+
+## Step 3: Get Node A's address and connect Node B
+```cpp
+    auto infoA = nodeA.peerInfo().value;
+    std::string peerIdA = infoA["peerId"].get<std::string>();
+    std::vector<std::string> addrsA;
+    for (const auto& a : infoA["addrs"])
+        addrsA.push_back(a.get<std::string>());
+
+    printf("Connecting Node B to Node A...\n");
+    if (!nodeB.connectPeer(peerIdA, addrsA, 5000).success) {
+        fprintf(stderr, "Failed to connect\n");
+        return 1;
+    }
+    printf("Connected\n");
+
+```
+
+## Step 4: Node B dials the echo protocol
+
+When Node B dials our custom protocol, Node A's protocol handler
+fires, and Node A receives a new stream.
+```cpp
+    printf("Node B dialing '%s'...\n", kEchoProtocol.c_str());
+    auto dialRes = nodeB.dial(peerIdA, kEchoProtocol);
+    if (!dialRes.success) {
+        fprintf(stderr, "Dial failed: %s\n", dialRes.error.c_str());
+        return 1;
+    }
+    uint64_t clientStreamId = dialRes.value.get<uint64_t>();
+    printf("Node B client stream id: %llu\n",
+           (unsigned long long)clientStreamId);
+
+```
+
+## Step 5: Wait for Node A to receive the stream
+```cpp
+    uint64_t serverStreamId = 0;
+    {
+        std::unique_lock<std::mutex> lock(server.mtx);
+        if (!server.cv.wait_for(lock, std::chrono::seconds(5),
+                                [&] { return server.ready; })) {
+            fprintf(stderr, "Timed out waiting for incoming stream\n");
+            return 1;
+        }
+        serverStreamId = server.streamId;
+    }
+    printf("Node A received stream id: %llu\n",
+           (unsigned long long)serverStreamId);
+
+```
+
+## Step 6: Node B sends a message
+```cpp
+    std::string message = "Hello from Node B!";
+    printf("Node B sending: \"%s\"\n", message.c_str());
+    if (!nodeB.streamWriteLp(clientStreamId, message).success) {
+        fprintf(stderr, "Write failed\n");
+        return 1;
+    }
+
+```
+
+## Step 7: Node A reads the message and echoes it back
+```cpp
+    auto readRes = nodeA.streamReadLp(serverStreamId, 4096);
+    if (!readRes.success) {
+        fprintf(stderr, "Node A read failed: %s\n",
+                readRes.error.c_str());
+        return 1;
+    }
+    std::string received = readRes.value.get<std::string>();
+    printf("Node A received: \"%s\"\n", received.c_str());
+
+```
+
+Echo it back:
+```cpp
+    if (!nodeA.streamWriteLp(serverStreamId, received).success) {
+        fprintf(stderr, "Node A echo write failed\n");
+        return 1;
+    }
+
+```
+
+## Step 8: Node B reads the echo
+```cpp
+    auto echoRes = nodeB.streamReadLp(clientStreamId, 4096);
+    if (!echoRes.success) {
+        fprintf(stderr, "Node B read echo failed: %s\n",
+                echoRes.error.c_str());
+        return 1;
+    }
+    std::string echo = echoRes.value.get<std::string>();
+    printf("Node B received echo: \"%s\"\n", echo.c_str());
+
+    if (echo != message) {
+        fprintf(stderr, "Echo mismatch! Got '%s'\n", echo.c_str());
+        return 1;
+    }
+    printf("Echo verified successfully!\n");
+
+```
+
+## Step 9: Clean up
+
+The client (dialing side) closes its stream with `streamCloseWithEOF()`
+to signal that it's done writing. Both sides release their stream
+resources with `streamRelease()`.
+```cpp
+    nodeB.streamCloseWithEOF(clientStreamId);
+    nodeB.streamRelease(clientStreamId);
+    nodeA.streamRelease(serverStreamId);
+
+    nodeA.stop();
+    nodeB.stop();
+
+    printf("\n=== Tutorial 4 Complete ===\n");
+
+```
+
+## Key Takeaways
+
+  - `mountProtocol()` registers a handler on the server side
+  - `emitEvent` with the `"protocolStream"` event delivers incoming streams
+  - The dialing side uses `streamClose()`/`streamCloseWithEOF()`
+  - The server side uses `streamRelease()` (no close)
+  - Use `streamWriteLp()` / `streamReadLp()` for length-prefixed messages
+
+In the [next tutorial](tutorial_5_kademlia_basics.md), we'll explore
+Kademlia DHT for distributed key-value storage.
+```cpp
+    return 0;
+}
+```
+

--- a/tutorial/docs/tutorial_4_custom_protocol.md
+++ b/tutorial/docs/tutorial_4_custom_protocol.md
@@ -245,6 +245,12 @@ resources with `streamRelease()`.
 
 ## Run tutorial
 
+Build the module (one time):
+```bash
+nix develop
+./tutorial/build_tutorials.sh
+```
+
 Run this tutorial:
 ```bash
 ./build/tutorial_4_custom_protocol

--- a/tutorial/docs/tutorial_4_custom_protocol.md
+++ b/tutorial/docs/tutorial_4_custom_protocol.md
@@ -229,7 +229,10 @@ resources with `streamRelease()`.
     nodeB.stop();
 
     printf("\n=== Tutorial 4 Complete ===\n");
-
+    
+    return 0;
+}
+    
 ```
 
 ## Key Takeaways
@@ -240,10 +243,12 @@ resources with `streamRelease()`.
   - The server side uses `streamRelease()` (no close)
   - Use `streamWriteLp()` / `streamReadLp()` for length-prefixed messages
 
-In the [next tutorial](tutorial_5_kademlia_basics.md), we'll explore
-Kademlia DHT for distributed key-value storage.
-```cpp
-    return 0;
-}
-```
+## Run tutorial
 
+Run this tutorial:
+```bash
+./build/tutorial_4_custom_protocol
+```
+---
+
+< [Connecting Peers and Exchanging Data](tutorial_3_connecting_peers.md) -- [Kademlia DHT Basics](tutorial_5_kademlia_basics.md) >

--- a/tutorial/docs/tutorial_4_custom_protocol.md
+++ b/tutorial/docs/tutorial_4_custom_protocol.md
@@ -248,16 +248,14 @@ resources with `streamRelease()`.
 
 ## Run tutorial
 
-Build the module (one time):
 ```bash
-nix develop
-./tutorial/build_tutorials.sh
-```
-
-Run this tutorial:
-```bash
-./build/tutorial_4_custom_protocol
+./build/tutorial/tutorial_4_custom_protocol
 ```
 ---
 
-< [Connecting Peers and Exchanging Data](tutorial_3_connecting_peers.md) -- [Kademlia DHT Basics](tutorial_5_kademlia_basics.md) >
+<table width="100%">
+  <tr>
+<td width="50%" align="left"><a href="tutorial_3_connecting_peers.md">&larr; Connecting Peers and Exchanging Data</a></td>
+<td width="50%" align="right"><a href="tutorial_5_kademlia_basics.md">Kademlia DHT Basics &rarr;</a></td>
+  </tr>
+</table>

--- a/tutorial/docs/tutorial_4_custom_protocol.md
+++ b/tutorial/docs/tutorial_4_custom_protocol.md
@@ -29,9 +29,12 @@ The stream lifecycle on the server side is:
 > for closing it.
 ```cpp
 #include <cstdio>
+#include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <mutex>
 #include <string>
+#include <vector>
 #include "plugin.h"
 
 using json = nlohmann::json;
@@ -182,7 +185,7 @@ fires, and Node A receives a new stream.
                 readRes.error.c_str());
         return 1;
     }
-    std::string received = readRes.value.get<std::string>();
+    std::string received = base64Decode(readRes.value.get<std::string>());
     printf("Node A received: \"%s\"\n", received.c_str());
 
 ```
@@ -204,7 +207,7 @@ Echo it back:
                 echoRes.error.c_str());
         return 1;
     }
-    std::string echo = echoRes.value.get<std::string>();
+    std::string echo = base64Decode(echoRes.value.get<std::string>());
     printf("Node B received echo: \"%s\"\n", echo.c_str());
 
     if (echo != message) {
@@ -229,10 +232,10 @@ resources with `streamRelease()`.
     nodeB.stop();
 
     printf("\n=== Tutorial 4 Complete ===\n");
-    
+
     return 0;
 }
-    
+
 ```
 
 ## Key Takeaways

--- a/tutorial/docs/tutorial_5_kademlia_basics.md
+++ b/tutorial/docs/tutorial_5_kademlia_basics.md
@@ -150,7 +150,7 @@ controls the consistency level:
 
     std::string received;
     if (getRes.value.is_string()) {
-        received = getRes.value.get<std::string>();
+        received = base64Decode(getRes.value.get<std::string>());
     }
 
     if (received.empty()) {
@@ -173,8 +173,8 @@ controls the consistency level:
     nodeB.stop();
 
     printf("\n=== Tutorial 5 Complete ===\n");
-    
-    return 0;    
+
+    return 0;
 }
 
 ```

--- a/tutorial/docs/tutorial_5_kademlia_basics.md
+++ b/tutorial/docs/tutorial_5_kademlia_basics.md
@@ -173,6 +173,9 @@ controls the consistency level:
     nodeB.stop();
 
     printf("\n=== Tutorial 5 Complete ===\n");
+    
+    return 0;    
+}
 
 ```
 
@@ -185,11 +188,12 @@ controls the consistency level:
   - `kadGetRandomRecords()` discovers random peers in the DHT
   - Values may take a moment to propagate after storing
 
-In the [next tutorial](tutorial_6_kademlia_providers.md), we'll
-explore provider records — a way to find which peers offer
-specific content.
-```cpp
-    return 0;
-}
-```
+## Run tutorial
 
+Run this tutorial:
+```bash
+./build/tutorial_5_kademlia_basics
+```
+---
+
+< [Custom Protocol Handlers](tutorial_4_custom_protocol.md) -- [Kademlia Provider Records](tutorial_6_kademlia_providers.md) >

--- a/tutorial/docs/tutorial_5_kademlia_basics.md
+++ b/tutorial/docs/tutorial_5_kademlia_basics.md
@@ -40,7 +40,7 @@ int main()
 
 ```
 
-## Step 1: Create three nodes
+## Step 1: Create two nodes
 
 We need at least two nodes to demonstrate DHT operations. In a
 real network, one node would be a well-known bootstrap peer.

--- a/tutorial/docs/tutorial_5_kademlia_basics.md
+++ b/tutorial/docs/tutorial_5_kademlia_basics.md
@@ -190,6 +190,12 @@ controls the consistency level:
 
 ## Run tutorial
 
+Build the module (one time):
+```bash
+nix develop
+./tutorial/build_tutorials.sh
+```
+
 Run this tutorial:
 ```bash
 ./build/tutorial_5_kademlia_basics

--- a/tutorial/docs/tutorial_5_kademlia_basics.md
+++ b/tutorial/docs/tutorial_5_kademlia_basics.md
@@ -1,0 +1,195 @@
+# Tutorial 5: Kademlia DHT Basics
+
+Kademlia is a Distributed Hash Table (DHT) that lets peers store and
+retrieve values without a central server. The `logos-libp2p-module`
+exposes this through the `kadPutValue()`, `kadGetValue()`, and
+`kadGetRandomRecords()` functions.
+
+In this tutorial we'll:
+  - Start two nodes that bootstrap to each other
+  - Store a value from one node
+  - Retrieve it from the other node
+  - List random records to verify DHT participation
+
+## How Kademlia works in libp2p
+
+Each node in the DHT maintains a routing table of peers closest to
+certain "keys" (hashes). When you call `kadPutValue(key, value)`:
+  1. The key is hashed and the node finds the closest peers in its
+     routing table
+  2. The value is sent to those peers for storage
+
+When you call `kadGetValue(key, quorum)`:
+  1. The key is hashed and closest peers are looked up
+  2. The value is requested from them
+  3. The quorum parameter controls how many responses are needed
+
+## Bootstrap nodes
+
+New nodes need at least one bootstrap peer to join the DHT. In this
+tutorial, Node A acts as the bootstrap for Node B.
+```cpp
+#include <cstdio>
+#include <string>
+#include <vector>
+#include "plugin.h"
+
+int main()
+{
+    printf("=== Tutorial 5: Kademlia DHT Basics ===\n\n");
+
+```
+
+## Step 1: Create three nodes
+
+We need at least two nodes to demonstrate DHT operations. In a
+real network, one node would be a well-known bootstrap peer.
+
+> **Important**: Kademlia is mounted by default (`mountKad: true`).
+> We explicitly enable it in our options.
+```cpp
+    Libp2pModuleOptions optsA, optsB;
+    optsA.addrs = {"/ip4/127.0.0.1/tcp/9390"};
+    optsA.mountKad = true;
+    // Node A is the bootstrap — no special config needed, just its address.
+
+    optsB.addrs = {"/ip4/127.0.0.1/tcp/9391"};
+    optsB.mountKad = true;
+    // We'll add Node A as bootstrap after we know its peer ID.
+
+    Libp2pModuleImpl nodeA(optsA);
+    printf("Starting Node A (bootstrap)...\n");
+    if (!nodeA.start().success) {
+        fprintf(stderr, "Node A failed to start\n");
+        return 1;
+    }
+
+    // Get Node A's peer info for bootstrapping Node B
+    auto infoA = nodeA.peerInfo().value;
+    std::string peerIdA = infoA["peerId"].get<std::string>();
+    std::vector<std::string> addrsA;
+    for (const auto& a : infoA["addrs"])
+        addrsA.push_back(a.get<std::string>());
+    printf("Node A peer ID: %s\n", peerIdA.c_str());
+
+    // Now create Node B with Node A as its bootstrap
+    Libp2pModuleOptions optsBFinal;
+    optsBFinal.addrs = {"/ip4/127.0.0.1/tcp/9391"};
+    optsBFinal.bootstrapNodes = {{peerIdA, addrsA}};
+    optsBFinal.mountKad = true;
+
+    Libp2pModuleImpl nodeB(optsBFinal);
+    printf("Starting Node B (with Node A as bootstrap)...\n");
+    if (!nodeB.start().success) {
+        fprintf(stderr, "Node B failed to start\n");
+        return 1;
+    }
+
+    // Connect Node B to Node A so they can participate in the DHT
+    printf("Connecting Node B to Node A...\n");
+    if (!nodeB.connectPeer(peerIdA, addrsA, 5000).success) {
+        fprintf(stderr, "Failed to connect\n");
+        return 1;
+    }
+    printf("Nodes connected\n");
+
+```
+
+## Step 2: Check initial DHT state
+
+Before we store anything, let's check what random records Node B
+can find. This helps verify that the DHT is working.
+```cpp
+    auto recordsRes = nodeB.kadGetRandomRecords();
+    if (recordsRes.success && recordsRes.value.is_array()) {
+        printf("Node B found %zu random records\n",
+               recordsRes.value.size());
+        for (const auto& rec : recordsRes.value) {
+            printf("  Peer: %s\n",
+                   rec["peerId"].get<std::string>().c_str());
+        }
+    }
+
+```
+
+## Step 3: Store a value in the DHT
+
+Node A puts a key-value pair into the DHT. The key is a string,
+and the value is also a string.
+```cpp
+    std::string key = "greeting";
+    std::string value = "Hello from the DHT!";
+
+    printf("\nNode A putting value into DHT...\n");
+    printf("  Key: \"%s\"\n", key.c_str());
+    printf("  Value: \"%s\"\n", value.c_str());
+
+    if (!nodeA.kadPutValue(key, value).success) {
+        fprintf(stderr, "PutValue failed\n");
+        return 1;
+    }
+    printf("Value stored!\n");
+
+```
+
+## Step 4: Retrieve the value from Node B
+
+Node B fetches the value from the DHT. The `quorum` parameter
+controls the consistency level:
+  - `0` = default (usually 1 response is enough)
+  - `1` = wait for at least 1 peer's response
+  - Higher values = more consistency, slower
+```cpp
+    printf("\nNode B fetching value from DHT...\n");
+    auto getRes = nodeB.kadGetValue(key, 1);
+    if (!getRes.success) {
+        fprintf(stderr, "GetValue failed: %s\n",
+                getRes.error.c_str());
+        return 1;
+    }
+
+    std::string received;
+    if (getRes.value.is_string()) {
+        received = getRes.value.get<std::string>();
+    }
+
+    if (received.empty()) {
+        printf("Node B did not find the value (may need more time)\n");
+    } else {
+        printf("Node B received: \"%s\"\n", received.c_str());
+        if (received == value) {
+            printf("Value matches!\n");
+        } else {
+            printf("Value mismatch (expected: \"%s\")\n",
+                   value.c_str());
+        }
+    }
+
+```
+
+## Step 5: Clean up
+```cpp
+    nodeA.stop();
+    nodeB.stop();
+
+    printf("\n=== Tutorial 5 Complete ===\n");
+
+```
+
+## Key Takeaways
+
+  - Kademlia DHT is enabled by default (`mountKad: true`)
+  - Bootstrap nodes help new peers join the DHT
+  - `kadPutValue(key, value)` stores a value
+  - `kadGetValue(key, quorum)` retrieves it
+  - `kadGetRandomRecords()` discovers random peers in the DHT
+  - Values may take a moment to propagate after storing
+
+In the [next tutorial](tutorial_6_kademlia_providers.md), we'll
+explore provider records — a way to find which peers offer
+specific content.
+```cpp
+    return 0;
+}
+```
+

--- a/tutorial/docs/tutorial_5_kademlia_basics.md
+++ b/tutorial/docs/tutorial_5_kademlia_basics.md
@@ -190,16 +190,14 @@ controls the consistency level:
 
 ## Run tutorial
 
-Build the module (one time):
 ```bash
-nix develop
-./tutorial/build_tutorials.sh
-```
-
-Run this tutorial:
-```bash
-./build/tutorial_5_kademlia_basics
+./build/tutorial/tutorial_5_kademlia_basics
 ```
 ---
 
-< [Custom Protocol Handlers](tutorial_4_custom_protocol.md) -- [Kademlia Provider Records](tutorial_6_kademlia_providers.md) >
+<table width="100%">
+  <tr>
+<td width="50%" align="left"><a href="tutorial_4_custom_protocol.md">&larr; Custom Protocol Handlers</a></td>
+<td width="50%" align="right"><a href="tutorial_6_kademlia_providers.md">Kademlia Provider Records &rarr;</a></td>
+  </tr>
+</table>

--- a/tutorial/docs/tutorial_6_kademlia_providers.md
+++ b/tutorial/docs/tutorial_6_kademlia_providers.md
@@ -169,6 +169,10 @@ When Node A no longer has the content, it can stop advertising.
 
     printf("\n=== Tutorial 6 Complete ===\n");
 
+    return 0;
+}
+
+
 ```
 
 ## Key Takeaways
@@ -179,10 +183,11 @@ When Node A no longer has the content, it can stop advertising.
   - `kadGetProviders()` discovers who has content
   - `kadFindNode()` finds peers in the DHT routing table
 
-In the [next tutorial](tutorial_7_gossipsub.md), we'll explore
-GossipSub for pub/sub messaging.
-```cpp
-    return 0;
-}
-```
+## Run tutorial
 
+Run this tutorial:
+```bash
+./build/tutorial_6_kademlia_providers
+---
+
+< [Kademlia DHT Basics](tutorial_5_kademlia_basics.md) -- [GossipSub – Pub/Sub Messaging](tutorial_7_gossipsub.md) >

--- a/tutorial/docs/tutorial_6_kademlia_providers.md
+++ b/tutorial/docs/tutorial_6_kademlia_providers.md
@@ -185,9 +185,16 @@ When Node A no longer has the content, it can stop advertising.
 
 ## Run tutorial
 
+Build the module (one time):
+```bash
+nix develop
+./tutorial/build_tutorials.sh
+```
+
 Run this tutorial:
 ```bash
 ./build/tutorial_6_kademlia_providers
+```
 ---
 
 < [Kademlia DHT Basics](tutorial_5_kademlia_basics.md) -- [GossipSub – Pub/Sub Messaging](tutorial_7_gossipsub.md) >

--- a/tutorial/docs/tutorial_6_kademlia_providers.md
+++ b/tutorial/docs/tutorial_6_kademlia_providers.md
@@ -181,16 +181,14 @@ When Node A no longer has the content, it can stop advertising.
 
 ## Run tutorial
 
-Build the module (one time):
 ```bash
-nix develop
-./tutorial/build_tutorials.sh
-```
-
-Run this tutorial:
-```bash
-./build/tutorial_6_kademlia_providers
+./build/tutorial/tutorial_6_kademlia_providers
 ```
 ---
 
-< [Kademlia DHT Basics](tutorial_5_kademlia_basics.md) -- [GossipSub – Pub/Sub Messaging](tutorial_7_gossipsub.md) >
+<table width="100%">
+  <tr>
+<td width="50%" align="left"><a href="tutorial_5_kademlia_basics.md">&larr; Kademlia DHT Basics</a></td>
+<td width="50%" align="right"><a href="tutorial_7_gossipsub.md">GossipSub – Pub/Sub Messaging &rarr;</a></td>
+  </tr>
+</table>

--- a/tutorial/docs/tutorial_6_kademlia_providers.md
+++ b/tutorial/docs/tutorial_6_kademlia_providers.md
@@ -76,7 +76,7 @@ int main()
 ## Step 2: Convert a content key to a CID
 
 The `toCid()` function takes a string and produces a CID (Content ID)
-that can be used with Kadmelia's provider API.
+that can be used with Kademlia's provider API.
 ```cpp
     std::string contentKey = "my-awesome-file.txt";
     printf("Converting \"%s\" to CID...\n", contentKey.c_str());

--- a/tutorial/docs/tutorial_6_kademlia_providers.md
+++ b/tutorial/docs/tutorial_6_kademlia_providers.md
@@ -45,7 +45,6 @@ int main()
     optsB.mountKad = true;
 
     Libp2pModuleImpl nodeA(optsA);
-    Libp2pModuleImpl nodeB(optsB);
 
     if (!nodeA.start().success) {
         fprintf(stderr, "Node A failed\n");
@@ -60,16 +59,13 @@ int main()
 
     // Bootstrap and connect Node B
     optsB.bootstrapNodes = {{peerIdA, addrsA}};
-    Libp2pModuleImpl nodeB_final(optsB);
-    // Moving to a fresh node... but nodeB was already created.
-    // Let's instead just connect after creating properly:
-    Libp2pModuleImpl nodeB_real(optsB);
-    if (!nodeB_real.start().success) {
+    Libp2pModuleImpl nodeB(optsB);
+    if (!nodeB.start().success) {
         fprintf(stderr, "Node B failed\n");
         return 1;
     }
 
-    if (!nodeB_real.connectPeer(peerIdA, addrsA, 5000).success) {
+    if (!nodeB.connectPeer(peerIdA, addrsA, 5000).success) {
         fprintf(stderr, "Failed to connect\n");
         return 1;
     }
@@ -113,7 +109,7 @@ This advertises to the DHT that Node A has this content.
 Node B queries the DHT to find who provides this CID.
 ```cpp
     printf("\nNode B looking up providers...\n");
-    auto provRes = nodeB_real.kadGetProviders(cid);
+    auto provRes = nodeB.kadGetProviders(cid);
     if (!provRes.success) {
         fprintf(stderr, "kadGetProviders failed: %s\n",
                 provRes.error.c_str());
@@ -139,7 +135,7 @@ We can also use `kadFindNode()` to locate a specific peer in the
 DHT routing table.
 ```cpp
     printf("\nNode B finding Node A in the DHT...\n");
-    auto findRes = nodeB_real.kadFindNode(peerIdA);
+    auto findRes = nodeB.kadFindNode(peerIdA);
     if (findRes.success && findRes.value.is_array()) {
         printf("Closest peers to Node A:\n");
         for (const auto& p : findRes.value) {
@@ -165,7 +161,7 @@ When Node A no longer has the content, it can stop advertising.
 ## Step 7: Clean up
 ```cpp
     nodeA.stop();
-    nodeB_real.stop();
+    nodeB.stop();
 
     printf("\n=== Tutorial 6 Complete ===\n");
 

--- a/tutorial/docs/tutorial_6_kademlia_providers.md
+++ b/tutorial/docs/tutorial_6_kademlia_providers.md
@@ -1,0 +1,188 @@
+# Tutorial 6: Kademlia Provider Records
+
+In the [previous tutorial](tutorial_5_kademlia_basics.md), we stored and
+retrieved raw key-value pairs in the DHT. But what if you want to
+advertise that your node **has** a piece of content, rather than
+storing the content itself?
+
+This is where **provider records** come in. Instead of putting a value
+directly, you announce that your node provides a given Content ID (CID),
+and other peers can discover who provides that content.
+
+## Provider Records vs Key-Value Store
+
+| Feature | Key-Value Store | Provider Records |
+|---------|----------------|------------------|
+| What's stored | The value itself | The list of provider peer IDs |
+| Use case | Small configs, peer info | File sharing, content discovery |
+| Data size | Unlimited (but impractical for large data) | Metadata only |
+| Finding | `kadGetValue(key)` | `kadGetProviders(cid)` |
+
+## Content IDs (CIDs)
+
+CIDs are self-describing content hashes used in IPFS and IPLD. The
+`toCid()` function converts a string key into a CID that can be used
+with the provider API.
+```cpp
+#include <cstdio>
+#include <string>
+#include <vector>
+#include "plugin.h"
+
+int main()
+{
+    printf("=== Tutorial 6: Kademlia Provider Records ===\n\n");
+
+```
+
+## Step 1: Create two peers
+```cpp
+    Libp2pModuleOptions optsA, optsB;
+    optsA.addrs = {"/ip4/127.0.0.1/tcp/9490"};
+    optsA.mountKad = true;
+
+    optsB.addrs = {"/ip4/127.0.0.1/tcp/9491"};
+    optsB.mountKad = true;
+
+    Libp2pModuleImpl nodeA(optsA);
+    Libp2pModuleImpl nodeB(optsB);
+
+    if (!nodeA.start().success) {
+        fprintf(stderr, "Node A failed\n");
+        return 1;
+    }
+
+    auto infoA = nodeA.peerInfo().value;
+    std::string peerIdA = infoA["peerId"].get<std::string>();
+    std::vector<std::string> addrsA;
+    for (const auto& a : infoA["addrs"])
+        addrsA.push_back(a.get<std::string>());
+
+    // Bootstrap and connect Node B
+    optsB.bootstrapNodes = {{peerIdA, addrsA}};
+    Libp2pModuleImpl nodeB_final(optsB);
+    // Moving to a fresh node... but nodeB was already created.
+    // Let's instead just connect after creating properly:
+    Libp2pModuleImpl nodeB_real(optsB);
+    if (!nodeB_real.start().success) {
+        fprintf(stderr, "Node B failed\n");
+        return 1;
+    }
+
+    if (!nodeB_real.connectPeer(peerIdA, addrsA, 5000).success) {
+        fprintf(stderr, "Failed to connect\n");
+        return 1;
+    }
+    printf("Nodes connected\n");
+
+```
+
+## Step 2: Convert a content key to a CID
+
+The `toCid()` function takes a string and produces a CID (Content ID)
+that can be used with Kadmelia's provider API.
+```cpp
+    std::string contentKey = "my-awesome-file.txt";
+    printf("Converting \"%s\" to CID...\n", contentKey.c_str());
+    auto cidRes = nodeA.toCid(contentKey);
+    if (!cidRes.success) {
+        fprintf(stderr, "Failed to create CID: %s\n",
+                cidRes.error.c_str());
+        return 1;
+    }
+    std::string cid = cidRes.value.get<std::string>();
+    printf("CID: %s\n", cid.c_str());
+
+```
+
+## Step 3: Node A starts providing the CID
+
+This advertises to the DHT that Node A has this content.
+```cpp
+    printf("\nNode A starting to provide CID...\n");
+    if (!nodeA.kadStartProviding(cid).success) {
+        fprintf(stderr, "kadStartProviding failed\n");
+        return 1;
+    }
+    printf("Node A is now a provider for: %s\n", cid.c_str());
+
+```
+
+## Step 4: Node B discovers providers
+
+Node B queries the DHT to find who provides this CID.
+```cpp
+    printf("\nNode B looking up providers...\n");
+    auto provRes = nodeB_real.kadGetProviders(cid);
+    if (!provRes.success) {
+        fprintf(stderr, "kadGetProviders failed: %s\n",
+                provRes.error.c_str());
+        return 1;
+    }
+
+    auto providers = provRes.value;
+    printf("Node B found %zu provider(s):\n", providers.size());
+    for (const auto& p : providers) {
+        printf("  Peer: %s\n",
+               p["peerId"].get<std::string>().c_str());
+        for (const auto& addr : p["addrs"]) {
+            printf("    Address: %s\n",
+                   addr.get<std::string>().c_str());
+        }
+    }
+
+```
+
+## Step 5: Find a specific node in the DHT
+
+We can also use `kadFindNode()` to locate a specific peer in the
+DHT routing table.
+```cpp
+    printf("\nNode B finding Node A in the DHT...\n");
+    auto findRes = nodeB_real.kadFindNode(peerIdA);
+    if (findRes.success && findRes.value.is_array()) {
+        printf("Closest peers to Node A:\n");
+        for (const auto& p : findRes.value) {
+            printf("  %s\n", p.get<std::string>().c_str());
+        }
+    }
+
+```
+
+## Step 6: Stop providing
+
+When Node A no longer has the content, it can stop advertising.
+```cpp
+    printf("\nNode A stopping providing...\n");
+    if (!nodeA.kadStopProviding(cid).success) {
+        fprintf(stderr, "kadStopProviding failed\n");
+        return 1;
+    }
+    printf("Node A stopped providing %s\n", cid.c_str());
+
+```
+
+## Step 7: Clean up
+```cpp
+    nodeA.stop();
+    nodeB_real.stop();
+
+    printf("\n=== Tutorial 6 Complete ===\n");
+
+```
+
+## Key Takeaways
+
+  - Provider records advertise **content availability**, not content itself
+  - `toCid()` converts a key string to a CID for use with provider API
+  - `kadStartProviding()` / `kadStopProviding()` manage provider announcements
+  - `kadGetProviders()` discovers who has content
+  - `kadFindNode()` finds peers in the DHT routing table
+
+In the [next tutorial](tutorial_7_gossipsub.md), we'll explore
+GossipSub for pub/sub messaging.
+```cpp
+    return 0;
+}
+```
+

--- a/tutorial/docs/tutorial_7_gossipsub.md
+++ b/tutorial/docs/tutorial_7_gossipsub.md
@@ -217,9 +217,16 @@ for event-driven applications.
 
 ## Run tutorial
 
+Build the module (one time):
+```bash
+nix develop
+./tutorial/build_tutorials.sh
+```
+
 Run this tutorial:
 ```bash
 ./build/tutorial_7_gossipsub
+```
 ---
 
 < [Kademlia Provider Records](tutorial_6_kademlia_providers.md) -- [Service Discovery](tutorial_8_service_discovery.md) >

--- a/tutorial/docs/tutorial_7_gossipsub.md
+++ b/tutorial/docs/tutorial_7_gossipsub.md
@@ -160,9 +160,9 @@ for event-driven applications.
 ```cpp
     printf("\n--- Alternative: Event-driven reception ---\n");
 
+    std::mutex eventMtx;
     bool messageReceived = false;
     std::string eventMessage;
-
     nodeA.emitEvent = [&](const std::string& name,
                           const std::string& data) {
         if (name == "gossipsubMessage") {
@@ -171,8 +171,11 @@ for event-driven applications.
             std::string msg = j["data"].get<std::string>();
             printf("Node A (event): received on topic \"%s\": \"%s\"\n",
                    eventTopic.c_str(), msg.c_str());
-            messageReceived = true;
-            eventMessage = msg;
+            {
+                std::lock_guard<std::mutex> lock(eventMtx);
+                messageReceived = true;
+                eventMessage = msg;
+            }
         }
     };
 
@@ -183,9 +186,17 @@ for event-driven applications.
     // Give it a moment to arrive
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
-    if (messageReceived) {
+    bool received = false;
+    std::string msgCopy;
+    {
+        std::lock_guard<std::mutex> lock(eventMtx);
+        received = messageReceived;
+        msgCopy = eventMessage;
+    }
+
+    if (received) {
         printf("Event-driven reception worked: \"%s\"\n",
-               eventMessage.c_str());
+               msgCopy.c_str());
     }
 
 ```

--- a/tutorial/docs/tutorial_7_gossipsub.md
+++ b/tutorial/docs/tutorial_7_gossipsub.md
@@ -200,6 +200,9 @@ for event-driven applications.
     nodeB.stop();
 
     printf("\n=== Tutorial 7 Complete ===\n");
+    
+    return 0;
+}
 
 ```
 
@@ -212,11 +215,11 @@ for event-driven applications.
   - Use `emitEvent` for event-driven message reception
   - Always unsubscribe and stop cleanly
 
-In the [next tutorial](tutorial_8_service_discovery.md), we'll
-learn how peers can discover each other by capability using the
-service discovery API.
-```cpp
-    return 0;
-}
-```
+## Run tutorial
 
+Run this tutorial:
+```bash
+./build/tutorial_7_gossipsub
+---
+
+< [Kademlia Provider Records](tutorial_6_kademlia_providers.md) -- [Service Discovery](tutorial_8_service_discovery.md) >

--- a/tutorial/docs/tutorial_7_gossipsub.md
+++ b/tutorial/docs/tutorial_7_gossipsub.md
@@ -24,8 +24,10 @@ In this tutorial we'll:
 ```cpp
 #include <cstdio>
 #include <chrono>
+#include <mutex>
 #include <thread>
 #include <string>
+#include <vector>
 #include "plugin.h"
 
 int main()
@@ -186,15 +188,15 @@ for event-driven applications.
     // Give it a moment to arrive
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
-    bool received = false;
+    bool eventReceived = false;
     std::string msgCopy;
     {
         std::lock_guard<std::mutex> lock(eventMtx);
-        received = messageReceived;
+        eventReceived = messageReceived;
         msgCopy = eventMessage;
     }
 
-    if (received) {
+    if (eventReceived) {
         printf("Event-driven reception worked: \"%s\"\n",
                msgCopy.c_str());
     }
@@ -211,7 +213,7 @@ for event-driven applications.
     nodeB.stop();
 
     printf("\n=== Tutorial 7 Complete ===\n");
-    
+
     return 0;
 }
 

--- a/tutorial/docs/tutorial_7_gossipsub.md
+++ b/tutorial/docs/tutorial_7_gossipsub.md
@@ -1,0 +1,222 @@
+# Tutorial 7: GossipSub – Pub/Sub Messaging
+
+GossipSub is a pub/sub protocol that lets peers broadcast messages to
+everyone subscribed to a topic. It's the foundation for many
+decentralized applications — from chat rooms to blockchain transaction
+propagation.
+
+In this tutorial we'll:
+  - Subscribe two nodes to the same topic
+  - Wait for the GossipSub mesh to form
+  - Publish a message from one node
+  - Receive it on the other node
+
+## How GossipSub Works
+
+1. Peers subscribe to topics by calling `gossipsubSubscribe(topic)`
+2. libp2p builds a **mesh** — a set of peer connections per topic
+3. When a peer publishes to a topic, the message is forwarded through
+   the mesh to all subscribers
+4. Subscribers receive messages via `gossipsubNextMessage(topic, timeout)`
+
+> **Note**: The GossipSub mesh takes some time to form after both
+> peers have subscribed. A short delay (1-2 seconds) is usually enough.
+```cpp
+#include <cstdio>
+#include <chrono>
+#include <thread>
+#include <string>
+#include "plugin.h"
+
+int main()
+{
+    printf("=== Tutorial 7: GossipSub – Pub/Sub Messaging ===\n\n");
+
+```
+
+## Step 1: Create two nodes with GossipSub enabled
+
+GossipSub is enabled by default (`mountGossipsub: true`).
+We keep it explicit here for clarity.
+```cpp
+    Libp2pModuleOptions optsA, optsB;
+    optsA.addrs = {"/ip4/127.0.0.1/tcp/9590"};
+    optsA.mountGossipsub = true;
+
+    optsB.addrs = {"/ip4/127.0.0.1/tcp/9591"};
+    optsB.mountGossipsub = true;
+
+    Libp2pModuleImpl nodeA(optsA);
+    Libp2pModuleImpl nodeB(optsB);
+
+    if (!nodeA.start().success) {
+        fprintf(stderr, "Node A failed\n");
+        return 1;
+    }
+    if (!nodeB.start().success) {
+        fprintf(stderr, "Node B failed\n");
+        return 1;
+    }
+    printf("Both nodes started\n");
+
+```
+
+## Step 2: Connect the nodes
+
+GossipSub needs connectivity between peers to build the mesh.
+```cpp
+    auto infoA = nodeA.peerInfo().value;
+    std::string peerIdA = infoA["peerId"].get<std::string>();
+    std::vector<std::string> addrsA;
+    for (const auto& a : infoA["addrs"])
+        addrsA.push_back(a.get<std::string>());
+
+    printf("Connecting Node B to Node A...\n");
+    if (!nodeB.connectPeer(peerIdA, addrsA, 5000).success) {
+        fprintf(stderr, "Failed to connect\n");
+        return 1;
+    }
+    printf("Connected\n");
+
+```
+
+## Step 3: Both nodes subscribe to a topic
+
+A topic is just a string identifier. Peers who subscribe to the
+same topic will receive each other's messages.
+```cpp
+    std::string topic = "chat-room-1";
+    printf("Node B subscribing to topic: \"%s\"\n", topic.c_str());
+    if (!nodeB.gossipsubSubscribe(topic).success) {
+        fprintf(stderr, "Node B subscribe failed\n");
+        return 1;
+    }
+
+    printf("Node A subscribing to topic: \"%s\"\n", topic.c_str());
+    if (!nodeA.gossipsubSubscribe(topic).success) {
+        fprintf(stderr, "Node A subscribe failed\n");
+        return 1;
+    }
+
+```
+
+## Step 4: Wait for the GossipSub mesh to form
+
+After subscribing, libp2p needs time to discover subscribers
+and build the message-forwarding mesh.
+```cpp
+    printf("Waiting for GossipSub mesh to form...\n");
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+
+```
+
+## Step 5: Publish a message
+
+Node A publishes a message to the topic. It will be forwarded
+to all subscribers (including Node B).
+```cpp
+    std::string payload = "Hello from Node A via GossipSub!";
+    printf("\nNode A publishing: \"%s\"\n", payload.c_str());
+    printf("  Topic: \"%s\"\n", topic.c_str());
+
+    if (!nodeA.gossipsubPublish(topic, payload).success) {
+        fprintf(stderr, "Publish failed\n");
+        return 1;
+    }
+    printf("Message published!\n");
+
+```
+
+## Step 6: Receive the message on Node B
+
+`gossipsubNextMessage()` blocks until a message arrives or the
+timeout expires. The timeout is in milliseconds.
+```cpp
+    printf("\nNode B waiting for message...\n");
+    auto res = nodeB.gossipsubNextMessage(topic, 3000);
+    if (!res.success) {
+        fprintf(stderr, "Node B did not receive any messages: %s\n",
+                res.error.c_str());
+        return 1;
+    }
+
+    std::string received = res.value.get<std::string>();
+    printf("Node B received: \"%s\"\n", received.c_str());
+
+    if (received == payload) {
+        printf("Message verified!\n");
+    } else {
+        printf("Message content differs (expected: \"%s\")\n",
+               payload.c_str());
+    }
+
+```
+
+## Step 7: Alternative — listen via event callback
+
+Instead of polling with `gossipsubNextMessage()`, you can listen
+for the `"gossipsubMessage"` event via `emitEvent`. This is useful
+for event-driven applications.
+```cpp
+    printf("\n--- Alternative: Event-driven reception ---\n");
+
+    bool messageReceived = false;
+    std::string eventMessage;
+
+    nodeA.emitEvent = [&](const std::string& name,
+                          const std::string& data) {
+        if (name == "gossipsubMessage") {
+            auto j = nlohmann::json::parse(data);
+            std::string eventTopic = j["topic"].get<std::string>();
+            std::string msg = j["data"].get<std::string>();
+            printf("Node A (event): received on topic \"%s\": \"%s\"\n",
+                   eventTopic.c_str(), msg.c_str());
+            messageReceived = true;
+            eventMessage = msg;
+        }
+    };
+
+    // Publish another message
+    std::string payload2 = "Second message via event!";
+    nodeB.gossipsubPublish(topic, payload2);
+
+    // Give it a moment to arrive
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    if (messageReceived) {
+        printf("Event-driven reception worked: \"%s\"\n",
+               eventMessage.c_str());
+    }
+
+```
+
+## Step 8: Unsubscribe and clean up
+```cpp
+    printf("\nUnsubscribing...\n");
+    nodeB.gossipsubUnsubscribe(topic);
+    nodeA.gossipsubUnsubscribe(topic);
+
+    nodeA.stop();
+    nodeB.stop();
+
+    printf("\n=== Tutorial 7 Complete ===\n");
+
+```
+
+## Key Takeaways
+
+  - GossipSub provides topic-based pub/sub messaging
+  - Both publisher and subscriber must subscribe to the topic
+  - Allow 1-2 seconds for the mesh to form
+  - Use `gossipsubNextMessage(topic, timeout)` for polling
+  - Use `emitEvent` for event-driven message reception
+  - Always unsubscribe and stop cleanly
+
+In the [next tutorial](tutorial_8_service_discovery.md), we'll
+learn how peers can discover each other by capability using the
+service discovery API.
+```cpp
+    return 0;
+}
+```
+

--- a/tutorial/docs/tutorial_7_gossipsub.md
+++ b/tutorial/docs/tutorial_7_gossipsub.md
@@ -230,16 +230,14 @@ for event-driven applications.
 
 ## Run tutorial
 
-Build the module (one time):
 ```bash
-nix develop
-./tutorial/build_tutorials.sh
-```
-
-Run this tutorial:
-```bash
-./build/tutorial_7_gossipsub
+./build/tutorial/tutorial_7_gossipsub
 ```
 ---
 
-< [Kademlia Provider Records](tutorial_6_kademlia_providers.md) -- [Service Discovery](tutorial_8_service_discovery.md) >
+<table width="100%">
+  <tr>
+<td width="50%" align="left"><a href="tutorial_6_kademlia_providers.md">&larr; Kademlia Provider Records</a></td>
+<td width="50%" align="right"><a href="tutorial_8_service_discovery.md">Service Discovery &rarr;</a></td>
+  </tr>
+</table>

--- a/tutorial/docs/tutorial_8_service_discovery.md
+++ b/tutorial/docs/tutorial_8_service_discovery.md
@@ -294,16 +294,14 @@ side channels.
 
 ## Run tutorial
 
-Build the module (one time):
 ```bash
-nix develop
-./tutorial/build_tutorials.sh
-```
-
-Run this tutorial:
-```bash
-./build/tutorial_8_service_discovery
+./build/tutorial/tutorial_8_service_discovery
 ```
 ---
 
-< [GossipSub – Pub/Sub Messaging](tutorial_7_gossipsub.md) -- [Peer Store Management](tutorial_9_peerstore.md) >
+<table width="100%">
+  <tr>
+<td width="50%" align="left"><a href="tutorial_7_gossipsub.md">&larr; GossipSub – Pub/Sub Messaging</a></td>
+<td width="50%" align="right"><a href="tutorial_9_peerstore.md">Peer Store Management &rarr;</a></td>
+  </tr>
+</table>

--- a/tutorial/docs/tutorial_8_service_discovery.md
+++ b/tutorial/docs/tutorial_8_service_discovery.md
@@ -276,6 +276,10 @@ side channels.
 
     printf("\n=== Tutorial 8 Complete ===\n");
 
+    return 0;
+}
+
+
 ```
 
 ## Key Takeaways
@@ -288,10 +292,12 @@ side channels.
   - `discoRandomLookup()` discovers random peers
   - `createXpr()` / `decodeXpr()` work with signed peer records
 
-In the [next tutorial](tutorial_9_peerstore.md), we'll learn how
-to manage known peers in the peer store.
-```cpp
-    return 0;
-}
-```
+## Run tutorial
 
+Run this tutorial:
+```bash
+./build/tutorial_8_service_discovery
+```
+---
+
+< [GossipSub – Pub/Sub Messaging](tutorial_7_gossipsub.md) -- [Peer Store Management](tutorial_9_peerstore.md) >

--- a/tutorial/docs/tutorial_8_service_discovery.md
+++ b/tutorial/docs/tutorial_8_service_discovery.md
@@ -1,0 +1,297 @@
+# Tutorial 8: Service Discovery
+
+In decentralized networks, peers join and leave dynamically. How do you
+find a peer that offers a specific service? That's what **Service
+Discovery** (Disco) is for.
+
+Service Discovery lets peers:
+  - **Advertise** the services they offer
+  - **Discover** peers offering services they're interested in
+  - **Register interest** to be notified when new providers appear
+  - **Query randomly** to discover the network
+
+## Architecture
+
+Service Discovery uses a **bootstrap node** as a rendezvous point.
+All peers connect to the bootstrap and register their services there.
+Looking up a service queries the bootstrap, which returns matching peers.
+
+```
+    Bootstrap
+    /       \
+  Advertiser  Discoverer
+```
+```cpp
+#include <cstdio>
+#include <chrono>
+#include <thread>
+#include <string>
+#include <vector>
+#include <utility>
+#include "plugin.h"
+
+```
+
+Helper to extract peer info from a node:
+```cpp
+static std::pair<std::string, std::vector<std::string>> getPeerInfo(
+    Libp2pModuleImpl& node)
+{
+    auto info = node.peerInfo().value;
+    std::string peerId = info["peerId"].get<std::string>();
+    std::vector<std::string> addrs;
+    for (const auto& a : info["addrs"])
+        addrs.push_back(a.get<std::string>());
+    return {peerId, addrs};
+}
+
+```
+
+Helper to retry a lookup with backoff:
+```cpp
+static nlohmann::json lookupWithRetry(
+    Libp2pModuleImpl& node,
+    const std::string& serviceId,
+    const std::string& serviceData,
+    int attempts,
+    int delayMs)
+{
+    for (int i = 0; i < attempts; ++i) {
+        auto res = node.discoLookup(serviceId, serviceData);
+        if (res.success && res.value.is_array() && !res.value.empty()) {
+            return res.value;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
+    }
+    return nlohmann::json::array();
+}
+
+int main()
+{
+    printf("=== Tutorial 8: Service Discovery ===\n\n");
+
+```
+
+## Step 1: Create a bootstrap node
+
+The bootstrap is a well-known node that all peers connect to.
+It relays service advertisements and lookup queries.
+```cpp
+    Libp2pModuleOptions optsBootstrap;
+    optsBootstrap.addrs = {"/ip4/127.0.0.1/tcp/9690"};
+    optsBootstrap.mountServiceDiscovery = true;
+
+    Libp2pModuleImpl bootstrap(optsBootstrap);
+    if (!bootstrap.start().success) {
+        fprintf(stderr, "Bootstrap failed\n");
+        return 1;
+    }
+    if (!bootstrap.discoStart().success) {
+        fprintf(stderr, "Bootstrap discoStart failed\n");
+        return 1;
+    }
+
+    auto [bootstrapId, bootstrapAddrs] = getPeerInfo(bootstrap);
+    printf("Bootstrap node started: %s\n", bootstrapId.c_str());
+
+```
+
+## Step 2: Create an advertiser node
+
+This node will advertise a service that others can discover.
+```cpp
+    Libp2pModuleOptions optsAdvertiser;
+    optsAdvertiser.addrs = {"/ip4/127.0.0.1/tcp/9691"};
+    optsAdvertiser.bootstrapNodes = {{bootstrapId, bootstrapAddrs}};
+    optsAdvertiser.mountServiceDiscovery = true;
+
+    Libp2pModuleImpl advertiser(optsAdvertiser);
+    if (!advertiser.start().success) {
+        fprintf(stderr, "Advertiser failed\n");
+        return 1;
+    }
+    if (!advertiser.discoStart().success) {
+        fprintf(stderr, "Advertiser discoStart failed\n");
+        return 1;
+    }
+
+    // Connect to bootstrap
+    if (!advertiser.connectPeer(bootstrapId, bootstrapAddrs, 5000).success) {
+        fprintf(stderr, "Advertiser failed to connect to bootstrap\n");
+        return 1;
+    }
+    printf("Advertiser connected to bootstrap\n");
+
+```
+
+## Step 3: Create a discoverer node
+```cpp
+    Libp2pModuleOptions optsDiscoverer;
+    optsDiscoverer.addrs = {"/ip4/127.0.0.1/tcp/9692"};
+    optsDiscoverer.bootstrapNodes = {{bootstrapId, bootstrapAddrs}};
+    optsDiscoverer.mountServiceDiscovery = true;
+
+    Libp2pModuleImpl discoverer(optsDiscoverer);
+    if (!discoverer.start().success) {
+        fprintf(stderr, "Discoverer failed\n");
+        return 1;
+    }
+    if (!discoverer.discoStart().success) {
+        fprintf(stderr, "Discoverer discoStart failed\n");
+        return 1;
+    }
+
+    if (!discoverer.connectPeer(bootstrapId, bootstrapAddrs, 5000).success) {
+        fprintf(stderr, "Discoverer failed to connect to bootstrap\n");
+        return 1;
+    }
+    printf("Discoverer connected to bootstrap\n");
+
+```
+
+## Step 4: The advertiser starts advertising a service
+
+Services are identified by a service ID (string) and can carry
+arbitrary data (also a string).
+```cpp
+    std::string serviceId = "demo-chat-service";
+    std::string serviceData = "version=1.0;capacity=100";
+
+    printf("\nAdvertiser advertising: \"%s\"\n", serviceId.c_str());
+    if (!advertiser.discoStartAdvertising(serviceId, serviceData).success) {
+        fprintf(stderr, "discoStartAdvertising failed\n");
+        return 1;
+    }
+    printf("Advertising started\n");
+
+```
+
+## Step 5: The discoverer registers interest
+
+Registering interest tells the service discovery system that
+this peer wants to know about providers of this service.
+```cpp
+    printf("Discoverer registering interest in \"%s\"\n", serviceId.c_str());
+    if (!discoverer.discoRegisterInterest(serviceId).success) {
+        fprintf(stderr, "discoRegisterInterest failed\n");
+        return 1;
+    }
+
+```
+
+## Step 6: Discoverer looks up the service
+
+The lookup queries the bootstrap for peers advertising this
+service. It may take a moment for the advertisement to propagate.
+```cpp
+    printf("Discoverer looking up \"%s\"...\n", serviceId.c_str());
+
+    constexpr int kLookupAttempts = 10;
+    constexpr int kLookupDelayMs = 500;
+    auto records = lookupWithRetry(
+        discoverer, serviceId, serviceData,
+        kLookupAttempts, kLookupDelayMs);
+
+    printf("Discoverer found %zu provider(s):\n", records.size());
+    for (const auto& rec : records) {
+        printf("  Peer: %s\n",
+               rec["peerId"].get<std::string>().c_str());
+        for (const auto& s : rec["services"]) {
+            printf("    Service: %s (data: %s)\n",
+                   s["id"].get<std::string>().c_str(),
+                   s["data"].get<std::string>().c_str());
+        }
+    }
+
+```
+
+## Step 7: Random lookup
+
+You can also discover random peers via `discoRandomLookup()`,
+which is useful for network exploration.
+```cpp
+    printf("\nRandom lookup by advertiser...\n");
+    auto randomRes = advertiser.discoRandomLookup();
+    if (randomRes.success && randomRes.value.is_array()) {
+        printf("Found %zu random peer(s):\n", randomRes.value.size());
+        for (const auto& rec : randomRes.value) {
+            printf("  Peer: %s\n",
+                   rec["peerId"].get<std::string>().c_str());
+        }
+    }
+
+```
+
+## Step 8: Creating and decoding Extended Peer Records (XPR)
+
+Extended Peer Records are signed records that bundle a peer's
+addresses and services. They can be shared offline or via
+side channels.
+```cpp
+    printf("\n--- Extended Peer Records ---\n");
+
+    std::vector<std::pair<std::string, std::string>> xprServices = {
+        {serviceId, serviceData},
+        {"file-sharing", "v2"},
+    };
+
+    auto xpr = advertiser.createXpr({}, xprServices, 0);
+    if (!xpr.success) {
+        printf("Failed to create XPR: %s\n", xpr.error.c_str());
+    } else {
+        std::string xprStr = xpr.value.get<std::string>();
+        printf("Created signed XPR: %zu bytes\n", xprStr.size());
+
+        // Decode it to verify
+        auto decoded = advertiser.decodeXpr(xprStr);
+        if (!decoded.success) {
+            printf("Failed to decode XPR: %s\n", decoded.error.c_str());
+        } else {
+            printf("Decoded XPR:\n");
+            printf("  Peer ID: %s\n",
+                   decoded.value["peerId"].get<std::string>().c_str());
+            printf("  Sequence: %llu\n",
+                   (unsigned long long)decoded.value["seqNo"]
+                       .get<uint64_t>());
+            printf("  Services: %zu\n",
+                   decoded.value["services"].size());
+        }
+    }
+
+```
+
+## Step 9: Clean up — unregister, stop advertising, stop disco
+```cpp
+    printf("\nCleaning up...\n");
+    discoverer.discoUnregisterInterest(serviceId);
+    advertiser.discoStopAdvertising(serviceId);
+
+    discoverer.discoStop();
+    advertiser.discoStop();
+    bootstrap.discoStop();
+
+    discoverer.stop();
+    advertiser.stop();
+    bootstrap.stop();
+
+    printf("\n=== Tutorial 8 Complete ===\n");
+
+```
+
+## Key Takeaways
+
+  - Service Discovery requires a bootstrap node as rendezvous
+  - `discoStart()` / `discoStop()` control the discovery service
+  - `discoStartAdvertising()` / `discoStopAdvertising()` manage ads
+  - `discoRegisterInterest()` / `discoUnregisterInterest()` manage subscriptions
+  - `discoLookup()` finds peers offering a service
+  - `discoRandomLookup()` discovers random peers
+  - `createXpr()` / `decodeXpr()` work with signed peer records
+
+In the [next tutorial](tutorial_9_peerstore.md), we'll learn how
+to manage known peers in the peer store.
+```cpp
+    return 0;
+}
+```
+

--- a/tutorial/docs/tutorial_8_service_discovery.md
+++ b/tutorial/docs/tutorial_8_service_discovery.md
@@ -294,6 +294,12 @@ side channels.
 
 ## Run tutorial
 
+Build the module (one time):
+```bash
+nix develop
+./tutorial/build_tutorials.sh
+```
+
 Run this tutorial:
 ```bash
 ./build/tutorial_8_service_discovery

--- a/tutorial/docs/tutorial_9_peerstore.md
+++ b/tutorial/docs/tutorial_9_peerstore.md
@@ -192,6 +192,9 @@ Verify deletion:
 
     printf("\n=== Tutorial 9 Complete ===\n");
 
+    return 0;
+}
+
 ```
 
 ## Key Takeaways
@@ -206,10 +209,12 @@ Verify deletion:
   - A populated peer store speeds up reconnection and reduces
     network overhead
 
-In the [next tutorial](tutorial_10_circuit_relay.md), we'll learn
-how to connect peers behind NAT/firewalls using Circuit Relay.
-```cpp
-    return 0;
-}
-```
+## Run tutorial
 
+Run this tutorial:
+```bash
+./build/tutorial_9_peerstore
+```
+---
+
+< [Service Discovery](tutorial_8_service_discovery.md) -- [Circuit Relay – Connecting Through Firewalls](tutorial_10_circuit_relay.md) >

--- a/tutorial/docs/tutorial_9_peerstore.md
+++ b/tutorial/docs/tutorial_9_peerstore.md
@@ -211,6 +211,12 @@ Verify deletion:
 
 ## Run tutorial
 
+Build the module (one time):
+```bash
+nix develop
+./tutorial/build_tutorials.sh
+```
+
 Run this tutorial:
 ```bash
 ./build/tutorial_9_peerstore

--- a/tutorial/docs/tutorial_9_peerstore.md
+++ b/tutorial/docs/tutorial_9_peerstore.md
@@ -1,0 +1,215 @@
+# Tutorial 9: Peer Store Management
+
+The **peer store** is libp2p's database of known peers. It maps peer IDs
+to their known addresses, protocols, public keys, and metadata.
+
+A well-maintained peer store helps:
+  - Reconnect to known peers without re-discovery
+  - Track protocol capabilities of known peers
+  - Maintain a persistent view of the network
+
+In this tutorial we'll:
+  - List known peers
+  - Get detailed peer info
+  - Manually add peers to the store
+  - Update addresses and protocols
+  - Delete peers from the store
+```cpp
+#include <cstdio>
+#include <string>
+#include <vector>
+#include "plugin.h"
+
+int main()
+{
+    printf("=== Tutorial 9: Peer Store Management ===\n\n");
+
+```
+
+## Step 1: Create a node
+
+The peer store is automatically available on any started node.
+```cpp
+    Libp2pModuleOptions opts;
+    opts.addrs = {"/ip4/127.0.0.1/tcp/9790"};
+
+    Libp2pModuleImpl node(opts);
+
+    if (!node.start().success) {
+        fprintf(stderr, "Node failed to start\n");
+        return 1;
+    }
+
+    auto info = node.peerInfo().value;
+    std::string nodePeerId = info["peerId"].get<std::string>();
+    printf("Node started, peer ID: %s\n", nodePeerId.c_str());
+
+```
+
+## Step 2: List known peers
+
+Initially, the peer store only contains our own node.
+`peerstoreGetPeers()` returns a JSON array of peer IDs.
+```cpp
+    printf("\nListing known peers...\n");
+    auto peersRes = node.peerstoreGetPeers();
+    if (peersRes.success && peersRes.value.is_array()) {
+        printf("Found %zu known peer(s):\n", peersRes.value.size());
+        for (const auto& p : peersRes.value) {
+            printf("  %s\n", p.get<std::string>().c_str());
+        }
+    }
+
+```
+
+## Step 3: Get detailed peer info
+
+`peerstoreGetPeerInfo()` returns a rich JSON object with addresses,
+protocols, and the public key.
+```cpp
+    printf("\nGetting our own peer info from the store:\n");
+    auto ownInfo = node.peerstoreGetPeerInfo(nodePeerId);
+    if (ownInfo.success) {
+        auto& j = ownInfo.value;
+        printf("  Peer ID: %s\n",
+               j["peerId"].get<std::string>().c_str());
+
+        printf("  Addresses:\n");
+        if (j.contains("addrs") && j["addrs"].is_array()) {
+            for (const auto& a : j["addrs"]) {
+                printf("    %s\n", a.get<std::string>().c_str());
+            }
+        }
+
+        printf("  Protocols:\n");
+        if (j.contains("protocols") && j["protocols"].is_array()) {
+            for (const auto& p : j["protocols"]) {
+                printf("    %s\n", p.get<std::string>().c_str());
+            }
+        }
+
+        printf("  Public key: %s\n",
+               j["publicKey"].get<std::string>().c_str());
+    }
+
+```
+
+## Step 4: Manually add a peer to the store
+
+You can manually register peers in the store. This is useful for
+peers discovered through out-of-band methods (e.g. a config file,
+QR code, or DNS).
+```cpp
+    printf("\nManually adding a peer to the store...\n");
+
+    std::string manualPeerId =
+        "16Uiu2HAkzM1nzU99VxRqzF9CjZAqjF3MZHQ2oRENL7SNgP1d8pRy";
+    std::vector<std::string> manualAddrs = {
+        "/ip4/192.168.1.100/tcp/9000",
+        "/ip4/10.0.0.50/tcp/9001",
+    };
+    std::vector<std::string> manualProtos = {
+        "/ipfs/ping/1.0.0",
+        "/examples/echo/1.0.0",
+    };
+
+    if (!node.peerstoreAddPeer(manualPeerId, manualAddrs, manualProtos)
+             .success) {
+        fprintf(stderr, "Failed to add peer\n");
+        return 1;
+    }
+    printf("Peer added: %s\n", manualPeerId.c_str());
+
+```
+
+Verify it was added:
+```cpp
+    printf("\nVerifying: listing peers again...\n");
+    auto peersAfter = node.peerstoreGetPeers();
+    if (peersAfter.success && peersAfter.value.is_array()) {
+        printf("Now have %zu known peer(s)\n", peersAfter.value.size());
+    }
+
+```
+
+## Step 5: Update peer info
+
+`peerstoreSetPeerAddresses()` and `peerstoreSetPeerProtocols()`
+update a peer's stored data.
+```cpp
+    printf("\nUpdating peer addresses...\n");
+    std::vector<std::string> updatedAddrs = {
+        "/ip4/192.168.1.100/tcp/9002",
+        "/dns4/peer.example.com/tcp/9000",
+    };
+    if (!node.peerstoreSetPeerAddresses(manualPeerId, updatedAddrs)
+             .success) {
+        fprintf(stderr, "Failed to update addresses\n");
+        return 1;
+    }
+    printf("Addresses updated\n");
+
+    // Check the updated info:
+    auto updatedInfo = node.peerstoreGetPeerInfo(manualPeerId);
+    if (updatedInfo.success) {
+        printf("Updated addresses:\n");
+        for (const auto& a : updatedInfo.value["addrs"]) {
+            printf("  %s\n", a.get<std::string>().c_str());
+        }
+    }
+
+```
+
+## Step 6: Delete a peer from the store
+
+`peerstoreDeletePeer()` removes a peer and all its metadata.
+```cpp
+    printf("\nDeleting peer from store...\n");
+    if (!node.peerstoreDeletePeer(manualPeerId).success) {
+        fprintf(stderr, "Failed to delete peer\n");
+        return 1;
+    }
+    printf("Peer deleted\n");
+
+```
+
+Verify deletion:
+```cpp
+    auto peersFinal = node.peerstoreGetPeers();
+    if (peersFinal.success && peersFinal.value.is_array()) {
+        printf("Now have %zu known peer(s)\n",
+               peersFinal.value.size());
+        for (const auto& p : peersFinal.value) {
+            printf("  %s\n", p.get<std::string>().c_str());
+        }
+    }
+
+```
+
+## Step 7: Clean up
+```cpp
+    node.stop();
+
+    printf("\n=== Tutorial 9 Complete ===\n");
+
+```
+
+## Key Takeaways
+
+  - The peer store is a built-in database of known peers
+  - `peerstoreGetPeers()` lists all known peer IDs
+  - `peerstoreGetPeerInfo()` returns detailed peer metadata
+  - `peerstoreAddPeer()` adds peers manually (with addresses + protocols)
+  - `peerstoreSetPeerAddresses()` / `peerstoreSetPeerProtocols()`
+    update existing entries
+  - `peerstoreDeletePeer()` removes peers
+  - A populated peer store speeds up reconnection and reduces
+    network overhead
+
+In the [next tutorial](tutorial_10_circuit_relay.md), we'll learn
+how to connect peers behind NAT/firewalls using Circuit Relay.
+```cpp
+    return 0;
+}
+```
+

--- a/tutorial/docs/tutorial_9_peerstore.md
+++ b/tutorial/docs/tutorial_9_peerstore.md
@@ -211,16 +211,14 @@ Verify deletion:
 
 ## Run tutorial
 
-Build the module (one time):
 ```bash
-nix develop
-./tutorial/build_tutorials.sh
-```
-
-Run this tutorial:
-```bash
-./build/tutorial_9_peerstore
+./build/tutorial/tutorial_9_peerstore
 ```
 ---
 
-< [Service Discovery](tutorial_8_service_discovery.md) -- [Circuit Relay – Connecting Through Firewalls](tutorial_10_circuit_relay.md) >
+<table width="100%">
+  <tr>
+<td width="50%" align="left"><a href="tutorial_8_service_discovery.md">&larr; Service Discovery</a></td>
+<td width="50%" align="right"><a href="tutorial_10_circuit_relay.md">Circuit Relay – Connecting Through Firewalls &rarr;</a></td>
+  </tr>
+</table>

--- a/tutorial/generate_markdown.sh
+++ b/tutorial/generate_markdown.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# generate_markdown.sh
+#
+# Extracts embedded documentation from tutorial C++ source files
+# and generates standalone Markdown files into tutorial/docs/.
+#
+# Conventions:
+#   - Lines starting with `///` (column 0) = documentation (Markdown)
+#   - All other lines = C++ code
+#
+# Usage:
+#   ./generate_markdown.sh                       # generate all .md files
+#   ./generate_markdown.sh tutorial_1.cpp         # generate a single file
+#
+# Output: tutorial/docs/tutorial_<name>.md for each input file
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_DIR="${SCRIPT_DIR}/docs"
+
+# --- helpers ---
+
+# Convert a tutorial filename to its markdown name
+md_name() {
+    local base
+    base="$(basename "$1" .cpp)"
+    echo "${base}.md"
+}
+
+# --- generate a single tutorial ---
+generate() {
+    local src="$1"
+    local base_name
+    base_name="$(basename "$src")"
+    local md="${OUTPUT_DIR}/$(md_name "$src")"
+
+    mkdir -p "${OUTPUT_DIR}"
+    echo "  → ${base_name}  →  docs/$(basename "${md}")"
+
+    # State machine tracks whether we're in DOC (/// at col 0) or CODE.
+    local state="DOC"
+    local code_content=""
+
+    flush_code() {
+        if [ -n "$code_content" ]; then
+            # Remove trailing newline from accumulated code
+            code_content="${code_content%$'\n'}"
+            echo "\`\`\`cpp"
+            echo "$code_content"
+            echo "\`\`\`"
+            echo ""
+            code_content=""
+        fi
+    }
+
+    {
+        while IFS= read -r line; do
+            # Doc comment: /// at column 0
+            if echo "$line" | grep -q '^///'; then
+                if [ "$state" = "CODE" ] || [ "$state" = "CODE_BLANK" ]; then
+                    flush_code
+                fi
+                state="DOC"
+
+                # Strip leading "///" and optional space
+                local md_line
+                md_line="$(echo "$line" | sed 's|^///||' | sed 's/^ //')"
+                echo "$md_line"
+
+            # Blank line
+            elif echo "$line" | grep -q '^[[:space:]]*$'; then
+                if [ "$state" = "CODE" ]; then
+                    state="CODE_BLANK"
+                    code_content+="${line}"$'\n'
+                elif [ "$state" = "CODE_BLANK" ]; then
+                    code_content+="${line}"$'\n'
+                elif [ "$state" = "DOC" ]; then
+                    echo ""
+                fi
+
+            # Code line
+            else
+                if [ "$state" = "DOC" ]; then
+                    # Starting a new code block — first output any trailing
+                    # doc blank lines as paragraph breaks, then code block.
+                    flush_code
+                    state="CODE"
+                elif [ "$state" = "CODE_BLANK" ]; then
+                    state="CODE"
+                fi
+                code_content+="${line}"$'\n'
+            fi
+        done < "$src"
+
+        # Flush any remaining code at EOF
+        if [ "$state" = "CODE" ] || [ "$state" = "CODE_BLANK" ]; then
+            flush_code
+        fi
+    } > "$md"
+}
+
+# --- main ---
+
+if [ $# -eq 0 ]; then
+    echo "Generating markdown from all tutorials..."
+    echo ""
+    for src in "${SCRIPT_DIR}"/tutorial_*.cpp; do
+        [ -f "$src" ] && generate "$src"
+    done
+    echo ""
+    echo "Done. Markdown files in: ${OUTPUT_DIR}/"
+    ls -1 "${OUTPUT_DIR}/"
+else
+    for src in "$@"; do
+        if [ -f "$src" ]; then
+            generate "$src"
+        else
+            echo "File not found: $src" >&2
+        fi
+    done
+fi

--- a/tutorial/generate_markdown.sh
+++ b/tutorial/generate_markdown.sh
@@ -133,17 +133,28 @@ generate() {
 
     flush_code() {
         if [ -n "$code_content" ]; then
-            code_content="${code_content%$'\n'}"
-            echo "\`\`\`cpp"
-            echo "$code_content"
-            echo "\`\`\`"
-            echo ""
+            printf '```cpp\n'
+            printf '%s' "$code_content"
+            printf '```\n\n'
             code_content=""
         fi
     }
 
+    nav_cell() {
+        local align="$1"
+        local href="$2"
+        local text="$3"
+
+        if [ -z "$href" ]; then
+            printf '<td width="50%%"></td>\n'
+        else
+            printf '<td width="50%%" align="%s"><a href="%s">%s</a></td>\n' \
+                "$align" "$href" "$text"
+        fi
+    }
+
     {
-        while IFS= read -r line; do
+        while IFS= read -r line || [ -n "$line" ]; do
             # Doc comment: /// at column 0
             if echo "$line" | grep -q '^///'; then
                 if [ "$state" = "CODE" ] || [ "$state" = "CODE_BLANK" ]; then
@@ -186,12 +197,13 @@ generate() {
         # Append navigation links
         echo "---"
         echo ""
-        if [ -n "$prev_link" ] && [ -n "$next_link" ]; then
-            echo "< [${prev_title}](${prev_link}) -- [${next_title}](${next_link}) >"
-        elif [ -n "$prev_link" ]; then
-            echo "< [${prev_title}](${prev_link})"
-        elif [ -n "$next_link" ]; then
-            echo "[${next_title}](${next_link}) >"
+        if [ -n "$prev_link" ] || [ -n "$next_link" ]; then
+            echo "<table width=\"100%\">"
+            echo "  <tr>"
+            nav_cell "left" "$prev_link" "&larr; ${prev_title}"
+            nav_cell "right" "$next_link" "${next_title} &rarr;"
+            echo "  </tr>"
+            echo "</table>"
         fi
 
     } > "$md"

--- a/tutorial/generate_markdown.sh
+++ b/tutorial/generate_markdown.sh
@@ -9,6 +9,10 @@
 #   - Lines starting with `///` (column 0) = documentation (Markdown)
 #   - All other lines = C++ code
 #
+# Navigation: prev/next links are auto-appended at the bottom of each
+# generated Markdown file, using the tutorial's own title (from the
+# `/// # Tutorial N: Title` first line) as link text.
+#
 # Usage:
 #   ./generate_markdown.sh                       # generate all .md files
 #   ./generate_markdown.sh tutorial_1.cpp         # generate a single file
@@ -20,8 +24,71 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 OUTPUT_DIR="${SCRIPT_DIR}/docs"
+SRC_DIR="${SCRIPT_DIR}"
+
+# --- discover tutorials dynamically ---
+
+# Returns lines of "number|stem|title" sorted by number, e.g.:
+#   1|tutorial_1_node_lifecycle|Creating and Starting a libp2p Node
+discover_tutorials() {
+    local dir="$1"
+    for f in "$dir"/tutorial_*.cpp; do
+        [ -f "$f" ] || continue
+        local base
+        base="$(basename "$f" .cpp)"
+
+        # Extract number: the first number after "tutorial_"
+        local num
+        num="$(echo "$base" | sed 's/tutorial_\([0-9]\+\).*/\1/')"
+
+        # Extract title from the first line: "/// # Tutorial N: Title"
+        local title
+        title="$(head -1 "$f" | sed 's|^/// # Tutorial [0-9]*: ||' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+        if [ -z "$title" ]; then
+            # Fallback: derive from filename stem
+            local stem
+            stem="$(echo "$base" | sed "s/tutorial_${num}_//" | tr '_' ' ' | sed 's/\b\(.\)/\u\1/g')"
+            title="$stem"
+        fi
+
+        echo "${num}|${base}|${title}"
+    done | sort -t'|' -k1 -n
+}
+
+# Build arrays by reading discovered tutorials
+TUTORIAL_STEMS=()
+TUTORIAL_NAMES=()
+TUTORIAL_NUMBERS=()
+
+populate_tutorials() {
+    local idx=0
+    while IFS='|' read -r num stem title; do
+        TUTORIAL_NUMBERS[$idx]="$num"
+        TUTORIAL_STEMS[$idx]="$stem"
+        TUTORIAL_NAMES[$idx]="$title"
+        idx=$((idx + 1))
+    done < <(discover_tutorials "$SRC_DIR")
+}
 
 # --- helpers ---
+
+# Get index in the ordered array for a given filename
+tutorial_index() {
+    local src="$1"
+    local base
+    base="$(basename "$src" .cpp)"
+    local num
+    num="$(echo "$base" | sed 's/tutorial_\([0-9]\+\).*/\1/')"
+
+    for i in "${!TUTORIAL_NUMBERS[@]}"; do
+        if [ "${TUTORIAL_NUMBERS[$i]}" = "$num" ]; then
+            echo "$i"
+            return 0
+        fi
+    done
+    echo "-1"
+    return 1
+}
 
 # Convert a tutorial filename to its markdown name
 md_name() {
@@ -38,15 +105,34 @@ generate() {
     local md="${OUTPUT_DIR}/$(md_name "$src")"
 
     mkdir -p "${OUTPUT_DIR}"
-    echo "  → ${base_name}  →  docs/$(basename "${md}")"
+    echo "  -> ${base_name}  ->  docs/$(basename "${md}")"
 
-    # State machine tracks whether we're in DOC (/// at col 0) or CODE.
+    # Determine nav links from ordered list
+    local idx
+    idx="$(tutorial_index "$src")"
+    local prev_link=""
+    local next_link=""
+    local prev_title=""
+    local next_title=""
+
+    if [ "$idx" -gt 0 ]; then
+        local prev_i=$((idx - 1))
+        prev_link="${TUTORIAL_STEMS[$prev_i]}.md"
+        prev_title="${TUTORIAL_NAMES[$prev_i]}"
+    fi
+
+    if [ "$idx" -lt "$(( ${#TUTORIAL_NUMBERS[@]} - 1 ))" ]; then
+        local next_i=$((idx + 1))
+        next_link="${TUTORIAL_STEMS[$next_i]}.md"
+        next_title="${TUTORIAL_NAMES[$next_i]}"
+    fi
+
+    # State machine: DOC (/// at col 0) or CODE
     local state="DOC"
     local code_content=""
 
     flush_code() {
         if [ -n "$code_content" ]; then
-            # Remove trailing newline from accumulated code
             code_content="${code_content%$'\n'}"
             echo "\`\`\`cpp"
             echo "$code_content"
@@ -65,7 +151,6 @@ generate() {
                 fi
                 state="DOC"
 
-                # Strip leading "///" and optional space
                 local md_line
                 md_line="$(echo "$line" | sed 's|^///||' | sed 's/^ //')"
                 echo "$md_line"
@@ -84,8 +169,6 @@ generate() {
             # Code line
             else
                 if [ "$state" = "DOC" ]; then
-                    # Starting a new code block — first output any trailing
-                    # doc blank lines as paragraph breaks, then code block.
                     flush_code
                     state="CODE"
                 elif [ "$state" = "CODE_BLANK" ]; then
@@ -99,15 +182,36 @@ generate() {
         if [ "$state" = "CODE" ] || [ "$state" = "CODE_BLANK" ]; then
             flush_code
         fi
+
+        # Append navigation links
+        echo "---"
+        echo ""
+        if [ -n "$prev_link" ] && [ -n "$next_link" ]; then
+            echo "< [${prev_title}](${prev_link}) -- [${next_title}](${next_link}) >"
+        elif [ -n "$prev_link" ]; then
+            echo "< [${prev_title}](${prev_link})"
+        elif [ -n "$next_link" ]; then
+            echo "[${next_title}](${next_link}) >"
+        fi
+
     } > "$md"
 }
 
 # --- main ---
 
+# Discover tutorials dynamically
+populate_tutorials
+
+echo "Discovered ${#TUTORIAL_NUMBERS[@]} tutorials:"
+for i in "${!TUTORIAL_NUMBERS[@]}"; do
+    echo "  ${TUTORIAL_NUMBERS[$i]}: ${TUTORIAL_NAMES[$i]}"
+done
+echo ""
+
 if [ $# -eq 0 ]; then
     echo "Generating markdown from all tutorials..."
     echo ""
-    for src in "${SCRIPT_DIR}"/tutorial_*.cpp; do
+    for src in "${SRC_DIR}"/tutorial_*.cpp; do
         [ -f "$src" ] && generate "$src"
     done
     echo ""

--- a/tutorial/tutorial_10_circuit_relay.cpp
+++ b/tutorial/tutorial_10_circuit_relay.cpp
@@ -207,6 +207,12 @@ int main()
 
 /// ## Run tutorial
 ///
+/// Build the module (one time):
+/// ```bash
+/// nix develop
+/// ./tutorial/build_tutorials.sh
+/// ```
+///
 /// Run this tutorial:
 /// ```bash
 /// ./build/tutorial_10_circuit_relay

--- a/tutorial/tutorial_10_circuit_relay.cpp
+++ b/tutorial/tutorial_10_circuit_relay.cpp
@@ -186,6 +186,9 @@ int main()
 
     printf("\n=== Tutorial 10 Complete ===\n");
 
+    return 0;
+}
+
 /// ## Key Takeaways
 ///
 ///   - Circuit Relay allows connecting peers behind NAT/firewalls
@@ -201,5 +204,10 @@ int main()
 /// This concludes the tutorial series! You now have a solid
 /// foundation for building peer-to-peer applications with
 /// `logos-libp2p-module`.
-    return 0;
-}
+
+/// ## Run tutorial
+///
+/// Run this tutorial:
+/// ```bash
+/// ./build/tutorial_10_circuit_relay
+/// ```

--- a/tutorial/tutorial_10_circuit_relay.cpp
+++ b/tutorial/tutorial_10_circuit_relay.cpp
@@ -212,13 +212,6 @@ int main()
 
 /// ## Run tutorial
 ///
-/// Build the module (one time):
 /// ```bash
-/// nix develop
-/// ./tutorial/build_tutorials.sh
-/// ```
-///
-/// Run this tutorial:
-/// ```bash
-/// ./build/tutorial_10_circuit_relay
+/// ./build/tutorial/tutorial_10_circuit_relay
 /// ```

--- a/tutorial/tutorial_10_circuit_relay.cpp
+++ b/tutorial/tutorial_10_circuit_relay.cpp
@@ -1,0 +1,205 @@
+/// # Tutorial 10: Circuit Relay – Connecting Through Firewalls
+///
+/// Not all peers are directly reachable. Some are behind NAT, firewalls,
+/// or have no public IP. Circuit Relay solves this by having a
+/// **relay node** forward traffic between peers.
+///
+/// ## The Three-Node Pattern
+///
+/// Circuit relay uses three roles:
+///
+/// ```
+///   Client  <-->  Relay  <-->  Destination
+///   (B)            (R)          (A)
+/// ```
+///
+/// - **Destination** (A) — The peer behind NAT that wants to be reachable.
+///   It connects to the relay and reserves a slot.
+/// - **Relay** (R) — A publicly reachable node that forwards traffic.
+/// - **Client** (B) — A peer that wants to connect to A through R.
+///
+/// ## How it works
+///
+/// 1. The Destination connects to the Relay and calls
+///    `circuitRelayReserve()` to request a relay slot.
+/// 2. The Relay confirms the reservation and returns relay addresses.
+/// 3. The Client dials the Destination via the Relay using
+///    `dialCircuitRelay()`.
+/// 4. The Relay transparently forwards stream data between them.
+///
+/// > **Note**: Circuit relay adds latency and bandwidth overhead on the
+/// > relay node. Use it only when direct connections are impossible.
+#include <cstdio>
+#include <chrono>
+#include <thread>
+#include <string>
+#include <vector>
+#include "plugin.h"
+
+int main()
+{
+    printf("=== Tutorial 10: Circuit Relay ===\n\n");
+
+/// ## Step 1: Create three nodes
+///
+/// - **Relay** (port 9890): publicly reachable, `circuitRelay: true`
+/// - **Destination** (port 9891): behind NAT
+/// - **Client** (port 9892): wants to connect to Destination
+///
+/// The Relay and Destination must be connected before the reservation.
+/// The Client connects to the Relay before dialing the Destination.
+
+    // Relay node — must have circuitRelay enabled
+    Libp2pModuleOptions optsRelay;
+    optsRelay.addrs = {"/ip4/127.0.0.1/tcp/9890"};
+    optsRelay.circuitRelay = true;
+
+    // Destination node (behind NAT)
+    Libp2pModuleOptions optsDest;
+    optsDest.addrs = {"/ip4/127.0.0.1/tcp/9891"};
+
+    // Client node
+    Libp2pModuleOptions optsClient;
+    optsClient.addrs = {"/ip4/127.0.0.1/tcp/9892"};
+
+    Libp2pModuleImpl relay(optsRelay);
+    Libp2pModuleImpl dest(optsDest);
+    Libp2pModuleImpl client(optsClient);
+
+    printf("Starting nodes...\n");
+
+    if (!relay.start().success) {
+        fprintf(stderr, "Relay failed\n");
+        return 1;
+    }
+
+    if (!dest.start().success) {
+        fprintf(stderr, "Destination failed\n");
+        return 1;
+    }
+
+    if (!client.start().success) {
+        fprintf(stderr, "Client failed\n");
+        return 1;
+    }
+    printf("All three nodes started\n");
+
+/// ## Step 2: Get node addresses
+    auto infoRelay = relay.peerInfo().value;
+    std::string relayPeerId = infoRelay["peerId"].get<std::string>();
+    std::vector<std::string> relayAddrs;
+    for (const auto& a : infoRelay["addrs"])
+        relayAddrs.push_back(a.get<std::string>());
+
+    auto infoDest = dest.peerInfo().value;
+    std::string destPeerId = infoDest["peerId"].get<std::string>();
+
+    printf("Relay peer ID: %s\n", relayPeerId.c_str());
+    printf("Destination peer ID: %s\n", destPeerId.c_str());
+
+/// ## Step 3: Destination connects to the Relay and reserves a slot
+///
+/// The Destination must connect to the Relay first, then call
+/// `circuitRelayReserve()` to request a reservation. The relay
+/// returns the addresses the Destination can be reached at (via relay).
+    printf("\nDestination connecting to relay...\n");
+    if (!dest.connectPeer(relayPeerId, relayAddrs, 5000).success) {
+        fprintf(stderr, "Destination failed to connect to relay\n");
+        return 1;
+    }
+    printf("Destination connected to relay\n");
+
+    printf("Destination requesting relay reservation...\n");
+    auto reserveRes = dest.circuitRelayReserve(relayPeerId, relayAddrs);
+    if (!reserveRes.success) {
+        fprintf(stderr, "Relay reservation failed: %s\n",
+                reserveRes.error.c_str());
+        return 1;
+    }
+
+    printf("Relay reservation successful!\n");
+    if (reserveRes.value.is_array()) {
+        printf("Relay addresses:\n");
+        for (const auto& addr : reserveRes.value) {
+            printf("  %s\n", addr.get<std::string>().c_str());
+        }
+    }
+
+/// ## Step 4: Client connects to the Relay, then dials Destination
+///
+/// The Client connects to the Relay (same as any other peer), then
+/// uses `dialCircuitRelay()` to reach the Destination through the Relay.
+    printf("\nClient connecting to relay...\n");
+    if (!client.connectPeer(relayPeerId, relayAddrs, 5000).success) {
+        fprintf(stderr, "Client failed to connect to relay\n");
+        return 1;
+    }
+    printf("Client connected to relay\n");
+
+/// Now the Client dials the Destination's peer ID through the relay.
+/// The multiaddr is the Destination's direct address (even though
+/// the traffic goes through the relay).
+    printf("Client dialing destination through relay...\n");
+
+    // Get the destination's address
+    std::string destAddr;
+    if (infoDest["addrs"].is_array() && infoDest["addrs"].size() > 0) {
+        destAddr = infoDest["addrs"][0].get<std::string>();
+    }
+
+/// For circuit relay, we use a well-known protocol to test connectivity.
+/// The ping protocol works well for this.
+    auto dialRes = client.dialCircuitRelay(
+        destPeerId,
+        destAddr,
+        "/ipfs/ping/1.0.0");
+
+    if (!dialRes.success) {
+        fprintf(stderr, "Circuit relay dial failed: %s\n",
+                dialRes.error.c_str());
+        printf("\nNote: Circuit relay may need configuration tuning.\n");
+        printf("Ensure the relay node has circuitRelay=true and the\n");
+        printf("destination has connected and reserved a slot.\n");
+    } else {
+        uint64_t streamId = dialRes.value.get<uint64_t>();
+        printf("Circuit relay stream opened! id: %llu\n",
+               (unsigned long long)streamId);
+
+        /// Send a ping through the relay:
+        std::string payload(32, '\0');
+        for (int i = 0; i < 32; ++i) payload[i] = static_cast<char>(i);
+
+        if (!client.streamWrite(streamId, payload).success) {
+            fprintf(stderr, "Write failed\n");
+        } else {
+            printf("Sent %zu bytes through relay\n", payload.size());
+        }
+
+        client.streamClose(streamId);
+        client.streamRelease(streamId);
+    }
+
+/// ## Step 5: Clean up
+    relay.stop();
+    dest.stop();
+    client.stop();
+
+    printf("\n=== Tutorial 10 Complete ===\n");
+
+/// ## Key Takeaways
+///
+///   - Circuit Relay allows connecting peers behind NAT/firewalls
+///   - Three roles: Destination (relayed), Relay (forwarder), Client
+///   - `circuitRelay: true` enables relay mode on a node
+///   - Destination calls `circuitRelayReserve()` to request a slot
+///   - Client calls `dialCircuitRelay()` with dest peer ID + address
+///   - Relay overhead should be considered; prefer direct connections
+///     when possible
+///   - The relay address returned by reserve may be needed by the
+///     client for some configurations
+///
+/// This concludes the tutorial series! You now have a solid
+/// foundation for building peer-to-peer applications with
+/// `logos-libp2p-module`.
+    return 0;
+}

--- a/tutorial/tutorial_10_circuit_relay.cpp
+++ b/tutorial/tutorial_10_circuit_relay.cpp
@@ -143,8 +143,11 @@ int main()
 
     // Get the destination's address
     std::string destAddr;
-    if (infoDest["addrs"].is_array() && infoDest["addrs"].size() > 0) {
+    if (infoDest.contains("addrs") && infoDest["addrs"].is_array() && !infoDest["addrs"].empty()) {
         destAddr = infoDest["addrs"][0].get<std::string>();
+    } else {
+        fprintf(stderr, "Destination has no known addresses to dial\n");
+        return 1;
     }
 
 /// For circuit relay, we use a well-known protocol to test connectivity.
@@ -165,7 +168,7 @@ int main()
         printf("Circuit relay stream opened! id: %llu\n",
                (unsigned long long)streamId);
 
-        /// Send a ping through the relay:
+        // Send a ping through the relay:
         std::string payload(32, '\0');
         for (int i = 0; i < 32; ++i) payload[i] = static_cast<char>(i);
 

--- a/tutorial/tutorial_10_circuit_relay.cpp
+++ b/tutorial/tutorial_10_circuit_relay.cpp
@@ -31,6 +31,7 @@
 /// > relay node. Use it only when direct connections are impossible.
 #include <cstdio>
 #include <chrono>
+#include <cstdint>
 #include <thread>
 #include <string>
 #include <vector>
@@ -57,10 +58,12 @@ int main()
     // Destination node (behind NAT)
     Libp2pModuleOptions optsDest;
     optsDest.addrs = {"/ip4/127.0.0.1/tcp/9891"};
+    optsDest.circuitRelayClient = true;
 
     // Client node
     Libp2pModuleOptions optsClient;
     optsClient.addrs = {"/ip4/127.0.0.1/tcp/9892"};
+    optsClient.circuitRelayClient = true;
 
     Libp2pModuleImpl relay(optsRelay);
     Libp2pModuleImpl dest(optsDest);
@@ -137,16 +140,15 @@ int main()
     printf("Client connected to relay\n");
 
 /// Now the Client dials the Destination's peer ID through the relay.
-/// The multiaddr is the Destination's direct address (even though
-/// the traffic goes through the relay).
+/// The multiaddr comes from the reservation response, with `/p2p-circuit`
+/// appended so libp2p routes the stream through the Relay.
     printf("Client dialing destination through relay...\n");
 
-    // Get the destination's address
-    std::string destAddr;
-    if (infoDest.contains("addrs") && infoDest["addrs"].is_array() && !infoDest["addrs"].empty()) {
-        destAddr = infoDest["addrs"][0].get<std::string>();
+    std::string relayDialAddr;
+    if (reserveRes.value.is_array() && !reserveRes.value.empty()) {
+        relayDialAddr = reserveRes.value[0].get<std::string>() + "/p2p-circuit";
     } else {
-        fprintf(stderr, "Destination has no known addresses to dial\n");
+        fprintf(stderr, "Reservation did not return relay addresses\n");
         return 1;
     }
 
@@ -154,7 +156,7 @@ int main()
 /// The ping protocol works well for this.
     auto dialRes = client.dialCircuitRelay(
         destPeerId,
-        destAddr,
+        relayDialAddr,
         "/ipfs/ping/1.0.0");
 
     if (!dialRes.success) {

--- a/tutorial/tutorial_1_node_lifecycle.cpp
+++ b/tutorial/tutorial_1_node_lifecycle.cpp
@@ -101,13 +101,6 @@ int main()
 
 /// ## Run tutorial
 ///
-/// Build the module (one time):
 /// ```bash
-/// nix develop
-/// ./tutorial/build_tutorials.sh
-/// ```
-///
-/// Run this tutorial:
-/// ```bash
-/// ./build/tutorial_1_node_lifecycle
+/// ./build/tutorial/tutorial_1_node_lifecycle
 /// ```

--- a/tutorial/tutorial_1_node_lifecycle.cpp
+++ b/tutorial/tutorial_1_node_lifecycle.cpp
@@ -87,6 +87,9 @@ int main()
     node.stop();
     printf("Node stopped\n");
 
+    return 0;
+}
+
 /// ## Summary
 ///
 /// In this tutorial you learned how to:
@@ -94,8 +97,10 @@ int main()
 ///   - Start and stop a libp2p node
 ///   - Query peer identity and listening addresses
 ///   - Retrieve module metadata
+
+/// ## Run tutorial
 ///
-/// In the [next tutorial](tutorial_2_custom_config.md), we'll explore
-/// how to configure the node with a custom port and transport settings.
-    return 0;
-}
+/// Run this tutorial:
+/// ```bash
+/// ./build/tutorial_1_node_lifecycle
+/// ```

--- a/tutorial/tutorial_1_node_lifecycle.cpp
+++ b/tutorial/tutorial_1_node_lifecycle.cpp
@@ -24,6 +24,7 @@
 ///
 /// Every program starts by including the module's single public header:
 #include <cstdio>
+#include <string>
 #include "plugin.h"
 
 /// The main class we work with is `Libp2pModuleImpl`. Let's create one with

--- a/tutorial/tutorial_1_node_lifecycle.cpp
+++ b/tutorial/tutorial_1_node_lifecycle.cpp
@@ -1,0 +1,101 @@
+/// # Tutorial 1: Creating and Starting a libp2p Node
+///
+/// Welcome to the first `logos-libp2p-module` tutorial!
+///
+/// This tutorial will guide you through the basics of creating, configuring,
+/// starting, and stopping a libp2p node using the Logos libp2p module.
+///
+/// ## Before You Start
+///
+/// Make sure you can build the `logos-libp2p-module` project. See the
+/// project's `README.md` for build instructions using Nix or CMake.
+///
+/// ## What is libp2p?
+///
+/// [libp2p](https://libp2p.io/) is a modular networking stack for building
+/// peer-to-peer applications. It provides transport-agnostic connectivity,
+/// peer identity, stream multiplexing, secure channels, and content routing
+/// — everything you need to build a decentralized network.
+///
+/// The `logos-libp2p-module` wraps libp2p's C bindings into a C++ class
+/// called `Libp2pModuleImpl` that you can embed directly into your application.
+///
+/// ## Step 1: Include the module header and instantiate a node
+///
+/// Every program starts by including the module's single public header:
+#include <cstdio>
+#include "plugin.h"
+
+/// The main class we work with is `Libp2pModuleImpl`. Let's create one with
+/// default options:
+int main()
+{
+    // Create a libp2p node with default configuration.
+    // By default it listens on 127.0.0.1 with a random port (tcp/0).
+    Libp2pModuleImpl node;
+
+    printf("Node object created (not yet started)\n");
+
+/// ## Step 2: Start the node
+///
+/// Calling `start()` creates the libp2p context, binds the configured
+/// address, and begins accepting connections.
+
+    if (!node.start().success) {
+        fprintf(stderr, "Failed to start node\n");
+        return 1;
+    }
+
+    printf("Node started successfully!\n");
+
+/// ## Step 3: Query node information
+///
+/// Once the node is running, we can inspect its identity and
+/// network addresses using `peerInfo()`.
+
+    auto info = node.peerInfo();
+    if (info.success) {
+        // Extract the peer ID — a unique cryptographic identifier
+        std::string peerId = info.value["peerId"].get<std::string>();
+        printf("Peer ID: %s\n", peerId.c_str());
+
+        // List all multiaddresses the node is listening on
+        printf("Listening addresses:\n");
+        for (const auto& addr : info.value["addrs"]) {
+            printf("  %s\n", addr.get<std::string>().c_str());
+        }
+    }
+
+/// We can also query specific fields using `getNodeInfo()`:
+
+    auto version = node.getNodeInfo("Version");
+    if (version.success) {
+        printf("Module version: %s\n",
+               version.value.get<std::string>().c_str());
+    }
+
+    auto peerIdResult = node.getNodeInfo("PeerId");
+    if (peerIdResult.success) {
+        printf("Peer ID (via getNodeInfo): %s\n",
+               peerIdResult.value.get<std::string>().c_str());
+    }
+
+/// ## Step 4: Stop the node
+///
+/// Always clean up by stopping the node when you're done.
+
+    node.stop();
+    printf("Node stopped\n");
+
+/// ## Summary
+///
+/// In this tutorial you learned how to:
+///   - Create a `Libp2pModuleImpl` instance
+///   - Start and stop a libp2p node
+///   - Query peer identity and listening addresses
+///   - Retrieve module metadata
+///
+/// In the [next tutorial](tutorial_2_custom_config.md), we'll explore
+/// how to configure the node with a custom port and transport settings.
+    return 0;
+}

--- a/tutorial/tutorial_1_node_lifecycle.cpp
+++ b/tutorial/tutorial_1_node_lifecycle.cpp
@@ -100,6 +100,12 @@ int main()
 
 /// ## Run tutorial
 ///
+/// Build the module (one time):
+/// ```bash
+/// nix develop
+/// ./tutorial/build_tutorials.sh
+/// ```
+///
 /// Run this tutorial:
 /// ```bash
 /// ./build/tutorial_1_node_lifecycle

--- a/tutorial/tutorial_2_custom_config.cpp
+++ b/tutorial/tutorial_2_custom_config.cpp
@@ -26,6 +26,7 @@
 /// By default nodes bind to port 0 (random). To listen on a specific port,
 /// provide a custom address in the `addrs` field.
 #include <cstdio>
+#include <string>
 #include "plugin.h"
 
 int main()
@@ -124,7 +125,7 @@ int main()
     }
 
     nodeFromJson.stop();
-    
+
     return 0;
 }
 

--- a/tutorial/tutorial_2_custom_config.cpp
+++ b/tutorial/tutorial_2_custom_config.cpp
@@ -155,13 +155,6 @@ int main()
 
 /// ## Run tutorial
 ///
-/// Build the module (one time):
 /// ```bash
-/// nix develop
-/// ./tutorial/build_tutorials.sh
-/// ```
-///
-/// Run this tutorial:
-/// ```bash
-/// ./build/tutorial_2_custom_config
+/// ./build/tutorial/tutorial_2_custom_config
 /// ```

--- a/tutorial/tutorial_2_custom_config.cpp
+++ b/tutorial/tutorial_2_custom_config.cpp
@@ -1,0 +1,155 @@
+/// # Tutorial 2: Custom Node Configuration
+///
+/// In the [previous tutorial](tutorial_1_node_lifecycle.md), we created a
+/// node with default settings that binds to a random port. In this tutorial,
+/// we'll learn how to configure the node explicitly — setting a fixed port,
+/// changing transports, and passing options via both C++ structs and JSON.
+///
+/// ## Understanding Libp2pModuleOptions
+///
+/// The `Libp2pModuleImpl` constructor accepts a `Libp2pModuleOptions` struct
+/// that lets you control every aspect of the node. Here are the most common
+/// configuration fields:
+///
+/// | Field | Type | Default | Description |
+/// |-------|------|---------|-------------|
+/// | `addrs` | `vector<string>` | `["/ip4/127.0.0.1/tcp/0"]` | Listen addresses |
+/// | `transport` | `int` | `LIBP2P_TRANSPORT_TCP` | Transport protocol |
+/// | `maxConnections` | `int` | `50` | Max total connections |
+/// | `maxConnsPerPeer` | `int` | `1` | Max connections per peer |
+/// | `mountGossipsub` | `bool` | `true` | Enable GossipSub |
+/// | `mountKad` | `bool` | `true` | Enable Kademlia DHT |
+/// | `mountServiceDiscovery` | `bool` | `true` | Enable service discovery |
+///
+/// ## Binding to a fixed port
+///
+/// By default nodes bind to port 0 (random). To listen on a specific port,
+/// provide a custom address in the `addrs` field.
+#include <cstdio>
+#include "plugin.h"
+
+int main()
+{
+/// ## Method 1: Configure via C++ struct
+///
+/// The most explicit way to configure a node is by constructing
+/// `Libp2pModuleOptions` directly and passing it to the constructor.
+    Libp2pModuleOptions options;
+
+    // Listen on TCP port 9090 on all interfaces
+    options.addrs = {"/ip4/0.0.0.0/tcp/9090"};
+
+    // Limit to 10 total connections
+    options.maxConnections = 10;
+
+    // Allow up to 2 connections from the same peer
+    options.maxConnsPerPeer = 2;
+
+    // We don't need GossipSub or Kademlia for this basic example
+    options.mountGossipsub = false;
+    options.mountKad = false;
+    options.mountServiceDiscovery = false;
+
+    printf("Creating node with custom configuration...\n");
+    printf("  Listen address: %s\n", options.addrs[0].c_str());
+    printf("  Max connections: %d\n", options.maxConnections);
+    printf("  Max per peer: %d\n", options.maxConnsPerPeer);
+
+    Libp2pModuleImpl node(options);
+
+    if (!node.start().success) {
+        fprintf(stderr, "Failed to start node\n");
+        return 1;
+    }
+
+/// Verify that the node is actually listening on the configured port:
+    auto info = node.peerInfo();
+    if (info.success) {
+        printf("\nNode is live!\n");
+        printf("  Peer ID: %s\n",
+               info.value["peerId"].get<std::string>().c_str());
+        for (const auto& addr : info.value["addrs"]) {
+            printf("  Listening on: %s\n",
+                   addr.get<std::string>().c_str());
+        }
+    }
+
+    node.stop();
+
+/// ## Method 2: Configure via JSON
+///
+/// When integrating with larger systems (e.g. `logoscore`), you'll
+/// often receive configuration as JSON. The same options can be
+/// supplied via `Libp2pModuleOptions::fromJson()`.
+    printf("\n--- Method 2: JSON configuration ---\n");
+
+    std::string jsonConfig = R"({
+        "addrs": ["/ip4/127.0.0.1/tcp/9091"],
+        "maxConnections": 20,
+        "mountGossipsub": false,
+        "mountKad": false,
+        "mountServiceDiscovery": false
+    })";
+
+    bool parseOk;
+    std::string parseErr;
+    auto jsonOpts = Libp2pModuleOptions::fromJson(jsonConfig, parseOk, &parseErr);
+
+    if (!parseOk) {
+        fprintf(stderr, "Failed to parse JSON config: %s\n",
+                parseErr.c_str());
+        return 1;
+    }
+
+    printf("Parsed JSON config:\n");
+    printf("  Listen address: %s\n", jsonOpts.addrs[0].c_str());
+    printf("  Max connections: %d\n", jsonOpts.maxConnections);
+
+    Libp2pModuleImpl nodeFromJson(jsonOpts);
+
+    if (!nodeFromJson.start().success) {
+        fprintf(stderr, "Failed to start JSON-configured node\n");
+        return 1;
+    }
+
+    auto info2 = nodeFromJson.peerInfo();
+    if (info2.success) {
+        printf("\nJSON-configured node is live!\n");
+        printf("  Peer ID: %s\n",
+               info2.value["peerId"].get<std::string>().c_str());
+        for (const auto& addr : info2.value["addrs"]) {
+            printf("  Listening on: %s\n",
+                   addr.get<std::string>().c_str());
+        }
+    }
+
+    nodeFromJson.stop();
+
+/// ## Exercise: Try different configurations
+///
+/// Experiment with these variations:
+///
+/// ```cpp
+/// // QUIC transport instead of TCP
+/// options.transport = LIBP2P_TRANSPORT_QUIC;
+/// options.addrs = {"/ip4/127.0.0.1/udp/9092/quic-v1"};
+///
+/// // Listen on multiple addresses
+/// options.addrs = {
+///     "/ip4/0.0.0.0/tcp/9093",
+///     "/ip4/0.0.0.0/tcp/9094"
+/// };
+/// ```
+
+/// ## Summary
+///
+/// In this tutorial you learned:
+///   - How to configure a node with a fixed port
+///   - How to control connection limits
+///   - How to pass options via C++ struct or JSON
+///   - How to verify the node's actual bound addresses
+///
+/// In the [next tutorial](tutorial_3_connecting_peers.md), we'll connect
+/// two nodes and exchange data.
+    return 0;
+}

--- a/tutorial/tutorial_2_custom_config.cpp
+++ b/tutorial/tutorial_2_custom_config.cpp
@@ -124,6 +124,9 @@ int main()
     }
 
     nodeFromJson.stop();
+    
+    return 0;
+}
 
 /// ## Exercise: Try different configurations
 ///
@@ -148,8 +151,10 @@ int main()
 ///   - How to control connection limits
 ///   - How to pass options via C++ struct or JSON
 ///   - How to verify the node's actual bound addresses
+
+/// ## Run tutorial
 ///
-/// In the [next tutorial](tutorial_3_connecting_peers.md), we'll connect
-/// two nodes and exchange data.
-    return 0;
-}
+/// Run this tutorial:
+/// ```bash
+/// ./build/tutorial_2_custom_config
+/// ```

--- a/tutorial/tutorial_2_custom_config.cpp
+++ b/tutorial/tutorial_2_custom_config.cpp
@@ -154,6 +154,12 @@ int main()
 
 /// ## Run tutorial
 ///
+/// Build the module (one time):
+/// ```bash
+/// nix develop
+/// ./tutorial/build_tutorials.sh
+/// ```
+///
 /// Run this tutorial:
 /// ```bash
 /// ./build/tutorial_2_custom_config

--- a/tutorial/tutorial_3_connecting_peers.cpp
+++ b/tutorial/tutorial_3_connecting_peers.cpp
@@ -174,5 +174,13 @@ int main()
     nodeB.stop();
 
     printf("\n=== Tutorial 3 Complete ===\n");
+    
     return 0;
 }
+
+/// ## Run tutorial
+///
+/// Run this tutorial:
+/// ```bash
+/// ./build/tutorial_3_connecting_peers
+/// ```

--- a/tutorial/tutorial_3_connecting_peers.cpp
+++ b/tutorial/tutorial_3_connecting_peers.cpp
@@ -183,13 +183,6 @@ int main()
 
 /// ## Run tutorial
 ///
-/// Build the module (one time):
 /// ```bash
-/// nix develop
-/// ./tutorial/build_tutorials.sh
-/// ```
-///
-/// Run this tutorial:
-/// ```bash
-/// ./build/tutorial_3_connecting_peers
+/// ./build/tutorial/tutorial_3_connecting_peers
 /// ```

--- a/tutorial/tutorial_3_connecting_peers.cpp
+++ b/tutorial/tutorial_3_connecting_peers.cpp
@@ -31,6 +31,9 @@
 ///   4. `streamClose()` or `streamCloseWithEOF()` — Close gracefully
 ///   5. `streamRelease()` — Free server-side resources
 #include <cstdio>
+#include <cstdint>
+#include <string>
+#include <vector>
 #include "plugin.h"
 
 int main()
@@ -154,7 +157,7 @@ int main()
         return 1;
     }
 
-    std::string reply = readRes.value.get<std::string>();
+    std::string reply = base64Decode(readRes.value.get<std::string>());
 
 /// Verify the echo matches:
     if (reply == payload) {
@@ -174,7 +177,7 @@ int main()
     nodeB.stop();
 
     printf("\n=== Tutorial 3 Complete ===\n");
-    
+
     return 0;
 }
 

--- a/tutorial/tutorial_3_connecting_peers.cpp
+++ b/tutorial/tutorial_3_connecting_peers.cpp
@@ -1,0 +1,178 @@
+/// # Tutorial 3: Connecting Peers and Exchanging Data
+///
+/// Now that we can create and configure nodes, let's make them talk to
+/// each other! In this tutorial we'll:
+///
+///   - Create two nodes
+///   - Connect one to the other
+///   - Dial a protocol and open a stream
+///   - Exchange data over the stream
+///
+/// ## How libp2p Connections Work
+///
+/// A libp2p connection is established in two steps:
+///
+/// 1. **Connect** — Establish a transport-level connection to a remote peer,
+///    identified by its Peer ID and a multiaddress.
+///
+/// 2. **Dial** — Negotiate a protocol on top of the connection and open a
+///    bidirectional stream. The stream is what you actually read from and
+///    write to.
+///
+/// Streams in `logos-libp2p-module` are identified by a numeric `streamId`
+/// that you get back from `dial()` and pass to read/write functions.
+///
+/// ## Stream Lifecycle
+///
+/// A stream must follow this lifecycle:
+///   1. `dial()` — Open a stream (returns a `streamId`)
+///   2. `streamWrite()` / `streamWriteLp()` — Send data
+///   3. `streamReadLp()` / `streamReadExactly()` — Receive data
+///   4. `streamClose()` or `streamCloseWithEOF()` — Close gracefully
+///   5. `streamRelease()` — Free server-side resources
+#include <cstdio>
+#include "plugin.h"
+
+int main()
+{
+    printf("=== Tutorial 3: Connecting Peers ===\n\n");
+
+/// ## Step 1: Create and start two nodes
+///
+/// We create two nodes. Node A listens on port 9190, Node B on port 9191.
+/// For simplicity, both mount the built-in `/ipfs/ping/1.0.0` protocol
+/// (enabled by default — no extra config needed).
+    Libp2pModuleOptions optsA;
+    optsA.addrs = {"/ip4/127.0.0.1/tcp/9190"};
+
+    Libp2pModuleOptions optsB;
+    optsB.addrs = {"/ip4/127.0.0.1/tcp/9191"};
+    // Node B needs to know about node A to connect, but we'll pass
+    // that info after starting both nodes.
+
+    Libp2pModuleImpl nodeA(optsA);
+    Libp2pModuleImpl nodeB(optsB);
+
+    if (!nodeA.start().success) {
+        fprintf(stderr, "Node A failed to start\n");
+        return 1;
+    }
+    printf("Node A started\n");
+
+    if (!nodeB.start().success) {
+        fprintf(stderr, "Node B failed to start\n");
+        return 1;
+    }
+    printf("Node B started\n");
+
+/// ## Step 2: Get Node A's address info
+///
+/// Node B needs to know where to find Node A. We get Node A's
+/// peer ID and listening addresses from `peerInfo()`.
+    auto infoA = nodeA.peerInfo();
+    if (!infoA.success) {
+        fprintf(stderr, "Failed to get node A info\n");
+        return 1;
+    }
+
+    std::string peerIdA = infoA.value["peerId"].get<std::string>();
+    std::vector<std::string> addrsA;
+    for (const auto& a : infoA.value["addrs"]) {
+        addrsA.push_back(a.get<std::string>());
+    }
+
+    printf("Node A peer ID: %s\n", peerIdA.c_str());
+    printf("Node A addresses:\n");
+    for (const auto& a : addrsA) {
+        printf("  %s\n", a.c_str());
+    }
+
+/// ## Step 3: Connect Node B to Node A
+///
+/// `connectPeer()` establishes the transport connection. The timeout
+/// parameter is in milliseconds.
+    printf("\nConnecting Node B to Node A...\n");
+    if (!nodeB.connectPeer(peerIdA, addrsA, 5000).success) {
+        fprintf(stderr, "Failed to connect\n");
+        return 1;
+    }
+    printf("Connected!\n");
+
+/// ## Step 4: List connected peers
+///
+/// We can verify the connection by listing connected peers on each node.
+/// The direction parameter `0` means "all connected peers".
+    auto peersA = nodeA.connectedPeers(0);
+    if (peersA.success) {
+        printf("\nNode A's connected peers:\n");
+        for (const auto& p : peersA.value) {
+            printf("  %s\n", p.get<std::string>().c_str());
+        }
+    }
+
+    auto peersB = nodeB.connectedPeers(0);
+    if (peersB.success) {
+        printf("Node B's connected peers:\n");
+        for (const auto& p : peersB.value) {
+            printf("  %s\n", p.get<std::string>().c_str());
+        }
+    }
+
+/// ## Step 5: Dial the ping protocol and exchange data
+///
+/// Now let's use the Ping protocol — a simple built-in protocol where
+/// the client sends a payload and the server echoes it back.
+///
+/// `dial()` opens a stream on the remote peer for a specific protocol.
+/// It returns the `streamId` we use for subsequent operations.
+    printf("\nDialing /ipfs/ping/1.0.0 on Node A...\n");
+    auto dialRes = nodeB.dial(peerIdA, "/ipfs/ping/1.0.0");
+    if (!dialRes.success) {
+        fprintf(stderr, "Dial failed: %s\n", dialRes.error.c_str());
+        return 1;
+    }
+
+    uint64_t streamId = dialRes.value.get<uint64_t>();
+    printf("Stream opened, id: %llu\n", (unsigned long long)streamId);
+
+/// Write a 32-byte ping payload:
+    std::string payload(32, '\0');
+    for (int i = 0; i < 32; ++i) {
+        payload[i] = static_cast<char>(i);
+    }
+
+    printf("Sending %zu bytes...\n", payload.size());
+    if (!nodeB.streamWrite(streamId, payload).success) {
+        fprintf(stderr, "Write failed\n");
+        return 1;
+    }
+
+/// Read the echo (32 bytes back):
+    auto readRes = nodeB.streamReadExactly(streamId, 32);
+    if (!readRes.success) {
+        fprintf(stderr, "Read failed: %s\n", readRes.error.c_str());
+        return 1;
+    }
+
+    std::string reply = readRes.value.get<std::string>();
+
+/// Verify the echo matches:
+    if (reply == payload) {
+        printf("Ping successful — received matching echo back!\n");
+    } else {
+        fprintf(stderr, "Ping payload mismatch\n");
+        return 1;
+    }
+
+/// ## Step 6: Clean up the stream and nodes
+///
+/// Always close and release streams when done:
+    nodeB.streamClose(streamId);
+    nodeB.streamRelease(streamId);
+
+    nodeA.stop();
+    nodeB.stop();
+
+    printf("\n=== Tutorial 3 Complete ===\n");
+    return 0;
+}

--- a/tutorial/tutorial_3_connecting_peers.cpp
+++ b/tutorial/tutorial_3_connecting_peers.cpp
@@ -180,6 +180,12 @@ int main()
 
 /// ## Run tutorial
 ///
+/// Build the module (one time):
+/// ```bash
+/// nix develop
+/// ./tutorial/build_tutorials.sh
+/// ```
+///
 /// Run this tutorial:
 /// ```bash
 /// ./build/tutorial_3_connecting_peers

--- a/tutorial/tutorial_4_custom_protocol.cpp
+++ b/tutorial/tutorial_4_custom_protocol.cpp
@@ -209,13 +209,6 @@ int main()
 
 /// ## Run tutorial
 ///
-/// Build the module (one time):
 /// ```bash
-/// nix develop
-/// ./tutorial/build_tutorials.sh
-/// ```
-///
-/// Run this tutorial:
-/// ```bash
-/// ./build/tutorial_4_custom_protocol
+/// ./build/tutorial/tutorial_4_custom_protocol
 /// ```

--- a/tutorial/tutorial_4_custom_protocol.cpp
+++ b/tutorial/tutorial_4_custom_protocol.cpp
@@ -206,6 +206,12 @@ int main()
 
 /// ## Run tutorial
 ///
+/// Build the module (one time):
+/// ```bash
+/// nix develop
+/// ./tutorial/build_tutorials.sh
+/// ```
+///
 /// Run this tutorial:
 /// ```bash
 /// ./build/tutorial_4_custom_protocol

--- a/tutorial/tutorial_4_custom_protocol.cpp
+++ b/tutorial/tutorial_4_custom_protocol.cpp
@@ -28,9 +28,12 @@
 /// > `streamClose()` — the peer that initiated the stream is responsible
 /// > for closing it.
 #include <cstdio>
+#include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <mutex>
 #include <string>
+#include <vector>
 #include "plugin.h"
 
 using json = nlohmann::json;
@@ -154,7 +157,7 @@ int main()
                 readRes.error.c_str());
         return 1;
     }
-    std::string received = readRes.value.get<std::string>();
+    std::string received = base64Decode(readRes.value.get<std::string>());
     printf("Node A received: \"%s\"\n", received.c_str());
 
 /// Echo it back:
@@ -170,7 +173,7 @@ int main()
                 echoRes.error.c_str());
         return 1;
     }
-    std::string echo = echoRes.value.get<std::string>();
+    std::string echo = base64Decode(echoRes.value.get<std::string>());
     printf("Node B received echo: \"%s\"\n", echo.c_str());
 
     if (echo != message) {
@@ -192,10 +195,10 @@ int main()
     nodeB.stop();
 
     printf("\n=== Tutorial 4 Complete ===\n");
-    
+
     return 0;
 }
-    
+
 /// ## Key Takeaways
 ///
 ///   - `mountProtocol()` registers a handler on the server side

--- a/tutorial/tutorial_4_custom_protocol.cpp
+++ b/tutorial/tutorial_4_custom_protocol.cpp
@@ -192,7 +192,10 @@ int main()
     nodeB.stop();
 
     printf("\n=== Tutorial 4 Complete ===\n");
-
+    
+    return 0;
+}
+    
 /// ## Key Takeaways
 ///
 ///   - `mountProtocol()` registers a handler on the server side
@@ -200,8 +203,10 @@ int main()
 ///   - The dialing side uses `streamClose()`/`streamCloseWithEOF()`
 ///   - The server side uses `streamRelease()` (no close)
 ///   - Use `streamWriteLp()` / `streamReadLp()` for length-prefixed messages
+
+/// ## Run tutorial
 ///
-/// In the [next tutorial](tutorial_5_kademlia_basics.md), we'll explore
-/// Kademlia DHT for distributed key-value storage.
-    return 0;
-}
+/// Run this tutorial:
+/// ```bash
+/// ./build/tutorial_4_custom_protocol
+/// ```

--- a/tutorial/tutorial_4_custom_protocol.cpp
+++ b/tutorial/tutorial_4_custom_protocol.cpp
@@ -1,0 +1,207 @@
+/// # Tutorial 4: Custom Protocol Handlers
+///
+/// In the [previous tutorial](tutorial_3_connecting_peers.md), we used the
+/// built-in Ping protocol to exchange data between peers. But real
+/// applications need their own protocols!
+///
+/// This tutorial shows you how to mount a custom protocol on a node so
+/// that it can handle incoming streams from peers who dial that protocol.
+///
+/// ## How Custom Protocols Work
+///
+/// A protocol in libp2p is identified by a **protocol ID string** — a
+/// `/`-separated path like `/myapp/chat/1.0.0`. When a remote peer dials
+/// this protocol ID, your node receives a new stream.
+///
+/// To handle incoming streams you:
+///   1. Call `mountProtocol()` to register a protocol ID
+///   2. Set an `emitEvent` callback that listens for `"protocolStream"` events
+///   3. Read from and write to the stream in the event handler
+///
+/// The stream lifecycle on the server side is:
+///   1. Receive `protocolStream` event with a `streamId`
+///   2. Read data from the stream
+///   3. Write data to the stream (optional)
+///   4. Call `streamRelease()` when done with the stream
+///
+/// > **Note**: Unlike the dialing side, the server side does **not** call
+/// > `streamClose()` — the peer that initiated the stream is responsible
+/// > for closing it.
+#include <cstdio>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include "plugin.h"
+
+using json = nlohmann::json;
+
+/// ## Defining our custom protocol
+///
+/// We'll create an **echo protocol**: the server reads a length-prefixed
+/// message and echoes it back to the client. This is a common pattern
+/// for request-response protocols.
+
+const std::string kEchoProtocol = "/examples/echo/1.0.0";
+
+int main()
+{
+    printf("=== Tutorial 4: Custom Protocol Handlers ===\n\n");
+
+/// ## Step 1: Create and start two nodes
+    Libp2pModuleOptions optsA, optsB;
+    optsA.addrs = {"/ip4/127.0.0.1/tcp/9290"};
+    optsB.addrs = {"/ip4/127.0.0.1/tcp/9291"};
+
+    Libp2pModuleImpl nodeA(optsA);
+    Libp2pModuleImpl nodeB(optsB);
+
+    if (!nodeA.start().success) { fprintf(stderr, "Node A failed\n"); return 1; }
+    if (!nodeB.start().success) { fprintf(stderr, "Node B failed\n"); return 1; }
+    printf("Both nodes started\n");
+
+/// ## Step 2: Set up the protocol handler on Node A
+///
+/// We define an `emitEvent` callback on Node A. Whenever a remote peer
+/// dials our protocol, a `"protocolStream"` event fires with a JSON
+/// payload containing the `streamId`.
+///
+/// For simplicity, this example reads one message, echoes it, then
+/// releases the stream. A real application would likely spawn a
+/// background thread to handle concurrent streams.
+    struct ServerState {
+        std::mutex mtx;
+        std::condition_variable cv;
+        uint64_t streamId = 0;
+        bool ready = false;
+    };
+    ServerState server;
+
+    nodeA.emitEvent = [&](const std::string& name, const std::string& data) {
+        if (name != "protocolStream") return;
+
+        auto j = json::parse(data);
+        uint64_t sid = j["streamId"].get<uint64_t>();
+
+        {
+            std::lock_guard<std::mutex> lock(server.mtx);
+            server.streamId = sid;
+            server.ready = true;
+        }
+        server.cv.notify_one();
+    };
+
+/// Register the echo protocol on Node A:
+    printf("Mounting protocol '%s' on Node A...\n", kEchoProtocol.c_str());
+    if (!nodeA.mountProtocol(kEchoProtocol).success) {
+        fprintf(stderr, "Failed to mount protocol\n");
+        return 1;
+    }
+
+/// ## Step 3: Get Node A's address and connect Node B
+    auto infoA = nodeA.peerInfo().value;
+    std::string peerIdA = infoA["peerId"].get<std::string>();
+    std::vector<std::string> addrsA;
+    for (const auto& a : infoA["addrs"])
+        addrsA.push_back(a.get<std::string>());
+
+    printf("Connecting Node B to Node A...\n");
+    if (!nodeB.connectPeer(peerIdA, addrsA, 5000).success) {
+        fprintf(stderr, "Failed to connect\n");
+        return 1;
+    }
+    printf("Connected\n");
+
+/// ## Step 4: Node B dials the echo protocol
+///
+/// When Node B dials our custom protocol, Node A's protocol handler
+/// fires, and Node A receives a new stream.
+    printf("Node B dialing '%s'...\n", kEchoProtocol.c_str());
+    auto dialRes = nodeB.dial(peerIdA, kEchoProtocol);
+    if (!dialRes.success) {
+        fprintf(stderr, "Dial failed: %s\n", dialRes.error.c_str());
+        return 1;
+    }
+    uint64_t clientStreamId = dialRes.value.get<uint64_t>();
+    printf("Node B client stream id: %llu\n",
+           (unsigned long long)clientStreamId);
+
+/// ## Step 5: Wait for Node A to receive the stream
+    uint64_t serverStreamId = 0;
+    {
+        std::unique_lock<std::mutex> lock(server.mtx);
+        if (!server.cv.wait_for(lock, std::chrono::seconds(5),
+                                [&] { return server.ready; })) {
+            fprintf(stderr, "Timed out waiting for incoming stream\n");
+            return 1;
+        }
+        serverStreamId = server.streamId;
+    }
+    printf("Node A received stream id: %llu\n",
+           (unsigned long long)serverStreamId);
+
+/// ## Step 6: Node B sends a message
+    std::string message = "Hello from Node B!";
+    printf("Node B sending: \"%s\"\n", message.c_str());
+    if (!nodeB.streamWriteLp(clientStreamId, message).success) {
+        fprintf(stderr, "Write failed\n");
+        return 1;
+    }
+
+/// ## Step 7: Node A reads the message and echoes it back
+    auto readRes = nodeA.streamReadLp(serverStreamId, 4096);
+    if (!readRes.success) {
+        fprintf(stderr, "Node A read failed: %s\n",
+                readRes.error.c_str());
+        return 1;
+    }
+    std::string received = readRes.value.get<std::string>();
+    printf("Node A received: \"%s\"\n", received.c_str());
+
+/// Echo it back:
+    if (!nodeA.streamWriteLp(serverStreamId, received).success) {
+        fprintf(stderr, "Node A echo write failed\n");
+        return 1;
+    }
+
+/// ## Step 8: Node B reads the echo
+    auto echoRes = nodeB.streamReadLp(clientStreamId, 4096);
+    if (!echoRes.success) {
+        fprintf(stderr, "Node B read echo failed: %s\n",
+                echoRes.error.c_str());
+        return 1;
+    }
+    std::string echo = echoRes.value.get<std::string>();
+    printf("Node B received echo: \"%s\"\n", echo.c_str());
+
+    if (echo != message) {
+        fprintf(stderr, "Echo mismatch! Got '%s'\n", echo.c_str());
+        return 1;
+    }
+    printf("Echo verified successfully!\n");
+
+/// ## Step 9: Clean up
+///
+/// The client (dialing side) closes its stream with `streamCloseWithEOF()`
+/// to signal that it's done writing. Both sides release their stream
+/// resources with `streamRelease()`.
+    nodeB.streamCloseWithEOF(clientStreamId);
+    nodeB.streamRelease(clientStreamId);
+    nodeA.streamRelease(serverStreamId);
+
+    nodeA.stop();
+    nodeB.stop();
+
+    printf("\n=== Tutorial 4 Complete ===\n");
+
+/// ## Key Takeaways
+///
+///   - `mountProtocol()` registers a handler on the server side
+///   - `emitEvent` with the `"protocolStream"` event delivers incoming streams
+///   - The dialing side uses `streamClose()`/`streamCloseWithEOF()`
+///   - The server side uses `streamRelease()` (no close)
+///   - Use `streamWriteLp()` / `streamReadLp()` for length-prefixed messages
+///
+/// In the [next tutorial](tutorial_5_kademlia_basics.md), we'll explore
+/// Kademlia DHT for distributed key-value storage.
+    return 0;
+}

--- a/tutorial/tutorial_5_kademlia_basics.cpp
+++ b/tutorial/tutorial_5_kademlia_basics.cpp
@@ -172,13 +172,6 @@ int main()
 
 /// ## Run tutorial
 ///
-/// Build the module (one time):
 /// ```bash
-/// nix develop
-/// ./tutorial/build_tutorials.sh
-/// ```
-///
-/// Run this tutorial:
-/// ```bash
-/// ./build/tutorial_5_kademlia_basics
+/// ./build/tutorial/tutorial_5_kademlia_basics
 /// ```

--- a/tutorial/tutorial_5_kademlia_basics.cpp
+++ b/tutorial/tutorial_5_kademlia_basics.cpp
@@ -37,7 +37,7 @@ int main()
 {
     printf("=== Tutorial 5: Kademlia DHT Basics ===\n\n");
 
-/// ## Step 1: Create three nodes
+/// ## Step 1: Create two nodes
 ///
 /// We need at least two nodes to demonstrate DHT operations. In a
 /// real network, one node would be a well-known bootstrap peer.

--- a/tutorial/tutorial_5_kademlia_basics.cpp
+++ b/tutorial/tutorial_5_kademlia_basics.cpp
@@ -137,7 +137,7 @@ int main()
 
     std::string received;
     if (getRes.value.is_string()) {
-        received = getRes.value.get<std::string>();
+        received = base64Decode(getRes.value.get<std::string>());
     }
 
     if (received.empty()) {
@@ -157,8 +157,8 @@ int main()
     nodeB.stop();
 
     printf("\n=== Tutorial 5 Complete ===\n");
-    
-    return 0;    
+
+    return 0;
 }
 
 /// ## Key Takeaways

--- a/tutorial/tutorial_5_kademlia_basics.cpp
+++ b/tutorial/tutorial_5_kademlia_basics.cpp
@@ -157,6 +157,9 @@ int main()
     nodeB.stop();
 
     printf("\n=== Tutorial 5 Complete ===\n");
+    
+    return 0;    
+}
 
 /// ## Key Takeaways
 ///
@@ -166,9 +169,10 @@ int main()
 ///   - `kadGetValue(key, quorum)` retrieves it
 ///   - `kadGetRandomRecords()` discovers random peers in the DHT
 ///   - Values may take a moment to propagate after storing
+
+/// ## Run tutorial
 ///
-/// In the [next tutorial](tutorial_6_kademlia_providers.md), we'll
-/// explore provider records — a way to find which peers offer
-/// specific content.
-    return 0;
-}
+/// Run this tutorial:
+/// ```bash
+/// ./build/tutorial_5_kademlia_basics
+/// ```

--- a/tutorial/tutorial_5_kademlia_basics.cpp
+++ b/tutorial/tutorial_5_kademlia_basics.cpp
@@ -1,0 +1,174 @@
+/// # Tutorial 5: Kademlia DHT Basics
+///
+/// Kademlia is a Distributed Hash Table (DHT) that lets peers store and
+/// retrieve values without a central server. The `logos-libp2p-module`
+/// exposes this through the `kadPutValue()`, `kadGetValue()`, and
+/// `kadGetRandomRecords()` functions.
+///
+/// In this tutorial we'll:
+///   - Start two nodes that bootstrap to each other
+///   - Store a value from one node
+///   - Retrieve it from the other node
+///   - List random records to verify DHT participation
+///
+/// ## How Kademlia works in libp2p
+///
+/// Each node in the DHT maintains a routing table of peers closest to
+/// certain "keys" (hashes). When you call `kadPutValue(key, value)`:
+///   1. The key is hashed and the node finds the closest peers in its
+///      routing table
+///   2. The value is sent to those peers for storage
+///
+/// When you call `kadGetValue(key, quorum)`:
+///   1. The key is hashed and closest peers are looked up
+///   2. The value is requested from them
+///   3. The quorum parameter controls how many responses are needed
+///
+/// ## Bootstrap nodes
+///
+/// New nodes need at least one bootstrap peer to join the DHT. In this
+/// tutorial, Node A acts as the bootstrap for Node B.
+#include <cstdio>
+#include <string>
+#include <vector>
+#include "plugin.h"
+
+int main()
+{
+    printf("=== Tutorial 5: Kademlia DHT Basics ===\n\n");
+
+/// ## Step 1: Create three nodes
+///
+/// We need at least two nodes to demonstrate DHT operations. In a
+/// real network, one node would be a well-known bootstrap peer.
+///
+/// > **Important**: Kademlia is mounted by default (`mountKad: true`).
+/// > We explicitly enable it in our options.
+    Libp2pModuleOptions optsA, optsB;
+    optsA.addrs = {"/ip4/127.0.0.1/tcp/9390"};
+    optsA.mountKad = true;
+    // Node A is the bootstrap — no special config needed, just its address.
+
+    optsB.addrs = {"/ip4/127.0.0.1/tcp/9391"};
+    optsB.mountKad = true;
+    // We'll add Node A as bootstrap after we know its peer ID.
+
+    Libp2pModuleImpl nodeA(optsA);
+    printf("Starting Node A (bootstrap)...\n");
+    if (!nodeA.start().success) {
+        fprintf(stderr, "Node A failed to start\n");
+        return 1;
+    }
+
+    // Get Node A's peer info for bootstrapping Node B
+    auto infoA = nodeA.peerInfo().value;
+    std::string peerIdA = infoA["peerId"].get<std::string>();
+    std::vector<std::string> addrsA;
+    for (const auto& a : infoA["addrs"])
+        addrsA.push_back(a.get<std::string>());
+    printf("Node A peer ID: %s\n", peerIdA.c_str());
+
+    // Now create Node B with Node A as its bootstrap
+    Libp2pModuleOptions optsBFinal;
+    optsBFinal.addrs = {"/ip4/127.0.0.1/tcp/9391"};
+    optsBFinal.bootstrapNodes = {{peerIdA, addrsA}};
+    optsBFinal.mountKad = true;
+
+    Libp2pModuleImpl nodeB(optsBFinal);
+    printf("Starting Node B (with Node A as bootstrap)...\n");
+    if (!nodeB.start().success) {
+        fprintf(stderr, "Node B failed to start\n");
+        return 1;
+    }
+
+    // Connect Node B to Node A so they can participate in the DHT
+    printf("Connecting Node B to Node A...\n");
+    if (!nodeB.connectPeer(peerIdA, addrsA, 5000).success) {
+        fprintf(stderr, "Failed to connect\n");
+        return 1;
+    }
+    printf("Nodes connected\n");
+
+/// ## Step 2: Check initial DHT state
+///
+/// Before we store anything, let's check what random records Node B
+/// can find. This helps verify that the DHT is working.
+    auto recordsRes = nodeB.kadGetRandomRecords();
+    if (recordsRes.success && recordsRes.value.is_array()) {
+        printf("Node B found %zu random records\n",
+               recordsRes.value.size());
+        for (const auto& rec : recordsRes.value) {
+            printf("  Peer: %s\n",
+                   rec["peerId"].get<std::string>().c_str());
+        }
+    }
+
+/// ## Step 3: Store a value in the DHT
+///
+/// Node A puts a key-value pair into the DHT. The key is a string,
+/// and the value is also a string.
+    std::string key = "greeting";
+    std::string value = "Hello from the DHT!";
+
+    printf("\nNode A putting value into DHT...\n");
+    printf("  Key: \"%s\"\n", key.c_str());
+    printf("  Value: \"%s\"\n", value.c_str());
+
+    if (!nodeA.kadPutValue(key, value).success) {
+        fprintf(stderr, "PutValue failed\n");
+        return 1;
+    }
+    printf("Value stored!\n");
+
+/// ## Step 4: Retrieve the value from Node B
+///
+/// Node B fetches the value from the DHT. The `quorum` parameter
+/// controls the consistency level:
+///   - `0` = default (usually 1 response is enough)
+///   - `1` = wait for at least 1 peer's response
+///   - Higher values = more consistency, slower
+    printf("\nNode B fetching value from DHT...\n");
+    auto getRes = nodeB.kadGetValue(key, 1);
+    if (!getRes.success) {
+        fprintf(stderr, "GetValue failed: %s\n",
+                getRes.error.c_str());
+        return 1;
+    }
+
+    std::string received;
+    if (getRes.value.is_string()) {
+        received = getRes.value.get<std::string>();
+    }
+
+    if (received.empty()) {
+        printf("Node B did not find the value (may need more time)\n");
+    } else {
+        printf("Node B received: \"%s\"\n", received.c_str());
+        if (received == value) {
+            printf("Value matches!\n");
+        } else {
+            printf("Value mismatch (expected: \"%s\")\n",
+                   value.c_str());
+        }
+    }
+
+/// ## Step 5: Clean up
+    nodeA.stop();
+    nodeB.stop();
+
+    printf("\n=== Tutorial 5 Complete ===\n");
+
+/// ## Key Takeaways
+///
+///   - Kademlia DHT is enabled by default (`mountKad: true`)
+///   - Bootstrap nodes help new peers join the DHT
+///   - `kadPutValue(key, value)` stores a value
+///   - `kadGetValue(key, quorum)` retrieves it
+///   - `kadGetRandomRecords()` discovers random peers in the DHT
+///   - Values may take a moment to propagate after storing
+///
+/// In the [next tutorial](tutorial_6_kademlia_providers.md), we'll
+/// explore provider records — a way to find which peers offer
+/// specific content.
+    return 0;
+}

--- a/tutorial/tutorial_5_kademlia_basics.cpp
+++ b/tutorial/tutorial_5_kademlia_basics.cpp
@@ -172,6 +172,12 @@ int main()
 
 /// ## Run tutorial
 ///
+/// Build the module (one time):
+/// ```bash
+/// nix develop
+/// ./tutorial/build_tutorials.sh
+/// ```
+///
 /// Run this tutorial:
 /// ```bash
 /// ./build/tutorial_5_kademlia_basics

--- a/tutorial/tutorial_6_kademlia_providers.cpp
+++ b/tutorial/tutorial_6_kademlia_providers.cpp
@@ -1,0 +1,161 @@
+/// # Tutorial 6: Kademlia Provider Records
+///
+/// In the [previous tutorial](tutorial_5_kademlia_basics.md), we stored and
+/// retrieved raw key-value pairs in the DHT. But what if you want to
+/// advertise that your node **has** a piece of content, rather than
+/// storing the content itself?
+///
+/// This is where **provider records** come in. Instead of putting a value
+/// directly, you announce that your node provides a given Content ID (CID),
+/// and other peers can discover who provides that content.
+///
+/// ## Provider Records vs Key-Value Store
+///
+/// | Feature | Key-Value Store | Provider Records |
+/// |---------|----------------|------------------|
+/// | What's stored | The value itself | The list of provider peer IDs |
+/// | Use case | Small configs, peer info | File sharing, content discovery |
+/// | Data size | Unlimited (but impractical for large data) | Metadata only |
+/// | Finding | `kadGetValue(key)` | `kadGetProviders(cid)` |
+///
+/// ## Content IDs (CIDs)
+///
+/// CIDs are self-describing content hashes used in IPFS and IPLD. The
+/// `toCid()` function converts a string key into a CID that can be used
+/// with the provider API.
+#include <cstdio>
+#include <string>
+#include <vector>
+#include "plugin.h"
+
+int main()
+{
+    printf("=== Tutorial 6: Kademlia Provider Records ===\n\n");
+
+/// ## Step 1: Create two peers
+    Libp2pModuleOptions optsA, optsB;
+    optsA.addrs = {"/ip4/127.0.0.1/tcp/9490"};
+    optsA.mountKad = true;
+
+    optsB.addrs = {"/ip4/127.0.0.1/tcp/9491"};
+    optsB.mountKad = true;
+
+    Libp2pModuleImpl nodeA(optsA);
+    Libp2pModuleImpl nodeB(optsB);
+
+    if (!nodeA.start().success) {
+        fprintf(stderr, "Node A failed\n");
+        return 1;
+    }
+
+    auto infoA = nodeA.peerInfo().value;
+    std::string peerIdA = infoA["peerId"].get<std::string>();
+    std::vector<std::string> addrsA;
+    for (const auto& a : infoA["addrs"])
+        addrsA.push_back(a.get<std::string>());
+
+    // Bootstrap and connect Node B
+    optsB.bootstrapNodes = {{peerIdA, addrsA}};
+    Libp2pModuleImpl nodeB_final(optsB);
+    // Moving to a fresh node... but nodeB was already created.
+    // Let's instead just connect after creating properly:
+    Libp2pModuleImpl nodeB_real(optsB);
+    if (!nodeB_real.start().success) {
+        fprintf(stderr, "Node B failed\n");
+        return 1;
+    }
+
+    if (!nodeB_real.connectPeer(peerIdA, addrsA, 5000).success) {
+        fprintf(stderr, "Failed to connect\n");
+        return 1;
+    }
+    printf("Nodes connected\n");
+
+/// ## Step 2: Convert a content key to a CID
+///
+/// The `toCid()` function takes a string and produces a CID (Content ID)
+/// that can be used with Kadmelia's provider API.
+    std::string contentKey = "my-awesome-file.txt";
+    printf("Converting \"%s\" to CID...\n", contentKey.c_str());
+    auto cidRes = nodeA.toCid(contentKey);
+    if (!cidRes.success) {
+        fprintf(stderr, "Failed to create CID: %s\n",
+                cidRes.error.c_str());
+        return 1;
+    }
+    std::string cid = cidRes.value.get<std::string>();
+    printf("CID: %s\n", cid.c_str());
+
+/// ## Step 3: Node A starts providing the CID
+///
+/// This advertises to the DHT that Node A has this content.
+    printf("\nNode A starting to provide CID...\n");
+    if (!nodeA.kadStartProviding(cid).success) {
+        fprintf(stderr, "kadStartProviding failed\n");
+        return 1;
+    }
+    printf("Node A is now a provider for: %s\n", cid.c_str());
+
+/// ## Step 4: Node B discovers providers
+///
+/// Node B queries the DHT to find who provides this CID.
+    printf("\nNode B looking up providers...\n");
+    auto provRes = nodeB_real.kadGetProviders(cid);
+    if (!provRes.success) {
+        fprintf(stderr, "kadGetProviders failed: %s\n",
+                provRes.error.c_str());
+        return 1;
+    }
+
+    auto providers = provRes.value;
+    printf("Node B found %zu provider(s):\n", providers.size());
+    for (const auto& p : providers) {
+        printf("  Peer: %s\n",
+               p["peerId"].get<std::string>().c_str());
+        for (const auto& addr : p["addrs"]) {
+            printf("    Address: %s\n",
+                   addr.get<std::string>().c_str());
+        }
+    }
+
+/// ## Step 5: Find a specific node in the DHT
+///
+/// We can also use `kadFindNode()` to locate a specific peer in the
+/// DHT routing table.
+    printf("\nNode B finding Node A in the DHT...\n");
+    auto findRes = nodeB_real.kadFindNode(peerIdA);
+    if (findRes.success && findRes.value.is_array()) {
+        printf("Closest peers to Node A:\n");
+        for (const auto& p : findRes.value) {
+            printf("  %s\n", p.get<std::string>().c_str());
+        }
+    }
+
+/// ## Step 6: Stop providing
+///
+/// When Node A no longer has the content, it can stop advertising.
+    printf("\nNode A stopping providing...\n");
+    if (!nodeA.kadStopProviding(cid).success) {
+        fprintf(stderr, "kadStopProviding failed\n");
+        return 1;
+    }
+    printf("Node A stopped providing %s\n", cid.c_str());
+
+/// ## Step 7: Clean up
+    nodeA.stop();
+    nodeB_real.stop();
+
+    printf("\n=== Tutorial 6 Complete ===\n");
+
+/// ## Key Takeaways
+///
+///   - Provider records advertise **content availability**, not content itself
+///   - `toCid()` converts a key string to a CID for use with provider API
+///   - `kadStartProviding()` / `kadStopProviding()` manage provider announcements
+///   - `kadGetProviders()` discovers who has content
+///   - `kadFindNode()` finds peers in the DHT routing table
+///
+/// In the [next tutorial](tutorial_7_gossipsub.md), we'll explore
+/// GossipSub for pub/sub messaging.
+    return 0;
+}

--- a/tutorial/tutorial_6_kademlia_providers.cpp
+++ b/tutorial/tutorial_6_kademlia_providers.cpp
@@ -41,7 +41,6 @@ int main()
     optsB.mountKad = true;
 
     Libp2pModuleImpl nodeA(optsA);
-    Libp2pModuleImpl nodeB(optsB);
 
     if (!nodeA.start().success) {
         fprintf(stderr, "Node A failed\n");
@@ -56,16 +55,13 @@ int main()
 
     // Bootstrap and connect Node B
     optsB.bootstrapNodes = {{peerIdA, addrsA}};
-    Libp2pModuleImpl nodeB_final(optsB);
-    // Moving to a fresh node... but nodeB was already created.
-    // Let's instead just connect after creating properly:
-    Libp2pModuleImpl nodeB_real(optsB);
-    if (!nodeB_real.start().success) {
+    Libp2pModuleImpl nodeB(optsB);
+    if (!nodeB.start().success) {
         fprintf(stderr, "Node B failed\n");
         return 1;
     }
 
-    if (!nodeB_real.connectPeer(peerIdA, addrsA, 5000).success) {
+    if (!nodeB.connectPeer(peerIdA, addrsA, 5000).success) {
         fprintf(stderr, "Failed to connect\n");
         return 1;
     }
@@ -100,7 +96,7 @@ int main()
 ///
 /// Node B queries the DHT to find who provides this CID.
     printf("\nNode B looking up providers...\n");
-    auto provRes = nodeB_real.kadGetProviders(cid);
+    auto provRes = nodeB.kadGetProviders(cid);
     if (!provRes.success) {
         fprintf(stderr, "kadGetProviders failed: %s\n",
                 provRes.error.c_str());
@@ -123,7 +119,7 @@ int main()
 /// We can also use `kadFindNode()` to locate a specific peer in the
 /// DHT routing table.
     printf("\nNode B finding Node A in the DHT...\n");
-    auto findRes = nodeB_real.kadFindNode(peerIdA);
+    auto findRes = nodeB.kadFindNode(peerIdA);
     if (findRes.success && findRes.value.is_array()) {
         printf("Closest peers to Node A:\n");
         for (const auto& p : findRes.value) {
@@ -143,7 +139,7 @@ int main()
 
 /// ## Step 7: Clean up
     nodeA.stop();
-    nodeB_real.stop();
+    nodeB.stop();
 
     printf("\n=== Tutorial 6 Complete ===\n");
 

--- a/tutorial/tutorial_6_kademlia_providers.cpp
+++ b/tutorial/tutorial_6_kademlia_providers.cpp
@@ -157,13 +157,6 @@ int main()
 
 /// ## Run tutorial
 ///
-/// Build the module (one time):
 /// ```bash
-/// nix develop
-/// ./tutorial/build_tutorials.sh
-/// ```
-///
-/// Run this tutorial:
-/// ```bash
-/// ./build/tutorial_6_kademlia_providers
+/// ./build/tutorial/tutorial_6_kademlia_providers
 /// ```

--- a/tutorial/tutorial_6_kademlia_providers.cpp
+++ b/tutorial/tutorial_6_kademlia_providers.cpp
@@ -147,6 +147,10 @@ int main()
 
     printf("\n=== Tutorial 6 Complete ===\n");
 
+    return 0;
+}
+
+
 /// ## Key Takeaways
 ///
 ///   - Provider records advertise **content availability**, not content itself
@@ -154,8 +158,10 @@ int main()
 ///   - `kadStartProviding()` / `kadStopProviding()` manage provider announcements
 ///   - `kadGetProviders()` discovers who has content
 ///   - `kadFindNode()` finds peers in the DHT routing table
+
+/// ## Run tutorial
 ///
-/// In the [next tutorial](tutorial_7_gossipsub.md), we'll explore
-/// GossipSub for pub/sub messaging.
-    return 0;
-}
+/// Run this tutorial:
+/// ```bash
+/// ./build/tutorial_6_kademlia_providers
+/// ```

--- a/tutorial/tutorial_6_kademlia_providers.cpp
+++ b/tutorial/tutorial_6_kademlia_providers.cpp
@@ -74,7 +74,7 @@ int main()
 /// ## Step 2: Convert a content key to a CID
 ///
 /// The `toCid()` function takes a string and produces a CID (Content ID)
-/// that can be used with Kadmelia's provider API.
+/// that can be used with Kademlia's provider API.
     std::string contentKey = "my-awesome-file.txt";
     printf("Converting \"%s\" to CID...\n", contentKey.c_str());
     auto cidRes = nodeA.toCid(contentKey);

--- a/tutorial/tutorial_6_kademlia_providers.cpp
+++ b/tutorial/tutorial_6_kademlia_providers.cpp
@@ -161,6 +161,12 @@ int main()
 
 /// ## Run tutorial
 ///
+/// Build the module (one time):
+/// ```bash
+/// nix develop
+/// ./tutorial/build_tutorials.sh
+/// ```
+///
 /// Run this tutorial:
 /// ```bash
 /// ./build/tutorial_6_kademlia_providers

--- a/tutorial/tutorial_7_gossipsub.cpp
+++ b/tutorial/tutorial_7_gossipsub.cpp
@@ -1,0 +1,192 @@
+/// # Tutorial 7: GossipSub – Pub/Sub Messaging
+///
+/// GossipSub is a pub/sub protocol that lets peers broadcast messages to
+/// everyone subscribed to a topic. It's the foundation for many
+/// decentralized applications — from chat rooms to blockchain transaction
+/// propagation.
+///
+/// In this tutorial we'll:
+///   - Subscribe two nodes to the same topic
+///   - Wait for the GossipSub mesh to form
+///   - Publish a message from one node
+///   - Receive it on the other node
+///
+/// ## How GossipSub Works
+///
+/// 1. Peers subscribe to topics by calling `gossipsubSubscribe(topic)`
+/// 2. libp2p builds a **mesh** — a set of peer connections per topic
+/// 3. When a peer publishes to a topic, the message is forwarded through
+///    the mesh to all subscribers
+/// 4. Subscribers receive messages via `gossipsubNextMessage(topic, timeout)`
+///
+/// > **Note**: The GossipSub mesh takes some time to form after both
+/// > peers have subscribed. A short delay (1-2 seconds) is usually enough.
+#include <cstdio>
+#include <chrono>
+#include <thread>
+#include <string>
+#include "plugin.h"
+
+int main()
+{
+    printf("=== Tutorial 7: GossipSub – Pub/Sub Messaging ===\n\n");
+
+/// ## Step 1: Create two nodes with GossipSub enabled
+///
+/// GossipSub is enabled by default (`mountGossipsub: true`).
+/// We keep it explicit here for clarity.
+    Libp2pModuleOptions optsA, optsB;
+    optsA.addrs = {"/ip4/127.0.0.1/tcp/9590"};
+    optsA.mountGossipsub = true;
+
+    optsB.addrs = {"/ip4/127.0.0.1/tcp/9591"};
+    optsB.mountGossipsub = true;
+
+    Libp2pModuleImpl nodeA(optsA);
+    Libp2pModuleImpl nodeB(optsB);
+
+    if (!nodeA.start().success) {
+        fprintf(stderr, "Node A failed\n");
+        return 1;
+    }
+    if (!nodeB.start().success) {
+        fprintf(stderr, "Node B failed\n");
+        return 1;
+    }
+    printf("Both nodes started\n");
+
+/// ## Step 2: Connect the nodes
+///
+/// GossipSub needs connectivity between peers to build the mesh.
+    auto infoA = nodeA.peerInfo().value;
+    std::string peerIdA = infoA["peerId"].get<std::string>();
+    std::vector<std::string> addrsA;
+    for (const auto& a : infoA["addrs"])
+        addrsA.push_back(a.get<std::string>());
+
+    printf("Connecting Node B to Node A...\n");
+    if (!nodeB.connectPeer(peerIdA, addrsA, 5000).success) {
+        fprintf(stderr, "Failed to connect\n");
+        return 1;
+    }
+    printf("Connected\n");
+
+/// ## Step 3: Both nodes subscribe to a topic
+///
+/// A topic is just a string identifier. Peers who subscribe to the
+/// same topic will receive each other's messages.
+    std::string topic = "chat-room-1";
+    printf("Node B subscribing to topic: \"%s\"\n", topic.c_str());
+    if (!nodeB.gossipsubSubscribe(topic).success) {
+        fprintf(stderr, "Node B subscribe failed\n");
+        return 1;
+    }
+
+    printf("Node A subscribing to topic: \"%s\"\n", topic.c_str());
+    if (!nodeA.gossipsubSubscribe(topic).success) {
+        fprintf(stderr, "Node A subscribe failed\n");
+        return 1;
+    }
+
+/// ## Step 4: Wait for the GossipSub mesh to form
+///
+/// After subscribing, libp2p needs time to discover subscribers
+/// and build the message-forwarding mesh.
+    printf("Waiting for GossipSub mesh to form...\n");
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+
+/// ## Step 5: Publish a message
+///
+/// Node A publishes a message to the topic. It will be forwarded
+/// to all subscribers (including Node B).
+    std::string payload = "Hello from Node A via GossipSub!";
+    printf("\nNode A publishing: \"%s\"\n", payload.c_str());
+    printf("  Topic: \"%s\"\n", topic.c_str());
+
+    if (!nodeA.gossipsubPublish(topic, payload).success) {
+        fprintf(stderr, "Publish failed\n");
+        return 1;
+    }
+    printf("Message published!\n");
+
+/// ## Step 6: Receive the message on Node B
+///
+/// `gossipsubNextMessage()` blocks until a message arrives or the
+/// timeout expires. The timeout is in milliseconds.
+    printf("\nNode B waiting for message...\n");
+    auto res = nodeB.gossipsubNextMessage(topic, 3000);
+    if (!res.success) {
+        fprintf(stderr, "Node B did not receive any messages: %s\n",
+                res.error.c_str());
+        return 1;
+    }
+
+    std::string received = res.value.get<std::string>();
+    printf("Node B received: \"%s\"\n", received.c_str());
+
+    if (received == payload) {
+        printf("Message verified!\n");
+    } else {
+        printf("Message content differs (expected: \"%s\")\n",
+               payload.c_str());
+    }
+
+/// ## Step 7: Alternative — listen via event callback
+///
+/// Instead of polling with `gossipsubNextMessage()`, you can listen
+/// for the `"gossipsubMessage"` event via `emitEvent`. This is useful
+/// for event-driven applications.
+    printf("\n--- Alternative: Event-driven reception ---\n");
+
+    bool messageReceived = false;
+    std::string eventMessage;
+
+    nodeA.emitEvent = [&](const std::string& name,
+                          const std::string& data) {
+        if (name == "gossipsubMessage") {
+            auto j = nlohmann::json::parse(data);
+            std::string eventTopic = j["topic"].get<std::string>();
+            std::string msg = j["data"].get<std::string>();
+            printf("Node A (event): received on topic \"%s\": \"%s\"\n",
+                   eventTopic.c_str(), msg.c_str());
+            messageReceived = true;
+            eventMessage = msg;
+        }
+    };
+
+    // Publish another message
+    std::string payload2 = "Second message via event!";
+    nodeB.gossipsubPublish(topic, payload2);
+
+    // Give it a moment to arrive
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    if (messageReceived) {
+        printf("Event-driven reception worked: \"%s\"\n",
+               eventMessage.c_str());
+    }
+
+/// ## Step 8: Unsubscribe and clean up
+    printf("\nUnsubscribing...\n");
+    nodeB.gossipsubUnsubscribe(topic);
+    nodeA.gossipsubUnsubscribe(topic);
+
+    nodeA.stop();
+    nodeB.stop();
+
+    printf("\n=== Tutorial 7 Complete ===\n");
+
+/// ## Key Takeaways
+///
+///   - GossipSub provides topic-based pub/sub messaging
+///   - Both publisher and subscriber must subscribe to the topic
+///   - Allow 1-2 seconds for the mesh to form
+///   - Use `gossipsubNextMessage(topic, timeout)` for polling
+///   - Use `emitEvent` for event-driven message reception
+///   - Always unsubscribe and stop cleanly
+///
+/// In the [next tutorial](tutorial_8_service_discovery.md), we'll
+/// learn how peers can discover each other by capability using the
+/// service discovery API.
+    return 0;
+}

--- a/tutorial/tutorial_7_gossipsub.cpp
+++ b/tutorial/tutorial_7_gossipsub.cpp
@@ -190,6 +190,12 @@ int main()
 
 /// ## Run tutorial
 ///
+/// Build the module (one time):
+/// ```bash
+/// nix develop
+/// ./tutorial/build_tutorials.sh
+/// ```
+///
 /// Run this tutorial:
 /// ```bash
 /// ./build/tutorial_7_gossipsub

--- a/tutorial/tutorial_7_gossipsub.cpp
+++ b/tutorial/tutorial_7_gossipsub.cpp
@@ -138,9 +138,9 @@ int main()
 /// for event-driven applications.
     printf("\n--- Alternative: Event-driven reception ---\n");
 
+    std::mutex eventMtx;
     bool messageReceived = false;
     std::string eventMessage;
-
     nodeA.emitEvent = [&](const std::string& name,
                           const std::string& data) {
         if (name == "gossipsubMessage") {
@@ -149,8 +149,11 @@ int main()
             std::string msg = j["data"].get<std::string>();
             printf("Node A (event): received on topic \"%s\": \"%s\"\n",
                    eventTopic.c_str(), msg.c_str());
-            messageReceived = true;
-            eventMessage = msg;
+            {
+                std::lock_guard<std::mutex> lock(eventMtx);
+                messageReceived = true;
+                eventMessage = msg;
+            }
         }
     };
 
@@ -161,9 +164,17 @@ int main()
     // Give it a moment to arrive
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
-    if (messageReceived) {
+    bool received = false;
+    std::string msgCopy;
+    {
+        std::lock_guard<std::mutex> lock(eventMtx);
+        received = messageReceived;
+        msgCopy = eventMessage;
+    }
+
+    if (received) {
         printf("Event-driven reception worked: \"%s\"\n",
-               eventMessage.c_str());
+               msgCopy.c_str());
     }
 
 /// ## Step 8: Unsubscribe and clean up

--- a/tutorial/tutorial_7_gossipsub.cpp
+++ b/tutorial/tutorial_7_gossipsub.cpp
@@ -175,6 +175,9 @@ int main()
     nodeB.stop();
 
     printf("\n=== Tutorial 7 Complete ===\n");
+    
+    return 0;
+}
 
 /// ## Key Takeaways
 ///
@@ -184,9 +187,10 @@ int main()
 ///   - Use `gossipsubNextMessage(topic, timeout)` for polling
 ///   - Use `emitEvent` for event-driven message reception
 ///   - Always unsubscribe and stop cleanly
+
+/// ## Run tutorial
 ///
-/// In the [next tutorial](tutorial_8_service_discovery.md), we'll
-/// learn how peers can discover each other by capability using the
-/// service discovery API.
-    return 0;
-}
+/// Run this tutorial:
+/// ```bash
+/// ./build/tutorial_7_gossipsub
+/// ```

--- a/tutorial/tutorial_7_gossipsub.cpp
+++ b/tutorial/tutorial_7_gossipsub.cpp
@@ -203,13 +203,6 @@ int main()
 
 /// ## Run tutorial
 ///
-/// Build the module (one time):
 /// ```bash
-/// nix develop
-/// ./tutorial/build_tutorials.sh
-/// ```
-///
-/// Run this tutorial:
-/// ```bash
-/// ./build/tutorial_7_gossipsub
+/// ./build/tutorial/tutorial_7_gossipsub
 /// ```

--- a/tutorial/tutorial_7_gossipsub.cpp
+++ b/tutorial/tutorial_7_gossipsub.cpp
@@ -23,8 +23,10 @@
 /// > peers have subscribed. A short delay (1-2 seconds) is usually enough.
 #include <cstdio>
 #include <chrono>
+#include <mutex>
 #include <thread>
 #include <string>
+#include <vector>
 #include "plugin.h"
 
 int main()
@@ -164,15 +166,15 @@ int main()
     // Give it a moment to arrive
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
-    bool received = false;
+    bool eventReceived = false;
     std::string msgCopy;
     {
         std::lock_guard<std::mutex> lock(eventMtx);
-        received = messageReceived;
+        eventReceived = messageReceived;
         msgCopy = eventMessage;
     }
 
-    if (received) {
+    if (eventReceived) {
         printf("Event-driven reception worked: \"%s\"\n",
                msgCopy.c_str());
     }
@@ -186,7 +188,7 @@ int main()
     nodeB.stop();
 
     printf("\n=== Tutorial 7 Complete ===\n");
-    
+
     return 0;
 }
 

--- a/tutorial/tutorial_8_service_discovery.cpp
+++ b/tutorial/tutorial_8_service_discovery.cpp
@@ -258,13 +258,6 @@ int main()
 
 /// ## Run tutorial
 ///
-/// Build the module (one time):
 /// ```bash
-/// nix develop
-/// ./tutorial/build_tutorials.sh
-/// ```
-///
-/// Run this tutorial:
-/// ```bash
-/// ./build/tutorial_8_service_discovery
+/// ./build/tutorial/tutorial_8_service_discovery
 /// ```

--- a/tutorial/tutorial_8_service_discovery.cpp
+++ b/tutorial/tutorial_8_service_discovery.cpp
@@ -1,0 +1,258 @@
+/// # Tutorial 8: Service Discovery
+///
+/// In decentralized networks, peers join and leave dynamically. How do you
+/// find a peer that offers a specific service? That's what **Service
+/// Discovery** (Disco) is for.
+///
+/// Service Discovery lets peers:
+///   - **Advertise** the services they offer
+///   - **Discover** peers offering services they're interested in
+///   - **Register interest** to be notified when new providers appear
+///   - **Query randomly** to discover the network
+///
+/// ## Architecture
+///
+/// Service Discovery uses a **bootstrap node** as a rendezvous point.
+/// All peers connect to the bootstrap and register their services there.
+/// Looking up a service queries the bootstrap, which returns matching peers.
+///
+/// ```
+///     Bootstrap
+///     /       \
+///   Advertiser  Discoverer
+/// ```
+#include <cstdio>
+#include <chrono>
+#include <thread>
+#include <string>
+#include <vector>
+#include <utility>
+#include "plugin.h"
+
+/// Helper to extract peer info from a node:
+static std::pair<std::string, std::vector<std::string>> getPeerInfo(
+    Libp2pModuleImpl& node)
+{
+    auto info = node.peerInfo().value;
+    std::string peerId = info["peerId"].get<std::string>();
+    std::vector<std::string> addrs;
+    for (const auto& a : info["addrs"])
+        addrs.push_back(a.get<std::string>());
+    return {peerId, addrs};
+}
+
+/// Helper to retry a lookup with backoff:
+static nlohmann::json lookupWithRetry(
+    Libp2pModuleImpl& node,
+    const std::string& serviceId,
+    const std::string& serviceData,
+    int attempts,
+    int delayMs)
+{
+    for (int i = 0; i < attempts; ++i) {
+        auto res = node.discoLookup(serviceId, serviceData);
+        if (res.success && res.value.is_array() && !res.value.empty()) {
+            return res.value;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
+    }
+    return nlohmann::json::array();
+}
+
+int main()
+{
+    printf("=== Tutorial 8: Service Discovery ===\n\n");
+
+/// ## Step 1: Create a bootstrap node
+///
+/// The bootstrap is a well-known node that all peers connect to.
+/// It relays service advertisements and lookup queries.
+    Libp2pModuleOptions optsBootstrap;
+    optsBootstrap.addrs = {"/ip4/127.0.0.1/tcp/9690"};
+    optsBootstrap.mountServiceDiscovery = true;
+
+    Libp2pModuleImpl bootstrap(optsBootstrap);
+    if (!bootstrap.start().success) {
+        fprintf(stderr, "Bootstrap failed\n");
+        return 1;
+    }
+    if (!bootstrap.discoStart().success) {
+        fprintf(stderr, "Bootstrap discoStart failed\n");
+        return 1;
+    }
+
+    auto [bootstrapId, bootstrapAddrs] = getPeerInfo(bootstrap);
+    printf("Bootstrap node started: %s\n", bootstrapId.c_str());
+
+/// ## Step 2: Create an advertiser node
+///
+/// This node will advertise a service that others can discover.
+    Libp2pModuleOptions optsAdvertiser;
+    optsAdvertiser.addrs = {"/ip4/127.0.0.1/tcp/9691"};
+    optsAdvertiser.bootstrapNodes = {{bootstrapId, bootstrapAddrs}};
+    optsAdvertiser.mountServiceDiscovery = true;
+
+    Libp2pModuleImpl advertiser(optsAdvertiser);
+    if (!advertiser.start().success) {
+        fprintf(stderr, "Advertiser failed\n");
+        return 1;
+    }
+    if (!advertiser.discoStart().success) {
+        fprintf(stderr, "Advertiser discoStart failed\n");
+        return 1;
+    }
+
+    // Connect to bootstrap
+    if (!advertiser.connectPeer(bootstrapId, bootstrapAddrs, 5000).success) {
+        fprintf(stderr, "Advertiser failed to connect to bootstrap\n");
+        return 1;
+    }
+    printf("Advertiser connected to bootstrap\n");
+
+/// ## Step 3: Create a discoverer node
+    Libp2pModuleOptions optsDiscoverer;
+    optsDiscoverer.addrs = {"/ip4/127.0.0.1/tcp/9692"};
+    optsDiscoverer.bootstrapNodes = {{bootstrapId, bootstrapAddrs}};
+    optsDiscoverer.mountServiceDiscovery = true;
+
+    Libp2pModuleImpl discoverer(optsDiscoverer);
+    if (!discoverer.start().success) {
+        fprintf(stderr, "Discoverer failed\n");
+        return 1;
+    }
+    if (!discoverer.discoStart().success) {
+        fprintf(stderr, "Discoverer discoStart failed\n");
+        return 1;
+    }
+
+    if (!discoverer.connectPeer(bootstrapId, bootstrapAddrs, 5000).success) {
+        fprintf(stderr, "Discoverer failed to connect to bootstrap\n");
+        return 1;
+    }
+    printf("Discoverer connected to bootstrap\n");
+
+/// ## Step 4: The advertiser starts advertising a service
+///
+/// Services are identified by a service ID (string) and can carry
+/// arbitrary data (also a string).
+    std::string serviceId = "demo-chat-service";
+    std::string serviceData = "version=1.0;capacity=100";
+
+    printf("\nAdvertiser advertising: \"%s\"\n", serviceId.c_str());
+    if (!advertiser.discoStartAdvertising(serviceId, serviceData).success) {
+        fprintf(stderr, "discoStartAdvertising failed\n");
+        return 1;
+    }
+    printf("Advertising started\n");
+
+/// ## Step 5: The discoverer registers interest
+///
+/// Registering interest tells the service discovery system that
+/// this peer wants to know about providers of this service.
+    printf("Discoverer registering interest in \"%s\"\n", serviceId.c_str());
+    if (!discoverer.discoRegisterInterest(serviceId).success) {
+        fprintf(stderr, "discoRegisterInterest failed\n");
+        return 1;
+    }
+
+/// ## Step 6: Discoverer looks up the service
+///
+/// The lookup queries the bootstrap for peers advertising this
+/// service. It may take a moment for the advertisement to propagate.
+    printf("Discoverer looking up \"%s\"...\n", serviceId.c_str());
+
+    constexpr int kLookupAttempts = 10;
+    constexpr int kLookupDelayMs = 500;
+    auto records = lookupWithRetry(
+        discoverer, serviceId, serviceData,
+        kLookupAttempts, kLookupDelayMs);
+
+    printf("Discoverer found %zu provider(s):\n", records.size());
+    for (const auto& rec : records) {
+        printf("  Peer: %s\n",
+               rec["peerId"].get<std::string>().c_str());
+        for (const auto& s : rec["services"]) {
+            printf("    Service: %s (data: %s)\n",
+                   s["id"].get<std::string>().c_str(),
+                   s["data"].get<std::string>().c_str());
+        }
+    }
+
+/// ## Step 7: Random lookup
+///
+/// You can also discover random peers via `discoRandomLookup()`,
+/// which is useful for network exploration.
+    printf("\nRandom lookup by advertiser...\n");
+    auto randomRes = advertiser.discoRandomLookup();
+    if (randomRes.success && randomRes.value.is_array()) {
+        printf("Found %zu random peer(s):\n", randomRes.value.size());
+        for (const auto& rec : randomRes.value) {
+            printf("  Peer: %s\n",
+                   rec["peerId"].get<std::string>().c_str());
+        }
+    }
+
+/// ## Step 8: Creating and decoding Extended Peer Records (XPR)
+///
+/// Extended Peer Records are signed records that bundle a peer's
+/// addresses and services. They can be shared offline or via
+/// side channels.
+    printf("\n--- Extended Peer Records ---\n");
+
+    std::vector<std::pair<std::string, std::string>> xprServices = {
+        {serviceId, serviceData},
+        {"file-sharing", "v2"},
+    };
+
+    auto xpr = advertiser.createXpr({}, xprServices, 0);
+    if (!xpr.success) {
+        printf("Failed to create XPR: %s\n", xpr.error.c_str());
+    } else {
+        std::string xprStr = xpr.value.get<std::string>();
+        printf("Created signed XPR: %zu bytes\n", xprStr.size());
+
+        // Decode it to verify
+        auto decoded = advertiser.decodeXpr(xprStr);
+        if (!decoded.success) {
+            printf("Failed to decode XPR: %s\n", decoded.error.c_str());
+        } else {
+            printf("Decoded XPR:\n");
+            printf("  Peer ID: %s\n",
+                   decoded.value["peerId"].get<std::string>().c_str());
+            printf("  Sequence: %llu\n",
+                   (unsigned long long)decoded.value["seqNo"]
+                       .get<uint64_t>());
+            printf("  Services: %zu\n",
+                   decoded.value["services"].size());
+        }
+    }
+
+/// ## Step 9: Clean up — unregister, stop advertising, stop disco
+    printf("\nCleaning up...\n");
+    discoverer.discoUnregisterInterest(serviceId);
+    advertiser.discoStopAdvertising(serviceId);
+
+    discoverer.discoStop();
+    advertiser.discoStop();
+    bootstrap.discoStop();
+
+    discoverer.stop();
+    advertiser.stop();
+    bootstrap.stop();
+
+    printf("\n=== Tutorial 8 Complete ===\n");
+
+/// ## Key Takeaways
+///
+///   - Service Discovery requires a bootstrap node as rendezvous
+///   - `discoStart()` / `discoStop()` control the discovery service
+///   - `discoStartAdvertising()` / `discoStopAdvertising()` manage ads
+///   - `discoRegisterInterest()` / `discoUnregisterInterest()` manage subscriptions
+///   - `discoLookup()` finds peers offering a service
+///   - `discoRandomLookup()` discovers random peers
+///   - `createXpr()` / `decodeXpr()` work with signed peer records
+///
+/// In the [next tutorial](tutorial_9_peerstore.md), we'll learn how
+/// to manage known peers in the peer store.
+    return 0;
+}

--- a/tutorial/tutorial_8_service_discovery.cpp
+++ b/tutorial/tutorial_8_service_discovery.cpp
@@ -242,6 +242,10 @@ int main()
 
     printf("\n=== Tutorial 8 Complete ===\n");
 
+    return 0;
+}
+
+
 /// ## Key Takeaways
 ///
 ///   - Service Discovery requires a bootstrap node as rendezvous
@@ -251,8 +255,10 @@ int main()
 ///   - `discoLookup()` finds peers offering a service
 ///   - `discoRandomLookup()` discovers random peers
 ///   - `createXpr()` / `decodeXpr()` work with signed peer records
+
+/// ## Run tutorial
 ///
-/// In the [next tutorial](tutorial_9_peerstore.md), we'll learn how
-/// to manage known peers in the peer store.
-    return 0;
-}
+/// Run this tutorial:
+/// ```bash
+/// ./build/tutorial_8_service_discovery
+/// ```

--- a/tutorial/tutorial_8_service_discovery.cpp
+++ b/tutorial/tutorial_8_service_discovery.cpp
@@ -258,6 +258,12 @@ int main()
 
 /// ## Run tutorial
 ///
+/// Build the module (one time):
+/// ```bash
+/// nix develop
+/// ./tutorial/build_tutorials.sh
+/// ```
+///
 /// Run this tutorial:
 /// ```bash
 /// ./build/tutorial_8_service_discovery

--- a/tutorial/tutorial_9_peerstore.cpp
+++ b/tutorial/tutorial_9_peerstore.cpp
@@ -181,6 +181,12 @@ int main()
 
 /// ## Run tutorial
 ///
+/// Build the module (one time):
+/// ```bash
+/// nix develop
+/// ./tutorial/build_tutorials.sh
+/// ```
+///
 /// Run this tutorial:
 /// ```bash
 /// ./build/tutorial_9_peerstore

--- a/tutorial/tutorial_9_peerstore.cpp
+++ b/tutorial/tutorial_9_peerstore.cpp
@@ -181,13 +181,6 @@ int main()
 
 /// ## Run tutorial
 ///
-/// Build the module (one time):
 /// ```bash
-/// nix develop
-/// ./tutorial/build_tutorials.sh
-/// ```
-///
-/// Run this tutorial:
-/// ```bash
-/// ./build/tutorial_9_peerstore
+/// ./build/tutorial/tutorial_9_peerstore
 /// ```

--- a/tutorial/tutorial_9_peerstore.cpp
+++ b/tutorial/tutorial_9_peerstore.cpp
@@ -1,0 +1,182 @@
+/// # Tutorial 9: Peer Store Management
+///
+/// The **peer store** is libp2p's database of known peers. It maps peer IDs
+/// to their known addresses, protocols, public keys, and metadata.
+///
+/// A well-maintained peer store helps:
+///   - Reconnect to known peers without re-discovery
+///   - Track protocol capabilities of known peers
+///   - Maintain a persistent view of the network
+///
+/// In this tutorial we'll:
+///   - List known peers
+///   - Get detailed peer info
+///   - Manually add peers to the store
+///   - Update addresses and protocols
+///   - Delete peers from the store
+#include <cstdio>
+#include <string>
+#include <vector>
+#include "plugin.h"
+
+int main()
+{
+    printf("=== Tutorial 9: Peer Store Management ===\n\n");
+
+/// ## Step 1: Create a node
+///
+/// The peer store is automatically available on any started node.
+    Libp2pModuleOptions opts;
+    opts.addrs = {"/ip4/127.0.0.1/tcp/9790"};
+
+    Libp2pModuleImpl node(opts);
+
+    if (!node.start().success) {
+        fprintf(stderr, "Node failed to start\n");
+        return 1;
+    }
+
+    auto info = node.peerInfo().value;
+    std::string nodePeerId = info["peerId"].get<std::string>();
+    printf("Node started, peer ID: %s\n", nodePeerId.c_str());
+
+/// ## Step 2: List known peers
+///
+/// Initially, the peer store only contains our own node.
+/// `peerstoreGetPeers()` returns a JSON array of peer IDs.
+    printf("\nListing known peers...\n");
+    auto peersRes = node.peerstoreGetPeers();
+    if (peersRes.success && peersRes.value.is_array()) {
+        printf("Found %zu known peer(s):\n", peersRes.value.size());
+        for (const auto& p : peersRes.value) {
+            printf("  %s\n", p.get<std::string>().c_str());
+        }
+    }
+
+/// ## Step 3: Get detailed peer info
+///
+/// `peerstoreGetPeerInfo()` returns a rich JSON object with addresses,
+/// protocols, and the public key.
+    printf("\nGetting our own peer info from the store:\n");
+    auto ownInfo = node.peerstoreGetPeerInfo(nodePeerId);
+    if (ownInfo.success) {
+        auto& j = ownInfo.value;
+        printf("  Peer ID: %s\n",
+               j["peerId"].get<std::string>().c_str());
+
+        printf("  Addresses:\n");
+        if (j.contains("addrs") && j["addrs"].is_array()) {
+            for (const auto& a : j["addrs"]) {
+                printf("    %s\n", a.get<std::string>().c_str());
+            }
+        }
+
+        printf("  Protocols:\n");
+        if (j.contains("protocols") && j["protocols"].is_array()) {
+            for (const auto& p : j["protocols"]) {
+                printf("    %s\n", p.get<std::string>().c_str());
+            }
+        }
+
+        printf("  Public key: %s\n",
+               j["publicKey"].get<std::string>().c_str());
+    }
+
+/// ## Step 4: Manually add a peer to the store
+///
+/// You can manually register peers in the store. This is useful for
+/// peers discovered through out-of-band methods (e.g. a config file,
+/// QR code, or DNS).
+    printf("\nManually adding a peer to the store...\n");
+
+    std::string manualPeerId =
+        "16Uiu2HAkzM1nzU99VxRqzF9CjZAqjF3MZHQ2oRENL7SNgP1d8pRy";
+    std::vector<std::string> manualAddrs = {
+        "/ip4/192.168.1.100/tcp/9000",
+        "/ip4/10.0.0.50/tcp/9001",
+    };
+    std::vector<std::string> manualProtos = {
+        "/ipfs/ping/1.0.0",
+        "/examples/echo/1.0.0",
+    };
+
+    if (!node.peerstoreAddPeer(manualPeerId, manualAddrs, manualProtos)
+             .success) {
+        fprintf(stderr, "Failed to add peer\n");
+        return 1;
+    }
+    printf("Peer added: %s\n", manualPeerId.c_str());
+
+/// Verify it was added:
+    printf("\nVerifying: listing peers again...\n");
+    auto peersAfter = node.peerstoreGetPeers();
+    if (peersAfter.success && peersAfter.value.is_array()) {
+        printf("Now have %zu known peer(s)\n", peersAfter.value.size());
+    }
+
+/// ## Step 5: Update peer info
+///
+/// `peerstoreSetPeerAddresses()` and `peerstoreSetPeerProtocols()`
+/// update a peer's stored data.
+    printf("\nUpdating peer addresses...\n");
+    std::vector<std::string> updatedAddrs = {
+        "/ip4/192.168.1.100/tcp/9002",
+        "/dns4/peer.example.com/tcp/9000",
+    };
+    if (!node.peerstoreSetPeerAddresses(manualPeerId, updatedAddrs)
+             .success) {
+        fprintf(stderr, "Failed to update addresses\n");
+        return 1;
+    }
+    printf("Addresses updated\n");
+
+    // Check the updated info:
+    auto updatedInfo = node.peerstoreGetPeerInfo(manualPeerId);
+    if (updatedInfo.success) {
+        printf("Updated addresses:\n");
+        for (const auto& a : updatedInfo.value["addrs"]) {
+            printf("  %s\n", a.get<std::string>().c_str());
+        }
+    }
+
+/// ## Step 6: Delete a peer from the store
+///
+/// `peerstoreDeletePeer()` removes a peer and all its metadata.
+    printf("\nDeleting peer from store...\n");
+    if (!node.peerstoreDeletePeer(manualPeerId).success) {
+        fprintf(stderr, "Failed to delete peer\n");
+        return 1;
+    }
+    printf("Peer deleted\n");
+
+/// Verify deletion:
+    auto peersFinal = node.peerstoreGetPeers();
+    if (peersFinal.success && peersFinal.value.is_array()) {
+        printf("Now have %zu known peer(s)\n",
+               peersFinal.value.size());
+        for (const auto& p : peersFinal.value) {
+            printf("  %s\n", p.get<std::string>().c_str());
+        }
+    }
+
+/// ## Step 7: Clean up
+    node.stop();
+
+    printf("\n=== Tutorial 9 Complete ===\n");
+
+/// ## Key Takeaways
+///
+///   - The peer store is a built-in database of known peers
+///   - `peerstoreGetPeers()` lists all known peer IDs
+///   - `peerstoreGetPeerInfo()` returns detailed peer metadata
+///   - `peerstoreAddPeer()` adds peers manually (with addresses + protocols)
+///   - `peerstoreSetPeerAddresses()` / `peerstoreSetPeerProtocols()`
+///     update existing entries
+///   - `peerstoreDeletePeer()` removes peers
+///   - A populated peer store speeds up reconnection and reduces
+///     network overhead
+///
+/// In the [next tutorial](tutorial_10_circuit_relay.md), we'll learn
+/// how to connect peers behind NAT/firewalls using Circuit Relay.
+    return 0;
+}

--- a/tutorial/tutorial_9_peerstore.cpp
+++ b/tutorial/tutorial_9_peerstore.cpp
@@ -164,6 +164,9 @@ int main()
 
     printf("\n=== Tutorial 9 Complete ===\n");
 
+    return 0;
+}
+
 /// ## Key Takeaways
 ///
 ///   - The peer store is a built-in database of known peers
@@ -175,8 +178,10 @@ int main()
 ///   - `peerstoreDeletePeer()` removes peers
 ///   - A populated peer store speeds up reconnection and reduces
 ///     network overhead
+
+/// ## Run tutorial
 ///
-/// In the [next tutorial](tutorial_10_circuit_relay.md), we'll learn
-/// how to connect peers behind NAT/firewalls using Circuit Relay.
-    return 0;
-}
+/// Run this tutorial:
+/// ```bash
+/// ./build/tutorial_9_peerstore
+/// ```


### PR DESCRIPTION
added new `tutorial` dir:
- `tutorial/tutorial_*.cpp` are tutorial files, they are runnable tutorials that are also used to generate `.md` readable files
-  `generate_markdown.sh` - discovers tutorial files and generates `.md`
- `tutorial/docs` is fully auto generated from source, it should be reviewed in form if presentation is good enough
- `tutorial.yml` is CI ensuring that tutorial code can be built and that documentation output is fresh (up to date)

how to review:
-  start were users will start https://github.com/logos-co/logos-libp2p-module/blob/tutorial/tutorial/README.md
- go through generated docs make sure they are ok
- then review code

future effort:
- [disable libp2p logs](https://github.com/logos-co/logos-libp2p-module/issues/79)