### PR TITLE
ci(tutorials): add smoke test for code

### DIFF
--- a/.github/workflows/tutorial.yml
+++ b/.github/workflows/tutorial.yml
@@ -56,6 +56,36 @@ jobs:
         run: |
           nix develop --command ./tutorial/build_tutorials.sh
 
+      # Run tutorials after compilation as a simple check that the tutorial code is also correct.
+      - name: Run tutorial examples inside Nix dev shell
+        run: |
+          nix develop --command bash -c '
+            set -euo pipefail
+            shopt -s nullglob
+
+            tutorial_binaries=(./build/tutorial/tutorial_*)
+            if [[ ${#tutorial_binaries[@]} -eq 0 ]]; then
+              echo "No tutorial binaries found in ./build/tutorial/"
+              exit 1
+            fi
+
+            ran_any=0
+            for tutorial_binary in "${tutorial_binaries[@]}"; do
+              if [[ ! -f "${tutorial_binary}" || ! -x "${tutorial_binary}" ]]; then
+                continue
+              fi
+
+              echo "Running ${tutorial_binary}"
+              "${tutorial_binary}"
+              ran_any=1
+            done
+
+            if [[ "${ran_any}" -eq 0 ]]; then
+              echo "No executable tutorial binaries found in ./build/tutorial/"
+              exit 1
+            fi
+          '
+
   markdown-check:
     name: Markdown freshness check
     runs-on: ubuntu-latest

--- a/.github/workflows/tutorial.yml
+++ b/.github/workflows/tutorial.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   compile-check:
-    name: Compile check (${{ matrix.name }})
+    name: Compile and Smoke check (${{ matrix.name }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
 

--- a/tutorial/build_tutorials.sh
+++ b/tutorial/build_tutorials.sh
@@ -71,6 +71,36 @@ for tutorial_target in "${tutorial_targets[@]}"; do
     cmake --build "${BUILD_DIR}" --target "${tutorial_target}" -j "${build_jobs}"
 done
 
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    plugin_dylib="${BUILD_DIR}/modules/libp2p_module_plugin.dylib"
+    libp2p_dylib="${BUILD_DIR}/modules/libp2p.dylib"
+
+    if [[ ! -f "${plugin_dylib}" ]]; then
+        echo "Expected plugin dylib not found: ${plugin_dylib}" >&2
+        exit 1
+    fi
+    if [[ ! -f "${libp2p_dylib}" ]]; then
+        echo "Expected libp2p dylib not found: ${libp2p_dylib}" >&2
+        exit 1
+    fi
+
+    libp2p_install_name="$(otool -L "${plugin_dylib}" \
+        | awk '/libp2p[.]dylib/ { print $1; exit }')"
+
+    if [[ -z "${libp2p_install_name}" ]]; then
+        echo "Could not find libp2p.dylib dependency in ${plugin_dylib}" >&2
+        exit 1
+    fi
+
+    if [[ "${libp2p_install_name}" != "@loader_path/libp2p.dylib" ]]; then
+        echo "Patching ${plugin_dylib} libp2p.dylib dependency"
+        install_name_tool -change \
+            "${libp2p_install_name}" \
+            "@loader_path/libp2p.dylib" \
+            "${plugin_dylib}"
+    fi
+fi
+
 echo ""
 echo "✅ All tutorials compiled successfully."
 echo ""

--- a/tutorial/build_tutorials.sh
+++ b/tutorial/build_tutorials.sh
@@ -66,8 +66,10 @@ if [[ "${#tutorial_targets[@]}" -eq 0 ]]; then
     exit 1
 fi
 
-cmake --build "${BUILD_DIR}" --target "${tutorial_targets[@]}" \
-    -j "$(nproc 2>/dev/null || echo 4)"
+build_jobs="$(nproc 2>/dev/null || echo 4)"
+for tutorial_target in "${tutorial_targets[@]}"; do
+    cmake --build "${BUILD_DIR}" --target "${tutorial_target}" -j "${build_jobs}"
+done
 
 echo ""
 echo "✅ All tutorials compiled successfully."

--- a/tutorial/docs/tutorial_1_node_lifecycle.md
+++ b/tutorial/docs/tutorial_1_node_lifecycle.md
@@ -65,16 +65,20 @@ network addresses using `peerInfo()`.
 
 ```cpp
     auto info = node.peerInfo();
-    if (info.success) {
-        // Extract the peer ID — a unique cryptographic identifier
-        std::string peerId = info.value["peerId"].get<std::string>();
-        printf("Peer ID: %s\n", peerId.c_str());
+    if (!info.success) {
+        fprintf(stderr, "Failed to get peer info: %s\n",
+                info.error.c_str());
+        return 1;
+    }
 
-        // List all multiaddresses the node is listening on
-        printf("Listening addresses:\n");
-        for (const auto& addr : info.value["addrs"]) {
-            printf("  %s\n", addr.get<std::string>().c_str());
-        }
+    // Extract the peer ID — a unique cryptographic identifier
+    std::string peerId = info.value["peerId"].get<std::string>();
+    printf("Peer ID: %s\n", peerId.c_str());
+
+    // List all multiaddresses the node is listening on
+    printf("Listening addresses:\n");
+    for (const auto& addr : info.value["addrs"]) {
+        printf("  %s\n", addr.get<std::string>().c_str());
     }
 
 ```
@@ -83,16 +87,22 @@ We can also query specific fields using `getNodeInfo()`:
 
 ```cpp
     auto version = node.getNodeInfo("Version");
-    if (version.success) {
-        printf("Module version: %s\n",
-               version.value.get<std::string>().c_str());
+    if (!version.success) {
+        fprintf(stderr, "Failed to get module version: %s\n",
+                version.error.c_str());
+        return 1;
     }
+    printf("Module version: %s\n",
+           version.value.get<std::string>().c_str());
 
     auto peerIdResult = node.getNodeInfo("PeerId");
-    if (peerIdResult.success) {
-        printf("Peer ID (via getNodeInfo): %s\n",
-               peerIdResult.value.get<std::string>().c_str());
+    if (!peerIdResult.success) {
+        fprintf(stderr, "Failed to get peer ID: %s\n",
+                peerIdResult.error.c_str());
+        return 1;
     }
+    printf("Peer ID (via getNodeInfo): %s\n",
+           peerIdResult.value.get<std::string>().c_str());
 
 ```
 

--- a/tutorial/docs/tutorial_2_custom_config.md
+++ b/tutorial/docs/tutorial_2_custom_config.md
@@ -72,14 +72,18 @@ The most explicit way to configure a node is by constructing
 Verify that the node is actually listening on the configured port:
 ```cpp
     auto info = node.peerInfo();
-    if (info.success) {
-        printf("\nNode is live!\n");
-        printf("  Peer ID: %s\n",
-               info.value["peerId"].get<std::string>().c_str());
-        for (const auto& addr : info.value["addrs"]) {
-            printf("  Listening on: %s\n",
-                   addr.get<std::string>().c_str());
-        }
+    if (!info.success) {
+        fprintf(stderr, "Failed to get node info: %s\n",
+                info.error.c_str());
+        return 1;
+    }
+
+    printf("\nNode is live!\n");
+    printf("  Peer ID: %s\n",
+           info.value["peerId"].get<std::string>().c_str());
+    for (const auto& addr : info.value["addrs"]) {
+        printf("  Listening on: %s\n",
+               addr.get<std::string>().c_str());
     }
 
     node.stop();
@@ -124,14 +128,18 @@ supplied via `Libp2pModuleOptions::fromJson()`.
     }
 
     auto info2 = nodeFromJson.peerInfo();
-    if (info2.success) {
-        printf("\nJSON-configured node is live!\n");
-        printf("  Peer ID: %s\n",
-               info2.value["peerId"].get<std::string>().c_str());
-        for (const auto& addr : info2.value["addrs"]) {
-            printf("  Listening on: %s\n",
-                   addr.get<std::string>().c_str());
-        }
+    if (!info2.success) {
+        fprintf(stderr, "Failed to get JSON-configured node info: %s\n",
+                info2.error.c_str());
+        return 1;
+    }
+
+    printf("\nJSON-configured node is live!\n");
+    printf("  Peer ID: %s\n",
+           info2.value["peerId"].get<std::string>().c_str());
+    for (const auto& addr : info2.value["addrs"]) {
+        printf("  Listening on: %s\n",
+               addr.get<std::string>().c_str());
     }
 
     nodeFromJson.stop();

--- a/tutorial/docs/tutorial_3_connecting_peers.md
+++ b/tutorial/docs/tutorial_3_connecting_peers.md
@@ -122,19 +122,25 @@ The direction parameter:
   - `1` means "incoming connections" (other peers connected to this node).
 ```cpp
     auto peersA = nodeA.connectedPeers(0);
-    if (peersA.success) {
-        printf("\nNode A's connected peers:\n");
-        for (const auto& p : peersA.value) {
-            printf("  %s\n", p.get<std::string>().c_str());
-        }
+    if (!peersA.success) {
+        fprintf(stderr, "Failed to list Node A peers: %s\n",
+                peersA.error.c_str());
+        return 1;
+    }
+    printf("\nNode A's connected peers:\n");
+    for (const auto& p : peersA.value) {
+        printf("  %s\n", p.get<std::string>().c_str());
     }
 
     auto peersB = nodeB.connectedPeers(0);
-    if (peersB.success) {
-        printf("Node B's connected peers:\n");
-        for (const auto& p : peersB.value) {
-            printf("  %s\n", p.get<std::string>().c_str());
-        }
+    if (!peersB.success) {
+        fprintf(stderr, "Failed to list Node B peers: %s\n",
+                peersB.error.c_str());
+        return 1;
+    }
+    printf("Node B's connected peers:\n");
+    for (const auto& p : peersB.value) {
+        printf("  %s\n", p.get<std::string>().c_str());
     }
 
 ```

--- a/tutorial/docs/tutorial_3_connecting_peers.md
+++ b/tutorial/docs/tutorial_3_connecting_peers.md
@@ -81,7 +81,8 @@ peer ID and listening addresses from `peerInfo()`.
 ```cpp
     auto infoA = nodeA.peerInfo();
     if (!infoA.success) {
-        fprintf(stderr, "Failed to get node A info\n");
+        fprintf(stderr, "Failed to get node A info: %s\n",
+                infoA.error.c_str());
         return 1;
     }
 

--- a/tutorial/docs/tutorial_4_custom_protocol.md
+++ b/tutorial/docs/tutorial_4_custom_protocol.md
@@ -118,7 +118,13 @@ Register the echo protocol on Node A:
 
 ## Step 3: Get Node A's address and connect Node B
 ```cpp
-    auto infoA = nodeA.peerInfo().value;
+    auto infoARes = nodeA.peerInfo();
+    if (!infoARes.success) {
+        fprintf(stderr, "Failed to get Node A info: %s\n",
+                infoARes.error.c_str());
+        return 1;
+    }
+    auto infoA = infoARes.value;
     std::string peerIdA = infoA["peerId"].get<std::string>();
     std::vector<std::string> addrsA;
     for (const auto& a : infoA["addrs"])

--- a/tutorial/tutorial_1_node_lifecycle.cpp
+++ b/tutorial/tutorial_1_node_lifecycle.cpp
@@ -55,31 +55,41 @@ int main()
 /// network addresses using `peerInfo()`.
 
     auto info = node.peerInfo();
-    if (info.success) {
-        // Extract the peer ID — a unique cryptographic identifier
-        std::string peerId = info.value["peerId"].get<std::string>();
-        printf("Peer ID: %s\n", peerId.c_str());
+    if (!info.success) {
+        fprintf(stderr, "Failed to get peer info: %s\n",
+                info.error.c_str());
+        return 1;
+    }
 
-        // List all multiaddresses the node is listening on
-        printf("Listening addresses:\n");
-        for (const auto& addr : info.value["addrs"]) {
-            printf("  %s\n", addr.get<std::string>().c_str());
-        }
+    // Extract the peer ID — a unique cryptographic identifier
+    std::string peerId = info.value["peerId"].get<std::string>();
+    printf("Peer ID: %s\n", peerId.c_str());
+
+    // List all multiaddresses the node is listening on
+    printf("Listening addresses:\n");
+    for (const auto& addr : info.value["addrs"]) {
+        printf("  %s\n", addr.get<std::string>().c_str());
     }
 
 /// We can also query specific fields using `getNodeInfo()`:
 
     auto version = node.getNodeInfo("Version");
-    if (version.success) {
-        printf("Module version: %s\n",
-               version.value.get<std::string>().c_str());
+    if (!version.success) {
+        fprintf(stderr, "Failed to get module version: %s\n",
+                version.error.c_str());
+        return 1;
     }
+    printf("Module version: %s\n",
+           version.value.get<std::string>().c_str());
 
     auto peerIdResult = node.getNodeInfo("PeerId");
-    if (peerIdResult.success) {
-        printf("Peer ID (via getNodeInfo): %s\n",
-               peerIdResult.value.get<std::string>().c_str());
+    if (!peerIdResult.success) {
+        fprintf(stderr, "Failed to get peer ID: %s\n",
+                peerIdResult.error.c_str());
+        return 1;
     }
+    printf("Peer ID (via getNodeInfo): %s\n",
+           peerIdResult.value.get<std::string>().c_str());
 
 /// ## Step 4: Stop the node
 ///

--- a/tutorial/tutorial_2_custom_config.cpp
+++ b/tutorial/tutorial_2_custom_config.cpp
@@ -65,14 +65,18 @@ int main()
 
 /// Verify that the node is actually listening on the configured port:
     auto info = node.peerInfo();
-    if (info.success) {
-        printf("\nNode is live!\n");
-        printf("  Peer ID: %s\n",
-               info.value["peerId"].get<std::string>().c_str());
-        for (const auto& addr : info.value["addrs"]) {
-            printf("  Listening on: %s\n",
-                   addr.get<std::string>().c_str());
-        }
+    if (!info.success) {
+        fprintf(stderr, "Failed to get node info: %s\n",
+                info.error.c_str());
+        return 1;
+    }
+
+    printf("\nNode is live!\n");
+    printf("  Peer ID: %s\n",
+           info.value["peerId"].get<std::string>().c_str());
+    for (const auto& addr : info.value["addrs"]) {
+        printf("  Listening on: %s\n",
+               addr.get<std::string>().c_str());
     }
 
     node.stop();
@@ -114,14 +118,18 @@ int main()
     }
 
     auto info2 = nodeFromJson.peerInfo();
-    if (info2.success) {
-        printf("\nJSON-configured node is live!\n");
-        printf("  Peer ID: %s\n",
-               info2.value["peerId"].get<std::string>().c_str());
-        for (const auto& addr : info2.value["addrs"]) {
-            printf("  Listening on: %s\n",
-                   addr.get<std::string>().c_str());
-        }
+    if (!info2.success) {
+        fprintf(stderr, "Failed to get JSON-configured node info: %s\n",
+                info2.error.c_str());
+        return 1;
+    }
+
+    printf("\nJSON-configured node is live!\n");
+    printf("  Peer ID: %s\n",
+           info2.value["peerId"].get<std::string>().c_str());
+    for (const auto& addr : info2.value["addrs"]) {
+        printf("  Listening on: %s\n",
+               addr.get<std::string>().c_str());
     }
 
     nodeFromJson.stop();

--- a/tutorial/tutorial_3_connecting_peers.cpp
+++ b/tutorial/tutorial_3_connecting_peers.cpp
@@ -109,19 +109,25 @@ int main()
 ///   - `0` means "outgoing connections" (this node connected to other peers).
 ///   - `1` means "incoming connections" (other peers connected to this node).
     auto peersA = nodeA.connectedPeers(0);
-    if (peersA.success) {
-        printf("\nNode A's connected peers:\n");
-        for (const auto& p : peersA.value) {
-            printf("  %s\n", p.get<std::string>().c_str());
-        }
+    if (!peersA.success) {
+        fprintf(stderr, "Failed to list Node A peers: %s\n",
+                peersA.error.c_str());
+        return 1;
+    }
+    printf("\nNode A's connected peers:\n");
+    for (const auto& p : peersA.value) {
+        printf("  %s\n", p.get<std::string>().c_str());
     }
 
     auto peersB = nodeB.connectedPeers(0);
-    if (peersB.success) {
-        printf("Node B's connected peers:\n");
-        for (const auto& p : peersB.value) {
-            printf("  %s\n", p.get<std::string>().c_str());
-        }
+    if (!peersB.success) {
+        fprintf(stderr, "Failed to list Node B peers: %s\n",
+                peersB.error.c_str());
+        return 1;
+    }
+    printf("Node B's connected peers:\n");
+    for (const auto& p : peersB.value) {
+        printf("  %s\n", p.get<std::string>().c_str());
     }
 
 /// ## Step 5: Dial the ping protocol and exchange data

--- a/tutorial/tutorial_3_connecting_peers.cpp
+++ b/tutorial/tutorial_3_connecting_peers.cpp
@@ -74,7 +74,8 @@ int main()
 /// peer ID and listening addresses from `peerInfo()`.
     auto infoA = nodeA.peerInfo();
     if (!infoA.success) {
-        fprintf(stderr, "Failed to get node A info\n");
+        fprintf(stderr, "Failed to get node A info: %s\n",
+                infoA.error.c_str());
         return 1;
     }
 

--- a/tutorial/tutorial_4_custom_protocol.cpp
+++ b/tutorial/tutorial_4_custom_protocol.cpp
@@ -102,7 +102,13 @@ int main()
     }
 
 /// ## Step 3: Get Node A's address and connect Node B
-    auto infoA = nodeA.peerInfo().value;
+    auto infoARes = nodeA.peerInfo();
+    if (!infoARes.success) {
+        fprintf(stderr, "Failed to get Node A info: %s\n",
+                infoARes.error.c_str());
+        return 1;
+    }
+    auto infoA = infoARes.value;
     std::string peerIdA = infoA["peerId"].get<std::string>();
     std::vector<std::string> addrsA;
     for (const auto& a : infoA["addrs"])


### PR DESCRIPTION
previously tutorials CI was just making sure that tutorials code compiles. 

with this change CI will execute tutorial code preforming smoke tests on them. all tutorials should finish with success. unsuccessful outcome can happen when, for example:

```cpp
    // faild to dial
    if (!dialRes.success) {
        fprintf(stderr, "Dial failed: %s\n", dialRes.error.c_str());
        return 1;
    }
```

or 

```cpp
        // value stored and recived form kad is not the same,
        if (received == value) {
            printf("Value matches!\n");
        } else {
            fprintf(stderr, "Value mismatch (expected: \"%s\")\n",
                   value.c_str());
            return 1;
        }
```        

etc ...


----

improving tutorial code, handling errors first. this should be general principle of any code
