### PR TITLE
fix(lidl): give createXpr services and newPrivateKey a LIDL type

### DIFF
--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -3,26 +3,29 @@
 using json = nlohmann::json;
 
 namespace {
-// {peerId, seqNo, addrs, services:{id: data}}. Keyed by service id, mirroring
-// the `{tstr: bstr}` map createXpr takes, so a decoded record feeds back in
-// without reshaping. A record repeating an id keeps the last entry; the record
-// this module signs cannot produce one, since its input is already a map.
+// {peerId, seqNo, addrs, services:[{id, data}]}. Service `data` is arbitrary
+// bytes, so it is base64-encoded to keep the JSON valid UTF-8.
 //
-// `data` stays base64 here and is NOT the bstr createXpr accepts: this value
-// rides in an untyped `result`, not a typed slot, so it has to survive as valid
-// UTF-8 JSON. Base64 is byte-exact, but a caller round-tripping decodeXpr into
-// createXpr must decode it first.
+// This is deliberately NOT keyed by id to mirror the `{tstr: bstr}` map
+// createXpr takes: the same shape is returned by discoLookup and
+// discoRandomLookup, whose records come from remote peers and may legitimately
+// repeat a service id — an object would drop all but the last. A caller
+// round-tripping a decoded record back into createXpr rebuilds the map itself,
+// base64-decoding each `data` as it goes.
 json recordEntryToJson(const ExtendedPeerRecordEntry& rec) {
     json out;
     out["peerId"] = nfStr(rec.peerId);
     out["seqNo"] = rec.seqNo;
     out["addrs"] = seqStrToJson(rec.addrs);
 
-    json services = json::object();
+    json services = json::array();
     if (rec.services.data) {
         for (size_t i = 0; i < rec.services.len; ++i) {
             const auto& s = rec.services.data[i];
-            services[nfStr(s.id)] = base64Encode(nfBytes(s.data));
+            json svc;
+            svc["id"] = nfStr(s.id);
+            svc["data"] = base64Encode(nfBytes(s.data));
+            services.push_back(svc);
         }
     }
     out["services"] = services;

--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -3,22 +3,26 @@
 using json = nlohmann::json;
 
 namespace {
-// {peerId, seqNo, addrs, services:[{id, data}]}. Service `data` is arbitrary
-// bytes, so it is base64-encoded to keep the JSON valid UTF-8.
+// {peerId, seqNo, addrs, services:{id: data}}. Keyed by service id, mirroring
+// the `{tstr: bstr}` map createXpr takes, so a decoded record feeds back in
+// without reshaping. A record repeating an id keeps the last entry; the record
+// this module signs cannot produce one, since its input is already a map.
+//
+// `data` stays base64 here and is NOT the bstr createXpr accepts: this value
+// rides in an untyped `result`, not a typed slot, so it has to survive as valid
+// UTF-8 JSON. Base64 is byte-exact, but a caller round-tripping decodeXpr into
+// createXpr must decode it first.
 json recordEntryToJson(const ExtendedPeerRecordEntry& rec) {
     json out;
     out["peerId"] = nfStr(rec.peerId);
     out["seqNo"] = rec.seqNo;
     out["addrs"] = seqStrToJson(rec.addrs);
 
-    json services = json::array();
+    json services = json::object();
     if (rec.services.data) {
         for (size_t i = 0; i < rec.services.len; ++i) {
             const auto& s = rec.services.data[i];
-            json svc;
-            svc["id"] = nfStr(s.id);
-            svc["data"] = base64Encode(nfBytes(s.data));
-            services.push_back(svc);
+            services[nfStr(s.id)] = base64Encode(nfBytes(s.data));
         }
     }
     out["services"] = services;

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -255,13 +255,18 @@ StdLogosResult Libp2pModuleImpl::status() {
     return {false, {}, m_initError.empty() ? "libp2p not initialized" : m_initError};
 }
 
-StdLogosResult Libp2pModuleImpl::newPrivateKey(KeyScheme scheme) {
+StdLogosResult Libp2pModuleImpl::newPrivateKey(const std::string& scheme) {
+    KeyScheme parsed{};
+    if (!parseKeyScheme(scheme, parsed)) {
+        return {false, {}, "Unknown key scheme '" + scheme +
+                           "'; expected rsa, ed25519, secp256k1 or ecdsa"};
+    }
     if (!ctx) {
         auto created = createContext();
         if (!created.success) return created;
     }
     NewPrivateKeyRequest req{};
-    req.scheme = static_cast<int64_t>(scheme);
+    req.scheme = static_cast<int64_t>(parsed);
     return callSyncWith("Failed to generate private key",
         [&](SyncPromise* p) {
             return libp2p_ctx_new_private_key(ctx, &req, &Libp2pModuleImpl::cbBytes, p);

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -9,6 +9,7 @@
 #include <deque>
 #include <functional>
 #include <future>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
@@ -59,6 +60,18 @@ enum class KeyScheme : int64_t {
     Secp256k1 = KEY_SCHEME_SECP256K1,
     Ecdsa = KEY_SCHEME_ECDSA,
 };
+
+// Maps a scheme name onto KeyScheme, matching the vocabulary metadata.json
+// documents for the `keyType` config key. The name is what crosses the module
+// boundary — LIDL has no enum, and the numeric KEY_SCHEME_* values belong to
+// the Nim binding, so they are no contract for a caller in another language.
+inline bool parseKeyScheme(const std::string& name, KeyScheme& out) {
+    if (name == "rsa") { out = KeyScheme::Rsa; return true; }
+    if (name == "ed25519") { out = KeyScheme::Ed25519; return true; }
+    if (name == "secp256k1") { out = KeyScheme::Secp256k1; return true; }
+    if (name == "ecdsa") { out = KeyScheme::Ecdsa; return true; }
+    return false;
+}
 
 using SyncPromise = std::promise<SyncResult>;
 
@@ -136,7 +149,7 @@ public:
 
     StdLogosResult start();
     StdLogosResult stop();
-    StdLogosResult newPrivateKey(KeyScheme scheme);
+    StdLogosResult newPrivateKey(const std::string& scheme);
     StdLogosResult publicKey();
 
     StdLogosResult connectPeer(const std::string& peerId, const std::vector<std::string>& multiaddrs, int64_t timeoutMs);
@@ -189,7 +202,7 @@ public:
     StdLogosResult discoLookup(const std::string& serviceId, const std::string& serviceData);
     StdLogosResult discoRandomLookup();
     StdLogosResult createXpr(const std::vector<std::string>& addrs,
-                             const std::vector<std::pair<std::string, std::string>>& services,
+                             const std::map<std::string, std::vector<uint8_t>>& services,
                              uint64_t seqNo);
     StdLogosResult decodeXpr(const std::string& xpr);
 

--- a/src/service_discovery.cpp
+++ b/src/service_discovery.cpp
@@ -72,9 +72,12 @@ StdLogosResult Libp2pModuleImpl::discoRandomLookup() {
 
 /// Builds and signs the node's own Extended Peer Record, returning the signed
 /// protobuf bytes. Empty `addrs` uses the listen addresses; `seqNo` 0 uses now.
+/// `services` maps a service id to its advertised payload, which is arbitrary
+/// bytes: it is carried as `bstr` and reaches the record byte for byte, with no
+/// UTF-8 round-trip in between.
 StdLogosResult Libp2pModuleImpl::createXpr(
     const std::vector<std::string>& addrs,
-    const std::vector<std::pair<std::string, std::string>>& services,
+    const std::map<std::string, std::vector<uint8_t>>& services,
     uint64_t seqNo)
 {
     auto addrsFfi = toNimFfiStrs(addrs);
@@ -104,8 +107,9 @@ StdLogosResult Libp2pModuleImpl::createXpr(
 /// seqNo, addrs, services). `xpr` is the base64 string produced by createXpr and
 /// is decoded back to the signed protobuf bytes here, so createXpr's output can
 /// be passed straight in. A bad signature or malformed payload yields a failed
-/// result. Each service's `data` is base64-encoded, since it is arbitrary bytes
-/// that may not be valid UTF-8.
+/// result. `services` is an object keyed by service id, mirroring the map
+/// createXpr takes; each `data` is base64-encoded, since it is arbitrary bytes
+/// that may not be valid UTF-8 and this result is untyped JSON.
 StdLogosResult Libp2pModuleImpl::decodeXpr(const std::string& xpr) {
     if (xpr.empty()) return {false, {}, "decodeXpr: empty XPR"};
 

--- a/src/service_discovery.cpp
+++ b/src/service_discovery.cpp
@@ -107,9 +107,10 @@ StdLogosResult Libp2pModuleImpl::createXpr(
 /// seqNo, addrs, services). `xpr` is the base64 string produced by createXpr and
 /// is decoded back to the signed protobuf bytes here, so createXpr's output can
 /// be passed straight in. A bad signature or malformed payload yields a failed
-/// result. `services` is an object keyed by service id, mirroring the map
-/// createXpr takes; each `data` is base64-encoded, since it is arbitrary bytes
-/// that may not be valid UTF-8 and this result is untyped JSON.
+/// result. `services` comes back as `[{id, data}]` — the shape discoLookup and
+/// discoRandomLookup also use — with each `data` base64-encoded, since it is
+/// arbitrary bytes that may not be valid UTF-8 and this result is untyped JSON.
+/// Feeding it back into createXpr means rebuilding the map and base64-decoding.
 StdLogosResult Libp2pModuleImpl::decodeXpr(const std::string& xpr) {
     if (xpr.empty()) return {false, {}, "decodeXpr: empty XPR"};
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -29,6 +29,11 @@ inline NimFfiBytes nimffiBytes(const std::string& data) {
         reinterpret_cast<uint8_t*>(const_cast<char*>(data.data())), data.size()};
 }
 
+// Same, for data that is already bytes and so needs no reinterpretation.
+inline NimFfiBytes nimffiBytes(const std::vector<uint8_t>& data) {
+    return NimFfiBytes{const_cast<uint8_t*>(data.data()), data.size()};
+}
+
 // Non-owning NimFfiStr views over each string in `in`, which must outlive them.
 inline std::vector<NimFfiStr> toNimFfiStrs(const std::vector<std::string>& in) {
     std::vector<NimFfiStr> out;

--- a/tests/integration_service_discovery.cpp
+++ b/tests/integration_service_discovery.cpp
@@ -218,15 +218,14 @@ LOGOS_TEST(decode_xpr) {
     LOGOS_ASSERT_EQ(decoded.value["peerId"].get<std::string>(), peerId);
     LOGOS_ASSERT_EQ(decoded.value["seqNo"].get<uint64_t>(), 42u);
     LOGOS_ASSERT_EQ(decoded.value["services"].size(), services.size());
-    // Keyed by service id, so a dropped or renamed key fails here rather than
-    // shifting an index and silently comparing the wrong service.
-    LOGOS_ASSERT_TRUE(decoded.value["services"].contains("chat"));
-    LOGOS_ASSERT_TRUE(decoded.value["services"].contains("file-share"));
+    // std::map orders its keys, so "chat" precedes "file-share" on the wire.
+    LOGOS_ASSERT_EQ(decoded.value["services"][0]["id"].get<std::string>(), "chat");
     // Every advertised byte survives — this is what `bstr` buys over the old
     // std::string parameter, which mangled anything that was not valid UTF-8.
-    LOGOS_ASSERT_EQ(base64Decode(decoded.value["services"]["chat"].get<std::string>()),
+    LOGOS_ASSERT_EQ(base64Decode(decoded.value["services"][0]["data"].get<std::string>()),
                     binDataStr);
-    LOGOS_ASSERT_TRUE(decoded.value["services"]["file-share"].get<std::string>().empty());
+    LOGOS_ASSERT_EQ(decoded.value["services"][1]["id"].get<std::string>(), "file-share");
+    LOGOS_ASSERT_TRUE(decoded.value["services"][1]["data"].get<std::string>().empty());
 
     // A flipped byte must fail signature verification, not silently decode.
     std::string rawBytes = base64Decode(signedXpr);

--- a/tests/integration_service_discovery.cpp
+++ b/tests/integration_service_discovery.cpp
@@ -1,5 +1,6 @@
 #include <logos_test.h>
 #include <plugin.h>
+#include <map>
 #include <thread>
 #include <chrono>
 #include "test_helpers.h"
@@ -170,9 +171,9 @@ LOGOS_TEST(create_xpr) {
 
     auto [peerId, addrs] = getPeerInfoPair(node);
 
-    std::vector<std::pair<std::string, std::string>> services = {
-        {"chat", std::string{0x01, 0x02, 0x03}},
-        {"file-share", ""},
+    std::map<std::string, std::vector<uint8_t>> services = {
+        {"chat", {0x01, 0x02, 0x03}},
+        {"file-share", {}},
     };
 
     auto res = node.createXpr(addrs, services, 42);
@@ -198,11 +199,13 @@ LOGOS_TEST(decode_xpr) {
 
     auto [peerId, addrs] = getPeerInfoPair(node);
 
-    // 0xff is non-UTF-8: exercises the binary-safe base64 encoding of `data`.
-    std::string binData{0x01, 0x02, 0x03, static_cast<char>(0xff)};
-    std::vector<std::pair<std::string, std::string>> services = {
+    // None of 0x80/0xfe/0xff is valid UTF-8 and 0x00 terminates a C string:
+    // together they catch a lossy UTF-8 round-trip and a truncating one alike.
+    const std::vector<uint8_t> binData{0x01, 0x00, 0x02, 0x80, 0xfe, 0xff, 0x03};
+    const std::string binDataStr(binData.begin(), binData.end());
+    std::map<std::string, std::vector<uint8_t>> services = {
         {"chat", binData},
-        {"file-share", ""},
+        {"file-share", {}},
     };
 
     auto created = node.createXpr(addrs, services, 42);
@@ -215,9 +218,15 @@ LOGOS_TEST(decode_xpr) {
     LOGOS_ASSERT_EQ(decoded.value["peerId"].get<std::string>(), peerId);
     LOGOS_ASSERT_EQ(decoded.value["seqNo"].get<uint64_t>(), 42u);
     LOGOS_ASSERT_EQ(decoded.value["services"].size(), services.size());
-    LOGOS_ASSERT_EQ(decoded.value["services"][0]["id"].get<std::string>(), "chat");
-    LOGOS_ASSERT_EQ(base64Decode(decoded.value["services"][0]["data"].get<std::string>()),
-                    binData);
+    // Keyed by service id, so a dropped or renamed key fails here rather than
+    // shifting an index and silently comparing the wrong service.
+    LOGOS_ASSERT_TRUE(decoded.value["services"].contains("chat"));
+    LOGOS_ASSERT_TRUE(decoded.value["services"].contains("file-share"));
+    // Every advertised byte survives — this is what `bstr` buys over the old
+    // std::string parameter, which mangled anything that was not valid UTF-8.
+    LOGOS_ASSERT_EQ(base64Decode(decoded.value["services"]["chat"].get<std::string>()),
+                    binDataStr);
+    LOGOS_ASSERT_TRUE(decoded.value["services"]["file-share"].get<std::string>().empty());
 
     // A flipped byte must fail signature verification, not silently decode.
     std::string rawBytes = base64Decode(signedXpr);

--- a/tests/sync.cpp
+++ b/tests/sync.cpp
@@ -62,10 +62,18 @@ LOGOS_TEST(sync_public_key) {
 
 LOGOS_TEST(sync_new_private_key) {
     Libp2pModuleImpl plugin;
-    auto res = plugin.newPrivateKey(KeyScheme::Ed25519);
+    auto res = plugin.newPrivateKey("ed25519");
     LOGOS_ASSERT_TRUE(res.success);
     LOGOS_ASSERT_TRUE(res.value.is_string());
     LOGOS_ASSERT_FALSE(res.value.get<std::string>().empty());
+}
+
+LOGOS_TEST(sync_new_private_key_unknown_scheme) {
+    Libp2pModuleImpl plugin;
+    // An unknown name is rejected by name, not silently mapped onto a scheme.
+    auto res = plugin.newPrivateKey("ed25519 ");
+    LOGOS_ASSERT_FALSE(res.success);
+    LOGOS_ASSERT_FALSE(res.error.empty());
 }
 
 LOGOS_TEST(sync_stream_close) {

--- a/tutorial/docs/tutorial_9_service_discovery.md
+++ b/tutorial/docs/tutorial_9_service_discovery.md
@@ -283,12 +283,6 @@ or a protobuf and nothing is mangled on the way in.
                .get<uint64_t>());
     printf("  Services: %zu\n",
            decoded.value["services"].size());
-    // `services` comes back keyed by id, mirroring the map passed in. Each
-    // value is the payload base64-encoded, since this result is untyped JSON.
-    for (auto it = decoded.value["services"].begin();
-         it != decoded.value["services"].end(); ++it) {
-        printf("    %s\n", it.key().c_str());
-    }
 
 ```
 

--- a/tutorial/docs/tutorial_9_service_discovery.md
+++ b/tutorial/docs/tutorial_9_service_discovery.md
@@ -27,6 +27,7 @@ Looking up a service queries the bootstrap, which returns matching peers.
 ```cpp
 #include <cstdio>
 #include <chrono>
+#include <map>
 #include <thread>
 #include <string>
 #include <vector>
@@ -247,12 +248,17 @@ which is useful for network exploration.
 Extended Peer Records are signed records that bundle a peer's
 addresses and services. They can be shared offline or via
 side channels.
+
+Services are a map of service id to its advertised payload. The
+payload is raw bytes, not text, so it is a `std::vector<uint8_t>`
+and reaches the record byte for byte — advertise a compressed blob
+or a protobuf and nothing is mangled on the way in.
 ```cpp
     printf("\n--- Extended Peer Records ---\n");
 
-    std::vector<std::pair<std::string, std::string>> xprServices = {
-        {serviceId, serviceData},
-        {"file-sharing", "v2"},
+    std::map<std::string, std::vector<uint8_t>> xprServices = {
+        {serviceId, {serviceData.begin(), serviceData.end()}},
+        {"file-sharing", {'v', '2'}},
     };
 
     StdLogosResult xpr = advertiser.createXpr({}, xprServices, 0);
@@ -277,6 +283,12 @@ side channels.
                .get<uint64_t>());
     printf("  Services: %zu\n",
            decoded.value["services"].size());
+    // `services` comes back keyed by id, mirroring the map passed in. Each
+    // value is the payload base64-encoded, since this result is untyped JSON.
+    for (auto it = decoded.value["services"].begin();
+         it != decoded.value["services"].end(); ++it) {
+        printf("    %s\n", it.key().c_str());
+    }
 
 ```
 

--- a/tutorial/tutorial_9_service_discovery.cpp
+++ b/tutorial/tutorial_9_service_discovery.cpp
@@ -258,12 +258,6 @@ int main()
                .get<uint64_t>());
     printf("  Services: %zu\n",
            decoded.value["services"].size());
-    // `services` comes back keyed by id, mirroring the map passed in. Each
-    // value is the payload base64-encoded, since this result is untyped JSON.
-    for (auto it = decoded.value["services"].begin();
-         it != decoded.value["services"].end(); ++it) {
-        printf("    %s\n", it.key().c_str());
-    }
 
 /// ## Step 9: Clean up — unregister, stop advertising, stop disco
     printf("\nCleaning up...\n");

--- a/tutorial/tutorial_9_service_discovery.cpp
+++ b/tutorial/tutorial_9_service_discovery.cpp
@@ -26,6 +26,7 @@
 
 #include <cstdio>
 #include <chrono>
+#include <map>
 #include <thread>
 #include <string>
 #include <vector>
@@ -223,11 +224,16 @@ int main()
 /// Extended Peer Records are signed records that bundle a peer's
 /// addresses and services. They can be shared offline or via
 /// side channels.
+///
+/// Services are a map of service id to its advertised payload. The
+/// payload is raw bytes, not text, so it is a `std::vector<uint8_t>`
+/// and reaches the record byte for byte — advertise a compressed blob
+/// or a protobuf and nothing is mangled on the way in.
     printf("\n--- Extended Peer Records ---\n");
 
-    std::vector<std::pair<std::string, std::string>> xprServices = {
-        {serviceId, serviceData},
-        {"file-sharing", "v2"},
+    std::map<std::string, std::vector<uint8_t>> xprServices = {
+        {serviceId, {serviceData.begin(), serviceData.end()}},
+        {"file-sharing", {'v', '2'}},
     };
 
     StdLogosResult xpr = advertiser.createXpr({}, xprServices, 0);
@@ -252,6 +258,12 @@ int main()
                .get<uint64_t>());
     printf("  Services: %zu\n",
            decoded.value["services"].size());
+    // `services` comes back keyed by id, mirroring the map passed in. Each
+    // value is the payload base64-encoded, since this result is untyped JSON.
+    for (auto it = decoded.value["services"].begin();
+         it != decoded.value["services"].end(); ++it) {
+        printf("    %s\n", it.key().c_str());
+    }
 
 /// ## Step 9: Clean up — unregister, stop advertising, stop disco
     printf("\nCleaning up...\n");


### PR DESCRIPTION
We're making interface definition for modules a bit stricter (things that we currently kind of automagically convert to something sendable across the module interface is gonna become a build error soon) to fix some cases where we had hard to find data losses on edge cases.

- Enums are not (currently) supported -> Changing `KeyScheme` with a string representation.
- std::pair is not a supported type for a module interface -> Replaced vector of pairs to map keyed by the first element of the pair (you tell me if multiple entries with the same ID are expected or the order matters, then map is not the proper data structure)
- std::vector<uint8_t> is the proper data type to losslessly transmit byte arrays without having to manually base64-stringify them first. But you're free to keep the base64 string if you wish.