### PR TITLE
feat: generic custom-protocol bridge for cross-module consumers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ logos_module(
         src/callbacks.cpp
         src/kademlia.cpp
         src/stream.cpp
+        src/protocol_bridge.cpp
         src/gossipsub.cpp
         src/service_discovery.cpp
         src/custom_handlers.cpp

--- a/src/custom_handlers.cpp
+++ b/src/custom_handlers.cpp
@@ -2,6 +2,29 @@
 
 using json = nlohmann::json;
 
+static constexpr size_t kMaxInboundStreamsPerProto = 1024;
+
+bool Libp2pModuleImpl::enqueueInboundStream(const std::string& proto,
+                                            libp2p_stream_t* stream, uint64_t streamId) {
+    bool queued = false;
+    {
+        std::lock_guard<std::mutex> lock(m_inboundStreamMutex);
+        auto& q = m_inboundStreamQueues[proto];
+        if (q.size() < kMaxInboundStreamsPerProto) {
+            q.push_back(streamId);
+            queued = true;
+        }
+    }
+    if (!queued) {
+        removeStream(streamId);
+        libp2p_stream_release(ctx, stream,
+                              +[](int, const char*, size_t, void*) {}, nullptr);
+        return false;
+    }
+    m_inboundStreamCond.notify_all();
+    return true;
+}
+
 void Libp2pModuleImpl::protocolHandler(
     libp2p_ctx_t* /*ctx*/, libp2p_stream_t* stream,
     const char* proto, size_t protoLen, void* userData)
@@ -15,6 +38,7 @@ void Libp2pModuleImpl::protocolHandler(
         : handlerCtx->proto;
 
     uint64_t streamId = self->addStream(stream);
+    if (!self->enqueueInboundStream(protoStr, stream, streamId)) return;
 
     json j;
     j["streamId"] = streamId;
@@ -34,9 +58,6 @@ void Libp2pModuleImpl::mountCompleteCallback(int ret, const char* msg, size_t le
 StdLogosResult Libp2pModuleImpl::mountProtocol(const std::string& proto) {
     if (!ctx) return {false, {}, "No libp2p context"};
     if (proto.empty()) return {false, {}, "Protocol string is empty"};
-    // Without emitEvent, protocolHandler would register a stream that no caller
-    // could ever read, close, or release — leaking the stream.
-    if (!emitEvent) return {false, {}, "emitEvent must be set before mounting a protocol"};
     publishEmitEvent();
 
     auto handlerCtx = std::make_unique<ProtocolHandlerCtx>();

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <deque>
 #include <functional>
 #include <future>
 #include <memory>
@@ -149,6 +150,13 @@ public:
     StdLogosResult streamCloseWithEOF(uint64_t streamId);
     StdLogosResult streamRelease(uint64_t streamId);
 
+    StdLogosResult protocolRequest(const std::string& argsJson);
+    StdLogosResult streamReadLpJson(const std::string& argsJson);
+    StdLogosResult streamWriteLpJson(const std::string& argsJson);
+    StdLogosResult streamCloseJson(const std::string& argsJson);
+    StdLogosResult streamReleaseJson(const std::string& argsJson);
+    StdLogosResult protocolAcceptStream(const std::string& argsJson);
+
     StdLogosResult gossipsubPublish(const std::string& topic, const std::string& data);
     StdLogosResult gossipsubSubscribe(const std::string& topic);
     StdLogosResult gossipsubUnsubscribe(const std::string& topic);
@@ -228,10 +236,17 @@ private:
     uint64_t addStream(libp2p_stream_t* stream);
     std::shared_ptr<StreamEntry> getStream(uint64_t id) const;
     std::shared_ptr<StreamEntry> removeStream(uint64_t id);
+    void removeInboundStream(uint64_t id);
+    bool enqueueInboundStream(const std::string& proto, libp2p_stream_t* stream,
+                              uint64_t streamId);
 
     std::mutex m_queueMutex;
     std::condition_variable m_queueCond;
     std::unordered_map<std::string, std::queue<std::string>> m_topicQueues;
+
+    std::mutex m_inboundStreamMutex;
+    std::condition_variable m_inboundStreamCond;
+    std::unordered_map<std::string, std::deque<uint64_t>> m_inboundStreamQueues;
 
     void applyOptions(const Libp2pModuleOptions& options);
     StdLogosResult createContext();
@@ -315,14 +330,16 @@ private:
     // whole sync-over-async call so a concurrent streamRelease can't free
     // entry->ptr mid-flight. `invoke(libp2p_stream_t*, SyncPromise*)`.
     template <class Invoke>
-    StdLogosResult callSyncStream(uint64_t streamId, const char* errPrefix, Invoke&& invoke) {
+    StdLogosResult callSyncStream(uint64_t streamId, const char* errPrefix, Invoke&& invoke,
+                                  int awaitMs = kDefaultOpTimeoutMs) {
         return callSyncStreamWith(streamId, errPrefix, std::forward<Invoke>(invoke),
-            [](const SyncResult&) -> StdLogosResult { return {true, {}, ""}; });
+            [](const SyncResult&) -> StdLogosResult { return {true, {}, ""}; }, awaitMs);
     }
 
     template <class Invoke, class Transform>
     StdLogosResult callSyncStreamWith(uint64_t streamId, const char* errPrefix,
-                                       Invoke&& invoke, Transform&& transform) {
+                                       Invoke&& invoke, Transform&& transform,
+                                       int awaitMs = kDefaultOpTimeoutMs) {
         if (!ctx || streamId == 0) return {false, {}, "Invalid stream"};
         auto entry = getStream(streamId);
         if (!entry) return {false, {}, "Stream not found"};
@@ -330,7 +347,7 @@ private:
         if (entry->released) return {false, {}, "Stream released"};
         return callSyncWith(errPrefix,
             [&](SyncPromise* p) { return invoke(entry->ptr, p); },
-            std::forward<Transform>(transform));
+            std::forward<Transform>(transform), awaitMs);
     }
 
     // Subscribe contexts live for the subscription's lifetime; the lock guards

--- a/src/protocol_bridge.cpp
+++ b/src/protocol_bridge.cpp
@@ -1,0 +1,207 @@
+#include "plugin.h"
+
+#include <charconv>
+
+using json = nlohmann::json;
+
+namespace {
+
+uint64_t asStreamId(const json& v) {
+    if (v.is_number_unsigned()) return v.get<uint64_t>();
+    if (v.is_number_integer()) return 0;
+    if (v.is_string()) {
+        const std::string& s = v.get_ref<const std::string&>();
+        uint64_t out = 0;
+        auto [p, ec] = std::from_chars(s.data(), s.data() + s.size(), out);
+        if (ec == std::errc{} && p == s.data() + s.size()) return out;
+    }
+    return 0;
+}
+
+bool parseBlob(const std::string& argsJson, const char* what, json& out, StdLogosResult& err) {
+    out = json::parse(argsJson, nullptr, false);
+    if (!out.is_object()) {
+        err = {false, {}, std::string(what) + ": invalid JSON object arg"};
+        return false;
+    }
+    return true;
+}
+
+constexpr uint64_t kDefaultReadMax = 1u << 20;
+
+uint64_t asReadMax(const json& a) {
+    auto it = a.find("maxSize");
+    if (it == a.end() || !it->is_number_unsigned()) return kDefaultReadMax;
+    uint64_t v = it->get<uint64_t>();
+    return v == 0 ? kDefaultReadMax : v;
+}
+
+}  // namespace
+
+StdLogosResult Libp2pModuleImpl::protocolRequest(const std::string& argsJson) {
+    json a;
+    StdLogosResult err;
+    if (!parseBlob(argsJson, "protocolRequest", a, err)) return err;
+
+    std::string peerId, proto, requestB64;
+    std::vector<std::string> multiaddrs;
+    int64_t timeoutMs = 0;
+    uint64_t maxSize = kDefaultReadMax;
+    bool expectResponse = true;
+    try {
+        peerId = a.at("peerId").get<std::string>();
+        proto = a.at("proto").get<std::string>();
+        requestB64 = a.at("requestB64").get<std::string>();
+        if (a.contains("multiaddrs"))
+            for (const auto& m : a["multiaddrs"]) multiaddrs.push_back(m.get<std::string>());
+        timeoutMs = a.value("timeoutMs", static_cast<int64_t>(0));
+        maxSize = asReadMax(a);
+        expectResponse = a.value("expectResponse", true);
+    } catch (...) {
+        return {false, {},
+                "protocolRequest: bad args (need {peerId,proto,multiaddrs?,requestB64,timeoutMs?,maxSize?,expectResponse?})"};
+    }
+
+    std::string requestBytes;
+    try {
+        requestBytes = base64Decode(requestB64);
+    } catch (const std::exception& e) {
+        return {false, {}, std::string("protocolRequest: bad requestB64: ") + e.what()};
+    }
+
+    if (!multiaddrs.empty()) {
+        auto c = connectPeer(peerId, multiaddrs, timeoutMs > 0 ? timeoutMs : kDefaultOpTimeoutMs);
+        if (!c.success) return {false, {}, "protocolRequest: connect failed: " + c.error};
+    }
+
+    auto d = dial(peerId, proto);
+    if (!d.success) return {false, {}, "protocolRequest: dial failed: " + d.error};
+    uint64_t streamId = 0;
+    try { streamId = d.value.get<uint64_t>(); } catch (...) {}
+    if (streamId == 0) return {false, {}, "protocolRequest: dial returned no stream"};
+
+    auto w = streamWriteLp(streamId, requestBytes);
+    if (!w.success) {
+        streamRelease(streamId);
+        return {false, {}, "protocolRequest: write failed: " + w.error};
+    }
+
+    if (!expectResponse) {
+        streamCloseWithEOF(streamId);
+        streamRelease(streamId);
+        return {true, json::object(), ""};
+    }
+
+    auto r = callSyncStreamWith(streamId, "Failed to read LP from stream",
+        [&](libp2p_stream_t* s, SyncPromise* p) {
+            return libp2p_stream_readLp(ctx, s, maxSize,
+                                        &Libp2pModuleImpl::promiseBufferCallback, p);
+        },
+        bufferToResult, awaitTimeoutFor(timeoutMs));
+    streamRelease(streamId);
+    if (!r.success) return {false, {}, "protocolRequest: read failed: " + r.error};
+
+    json out;
+    out["responseB64"] = r.value;
+    return {true, out, ""};
+}
+
+StdLogosResult Libp2pModuleImpl::streamReadLpJson(const std::string& argsJson) {
+    json a;
+    StdLogosResult err;
+    if (!parseBlob(argsJson, "streamReadLpJson", a, err)) return err;
+    if (!a.contains("streamId")) return {false, {}, "streamReadLpJson: missing streamId"};
+
+    uint64_t streamId = 0, maxSize = kDefaultReadMax;
+    int64_t timeoutMs = 0;
+    try {
+        streamId = asStreamId(a["streamId"]);
+        maxSize = asReadMax(a);
+        timeoutMs = a.value("timeoutMs", static_cast<int64_t>(0));
+    } catch (...) {
+        return {false, {}, "streamReadLpJson: bad args (need {streamId, maxSize?, timeoutMs?})"};
+    }
+
+    auto r = callSyncStreamWith(streamId, "Failed to read LP from stream",
+        [&](libp2p_stream_t* s, SyncPromise* p) {
+            return libp2p_stream_readLp(ctx, s, maxSize,
+                                        &Libp2pModuleImpl::promiseBufferCallback, p);
+        },
+        bufferToResult, awaitTimeoutFor(timeoutMs));
+    if (!r.success) return r;
+
+    json out;
+    out["dataB64"] = r.value;
+    return {true, out, ""};
+}
+
+StdLogosResult Libp2pModuleImpl::streamWriteLpJson(const std::string& argsJson) {
+    json a;
+    StdLogosResult err;
+    if (!parseBlob(argsJson, "streamWriteLpJson", a, err)) return err;
+    if (!a.contains("streamId")) return {false, {}, "streamWriteLpJson: missing streamId"};
+
+    uint64_t streamId = asStreamId(a["streamId"]);
+    std::string dataBytes;
+    try {
+        dataBytes = base64Decode(a.at("dataB64").get<std::string>());
+    } catch (const std::exception& e) {
+        return {false, {}, std::string("streamWriteLpJson: missing or bad dataB64: ") + e.what()};
+    }
+
+    auto w = streamWriteLp(streamId, dataBytes);
+    if (!w.success) return w;
+    return {true, json::object(), ""};
+}
+
+StdLogosResult Libp2pModuleImpl::streamCloseJson(const std::string& argsJson) {
+    json a;
+    StdLogosResult err;
+    if (!parseBlob(argsJson, "streamCloseJson", a, err)) return err;
+    if (!a.contains("streamId")) return {false, {}, "streamCloseJson: missing streamId"};
+    return streamClose(asStreamId(a["streamId"]));
+}
+
+StdLogosResult Libp2pModuleImpl::streamReleaseJson(const std::string& argsJson) {
+    json a;
+    StdLogosResult err;
+    if (!parseBlob(argsJson, "streamReleaseJson", a, err)) return err;
+    if (!a.contains("streamId")) return {false, {}, "streamReleaseJson: missing streamId"};
+    return streamRelease(asStreamId(a["streamId"]));
+}
+
+StdLogosResult Libp2pModuleImpl::protocolAcceptStream(const std::string& argsJson) {
+    json a;
+    StdLogosResult err;
+    if (!parseBlob(argsJson, "protocolAcceptStream", a, err)) return err;
+
+    std::string proto;
+    int64_t timeoutMs = 0;
+    try {
+        proto = a.at("proto").get<std::string>();
+        timeoutMs = a.value("timeoutMs", static_cast<int64_t>(0));
+    } catch (...) {
+        return {false, {}, "protocolAcceptStream: bad args (need {proto, timeoutMs?})"};
+    }
+
+    std::unique_lock<std::mutex> lock(m_inboundStreamMutex);
+    auto hasStream = [&] {
+        auto it = m_inboundStreamQueues.find(proto);
+        return it != m_inboundStreamQueues.end() && !it->second.empty();
+    };
+    if (!hasStream()) {
+        auto wait = std::chrono::milliseconds(timeoutMs > 0 ? timeoutMs : 0);
+        if (!m_inboundStreamCond.wait_for(lock, wait, hasStream)) {
+            return {false, {}, "timeout waiting for inbound stream"};
+        }
+    }
+    auto it = m_inboundStreamQueues.find(proto);
+    if (it == m_inboundStreamQueues.end() || it->second.empty()) {
+        return {false, {}, "no inbound stream"};
+    }
+    uint64_t streamId = it->second.front();
+    it->second.pop_front();
+    lock.unlock();
+
+    return {true, json{{"streamId", streamId}, {"proto", proto}}, ""};
+}

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -19,12 +19,28 @@ Libp2pModuleImpl::getStream(uint64_t id) const {
 
 std::shared_ptr<Libp2pModuleImpl::StreamEntry>
 Libp2pModuleImpl::removeStream(uint64_t id) {
-    std::unique_lock<std::shared_mutex> lock(m_streamsLock);
-    auto it = m_streams.find(id);
-    if (it == m_streams.end()) return nullptr;
-    auto entry = std::move(it->second);
-    m_streams.erase(it);
+    std::shared_ptr<StreamEntry> entry;
+    {
+        std::unique_lock<std::shared_mutex> lock(m_streamsLock);
+        auto it = m_streams.find(id);
+        if (it == m_streams.end()) return nullptr;
+        entry = std::move(it->second);
+        m_streams.erase(it);
+    }
+    removeInboundStream(id);
     return entry;
+}
+
+void Libp2pModuleImpl::removeInboundStream(uint64_t id) {
+    std::lock_guard<std::mutex> lock(m_inboundStreamMutex);
+    for (auto& [proto, q] : m_inboundStreamQueues) {
+        for (auto it = q.begin(); it != q.end(); ++it) {
+            if (*it == id) {
+                q.erase(it);
+                return;
+            }
+        }
+    }
 }
 
 StdLogosResult Libp2pModuleImpl::streamClose(uint64_t streamId) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ if(LIBP2P_PATH)
             ../src/callbacks.cpp
             ../src/kademlia.cpp
             ../src/stream.cpp
+            ../src/protocol_bridge.cpp
             ../src/gossipsub.cpp
             ../src/service_discovery.cpp
             ../src/custom_handlers.cpp

--- a/tests/custom_handlers.cpp
+++ b/tests/custom_handlers.cpp
@@ -3,6 +3,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <chrono>
+#include <thread>
 
 using json = nlohmann::json;
 
@@ -19,12 +20,10 @@ static std::pair<std::string, std::vector<std::string>> getPeerInfoPair(Libp2pMo
 
 static auto noopEmitEvent = [](const std::string&, const std::string&) {};
 
-LOGOS_TEST(custom_handlers_mount_requires_emit_event) {
+LOGOS_TEST(custom_handlers_mount_without_emit_event_ok) {
     Libp2pModuleImpl node;
     LOGOS_ASSERT_TRUE(node.start().success);
-    auto res = node.mountProtocol("/test/proto/1.0.0");
-    LOGOS_ASSERT_FALSE(res.success);
-    LOGOS_ASSERT_CONTAINS(res.error, "emitEvent");
+    LOGOS_ASSERT_TRUE(node.mountProtocol("/test/proto/1.0.0").success);
     LOGOS_ASSERT_TRUE(node.stop().success);
 }
 
@@ -105,4 +104,156 @@ LOGOS_TEST(custom_handlers_protocol_stream_event) {
 
     LOGOS_ASSERT_TRUE(nodeA.stop().success);
     LOGOS_ASSERT_TRUE(nodeB.stop().success);
+}
+
+LOGOS_TEST(protocol_bridge_request_accept_roundtrip) {
+    const std::string proto = "/test/bridge/1.0.0";
+
+    Libp2pModuleImpl nodeA;
+    Libp2pModuleImpl nodeB;
+
+    LOGOS_ASSERT_TRUE(nodeB.start().success);
+    LOGOS_ASSERT_TRUE(nodeB.mountProtocol(proto).success);
+    LOGOS_ASSERT_TRUE(nodeA.start().success);
+
+    const std::string request = "ping-over-the-bridge";
+    auto [peerIdB, addrsB] = getPeerInfoPair(nodeB);
+
+    std::string serverSawRequest;
+    bool serverOk = false;
+    std::thread server([&] {
+        auto acc = nodeB.protocolAcceptStream(json{{"proto", proto}, {"timeoutMs", 5000}}.dump());
+        if (!acc.success) return;
+        uint64_t sid = acc.value["streamId"].get<uint64_t>();
+        if (sid == 0) return;
+
+        auto rd = nodeB.streamReadLpJson(json{{"streamId", sid}, {"timeoutMs", 5000}}.dump());
+        if (!rd.success) return;
+        serverSawRequest = base64Decode(rd.value["dataB64"].get<std::string>());
+
+        std::string resp = "echo:" + serverSawRequest;
+        std::vector<uint8_t> respBytes(resp.begin(), resp.end());
+        auto w = nodeB.streamWriteLpJson(
+            json{{"streamId", sid}, {"dataB64", base64Encode(respBytes)}}.dump());
+        auto r = nodeB.streamReleaseJson(json{{"streamId", sid}}.dump());
+        serverOk = w.success && r.success;
+    });
+
+    std::vector<uint8_t> reqBytes(request.begin(), request.end());
+    auto resp = nodeA.protocolRequest(json{
+        {"peerId", peerIdB},
+        {"multiaddrs", addrsB},
+        {"proto", proto},
+        {"requestB64", base64Encode(reqBytes)},
+        {"timeoutMs", 5000},
+    }.dump());
+    server.join();
+
+    LOGOS_ASSERT_TRUE(serverOk);
+    LOGOS_ASSERT_TRUE(serverSawRequest == request);
+    LOGOS_ASSERT_TRUE(resp.success);
+    std::string respStr = base64Decode(resp.value["responseB64"].get<std::string>());
+    LOGOS_ASSERT_TRUE(respStr == "echo:" + request);
+
+    LOGOS_ASSERT_TRUE(nodeA.stop().success);
+    LOGOS_ASSERT_TRUE(nodeB.stop().success);
+}
+
+LOGOS_TEST(protocol_bridge_request_no_response) {
+    const std::string proto = "/test/bridge/noresp/1.0.0";
+
+    Libp2pModuleImpl nodeA;
+    Libp2pModuleImpl nodeB;
+
+    LOGOS_ASSERT_TRUE(nodeB.start().success);
+    LOGOS_ASSERT_TRUE(nodeB.mountProtocol(proto).success);
+    LOGOS_ASSERT_TRUE(nodeA.start().success);
+
+    const std::string request = "fire-and-forget";
+    auto [peerIdB, addrsB] = getPeerInfoPair(nodeB);
+    std::string serverSawRequest;
+    bool serverOk = false;
+    std::thread server([&] {
+        auto acc = nodeB.protocolAcceptStream(json{{"proto", proto}, {"timeoutMs", 5000}}.dump());
+        if (!acc.success) return;
+        uint64_t sid = acc.value["streamId"].get<uint64_t>();
+        if (sid == 0) return;
+        auto rd = nodeB.streamReadLpJson(json{{"streamId", sid}, {"timeoutMs", 5000}}.dump());
+        if (!rd.success) return;
+        serverSawRequest = base64Decode(rd.value["dataB64"].get<std::string>());
+        serverOk = nodeB.streamReleaseJson(json{{"streamId", sid}}.dump()).success;
+    });
+
+    std::vector<uint8_t> reqBytes(request.begin(), request.end());
+    auto resp = nodeA.protocolRequest(json{
+        {"peerId", peerIdB},
+        {"multiaddrs", addrsB},
+        {"proto", proto},
+        {"requestB64", base64Encode(reqBytes)},
+        {"timeoutMs", 5000},
+        {"expectResponse", false},
+    }.dump());
+    server.join();
+
+    LOGOS_ASSERT_TRUE(resp.success);
+    LOGOS_ASSERT_TRUE(serverOk);
+    LOGOS_ASSERT_TRUE(serverSawRequest == request);
+
+    LOGOS_ASSERT_TRUE(nodeA.stop().success);
+    LOGOS_ASSERT_TRUE(nodeB.stop().success);
+}
+
+LOGOS_TEST(protocol_bridge_release_purges_inbound_queue) {
+    const std::string proto = "/test/bridge/purge/1.0.0";
+
+    Libp2pModuleImpl nodeA;
+    Libp2pModuleImpl nodeB;
+
+    std::mutex mtx;
+    std::condition_variable cv;
+    uint64_t serverStreamId = 0;
+    bool eventReceived = false;
+
+    nodeB.emitEvent = [&](const std::string& name, const std::string& data) {
+        if (name != "protocolStream") return;
+        auto j = json::parse(data, nullptr, false);
+        if (j.is_discarded()) return;
+        std::lock_guard<std::mutex> lk(mtx);
+        serverStreamId = j["streamId"].get<uint64_t>();
+        eventReceived = true;
+        cv.notify_one();
+    };
+
+    LOGOS_ASSERT_TRUE(nodeB.start().success);
+    LOGOS_ASSERT_TRUE(nodeB.mountProtocol(proto).success);
+    LOGOS_ASSERT_TRUE(nodeA.start().success);
+
+    auto [peerIdB, addrsB] = getPeerInfoPair(nodeB);
+    LOGOS_ASSERT_TRUE(nodeA.connectPeer(peerIdB, addrsB, 500).success);
+    auto dialResult = nodeA.dial(peerIdB, proto);
+    LOGOS_ASSERT_TRUE(dialResult.success);
+    uint64_t clientStreamId = dialResult.value.get<uint64_t>();
+
+    {
+        std::unique_lock<std::mutex> lk(mtx);
+        LOGOS_ASSERT_TRUE(cv.wait_for(lk, std::chrono::seconds(5), [&] { return eventReceived; }));
+    }
+    LOGOS_ASSERT_NE(serverStreamId, static_cast<uint64_t>(0));
+
+    LOGOS_ASSERT_TRUE(nodeB.streamRelease(serverStreamId).success);
+
+    auto acc = nodeB.protocolAcceptStream(json{{"proto", proto}, {"timeoutMs", 200}}.dump());
+    LOGOS_ASSERT_FALSE(acc.success);
+
+    LOGOS_ASSERT_TRUE(nodeA.streamRelease(clientStreamId).success);
+    LOGOS_ASSERT_TRUE(nodeA.stop().success);
+    LOGOS_ASSERT_TRUE(nodeB.stop().success);
+}
+
+LOGOS_TEST(protocol_bridge_write_requires_dataB64) {
+    Libp2pModuleImpl node;
+    LOGOS_ASSERT_TRUE(node.start().success);
+    auto r = node.streamWriteLpJson(json{{"streamId", 1}}.dump());
+    LOGOS_ASSERT_FALSE(r.success);
+    LOGOS_ASSERT_TRUE(node.stop().success);
 }


### PR DESCRIPTION
## Generic custom-protocol bridge for cross-module consumers

Adds content-agnostic, single-JSON-blob methods so a **consumer module** can drive
any length-prefixed request/response protocol over the module boundary — **without
adding protocol-specific code to `libp2p_module`**:

| Method | Shape |
|---|---|
| `protocolRequest` | `{peerId, multiaddrs[], proto, requestB64, timeoutMs?, maxSize?} -> {responseB64}` — connect + dial + writeLp + readLp + release (client one-shot) |
| `streamReadLpJson` | `{streamId, maxSize?, timeoutMs?} -> {dataB64}` |
| `streamWriteLpJson` | `{streamId, dataB64} -> {}` (base64-decoded in C++) |
| `streamCloseJson` / `streamReleaseJson` | `{streamId}` |
| `protocolAcceptStream` | `{proto, timeoutMs?} -> {streamId, proto}` — polling drain of inbound streams |

### Why

The typed `dial`/`stream*` methods take multi-string / `uint64` signatures the
universal codegen QtRO dispatch can't marshal across the module boundary, and
`streamWriteLp` writes **raw** bytes that don't survive a JSON string arg. These
wrappers carry **opaque base64** instead, so any binary protocol survives the trip.
Everything builds on the existing base primitives (`connectPeer`, `dial`,
`streamWriteLp`, `callSyncStreamWith`, `base64*`) — no new dependencies.

### Inbound delivery: polling, not push

`protocolAcceptStream` drains a per-proto queue that `protocolHandler` now fills,
mirroring the existing `gossipsubNextMessage` pattern. This is deliberate: the
`protocolStream` push-event doesn't cross the module boundary (the universal
codegen skips the `emitEvent` sink), so a consumer module has no way to receive
it. Polling is the same mechanism gossipsub already uses successfully.

### Behavior change (please note)

`mountProtocol` **no longer requires `emitEvent` to be set.** Previously it
returned an error when `emitEvent` was unset, to avoid leaking a stream no one
could read. That's now safe because every inbound stream is queued for
`protocolAcceptStream` regardless — and the `protocolStream` event is *still*
emitted when `emitEvent` is set, so in-process consumers (tests/examples) are
unaffected. The existing `custom_handlers_mount_requires_emit_event` test is
updated to assert the new contract (`..._mount_without_emit_event_ok`).

### Tests

`tests/custom_handlers.cpp` adds `protocol_bridge_request_accept_roundtrip`: two
nodes complete a full request→echo→response using **only** the new JSON-blob
methods (server polls `protocolAcceptStream` + `streamReadLpJson` /
`streamWriteLpJson`, client drives one `protocolRequest`), with no `emitEvent`
and no typed calls — the exact cross-module usage shape, exercised in-process.
`src/protocol_bridge.cpp` is added to the integration test build.

### Footprint

+~310 / −8: `src/protocol_bridge.cpp` (new), `src/custom_handlers.cpp`,
`src/plugin.h`, `CMakeLists.txt`, plus `tests/custom_handlers.cpp` /
`tests/CMakeLists.txt`. Validated end-to-end driving a real custom protocol (RLN
membership gifter) cross-module from a separate consumer module.