### PR TITLE
chore: harden CI workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -41,12 +44,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v12
 
       - name: Setup Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v5
+        with:
+          use-flakehub: false
 
       - name: Run flake checks
         env:
@@ -65,12 +72,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v12
 
       - name: Setup Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v5
+        with:
+          use-flakehub: false
 
       - name: Setup Cachix
         uses: cachix/cachix-action@v15
@@ -108,12 +119,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v12
 
       - name: Setup Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v5
+        with:
+          use-flakehub: false
 
       - name: Build + run tests under ${{ matrix.sanitizer }}
         run: |
@@ -131,6 +146,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Ubuntu (if missing)
         shell: powershell

--- a/.github/workflows/tutorial.yml
+++ b/.github/workflows/tutorial.yml
@@ -16,6 +16,9 @@ on:
       - 'tutorial/CMakeLists.txt'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: tutorial-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -45,12 +48,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v12
 
       - name: Setup Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v5
+        with:
+          use-flakehub: false
 
       - name: Build tutorials inside Nix dev shell
         run: |
@@ -64,6 +71,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Generate markdown from tutorial sources
         run: |


### PR DESCRIPTION
- restrict both workflows to read-only repository contents permissions
- disable persisted checkout credentials in every checkout step
- disable FlakeHub auth in Magic Nix Cache so the workflows do not need `id-token: write`


