### PR TITLE
feat(bridge): restore the inbound accept queue, report the peer id, add pingPeer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ logos_module(
         src/utils.cpp
         src/topic_queues.h
         src/topic_queues.cpp
+        src/stream_queues.h
+        src/stream_queues.cpp
         src/plugin.cpp
         src/callbacks.cpp
         src/kademlia.cpp

--- a/README.md
+++ b/README.md
@@ -139,6 +139,54 @@ A scripted version of this flow runs in CI and locally via
 
 ---
 
+# Custom-protocol bridge
+
+Another module can run its own length-prefixed protocol on this node, instead of
+starting a second libp2p node. Every argument and every result is one JSON
+string, and every payload is base64, because that is the only shape the
+universal codegen marshals.
+
+| Call | Args | Result |
+| --- | --- | --- |
+| `protocolRequest` | `{peerId, proto, multiaddrs?, requestB64, timeoutMs?, maxSize?, expectResponse?}` | `{responseB64}` |
+| `mountProtocol` | `proto` | (none) |
+| `protocolAcceptStream` | `{proto, timeoutMs?}` | `{streamId, proto, peerId}` |
+| `streamReadLpJson` | `{streamId, maxSize?, timeoutMs?}` | `{dataB64}` |
+| `streamWriteLpJson` | `{streamId, dataB64}` | (none) |
+| `streamCloseJson` / `streamReleaseJson` | `{streamId}` | (none) |
+| `pingPeer` | `peerId`, `timeoutMs` | `{peerId, rttMs}` |
+
+`protocolRequest` does connect, dial, write, read and release in one call, so it
+covers a request and response exchange.
+
+The module boundary carries no push events, so an inbound stream waits in a
+per-protocol queue and the consumer polls it with `protocolAcceptStream`.
+`peerId` is the peer that opened the stream, which a service protocol needs to
+answer the right peer. A stream leaves the queue when `protocolAcceptStream`
+hands it out, when `streamReleaseJson` releases it, or when the node stops.
+Mounting needs no event listener, so a consumer that only polls never sets one.
+
+Each inbound stream also fires a `protocolStream` event with the same
+`{streamId, proto, peerId}`. Drive a stream from the queue or from the event,
+never from both: the two report the same stream, and the second reader finds a
+handle another one already released.
+
+The queue holds 1024 streams per protocol. Past that the newest inbound stream
+is released, and the drop is counted, so a consumer that stops polling loses
+streams instead of pinning them:
+
+| Metric | Type | Labels |
+| --- | --- | --- |
+| `libp2p_module_protocol_stream_queue_depth` | gauge | `proto` |
+| `libp2p_module_protocol_stream_dropped_total` | counter | `proto` |
+
+`pingPeer` dials `/ipfs/ping/1.0.0` on a peer this node is already connected to.
+Use it for a health check; it opens no connection of its own. `rttMs` is
+measured around the write and the read, so it carries the two FFI hops on top of
+the wire time. Compare it against itself over time, not against `ping(8)`.
+
+---
+
 # Building
 Currently the recommended and supported building way is using Nix
 

--- a/flake.lock
+++ b/flake.lock
@@ -875,16 +875,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1787230257,
-        "narHash": "sha256-uh1uEboviz6DMwFd7Evenrb04XWSRmvWvzLC3XBrSAc=",
+        "lastModified": 1787236201,
+        "narHash": "sha256-YGyr9mWN0LWqTJ93h3n1cLUPJkfLrioF8TETR60pgZQ=",
         "owner": "vacp2p",
         "repo": "nim-libp2p",
-        "rev": "86439e860a7d04329af51f097ef3e46eb1249bec",
+        "rev": "c7bed9bef76e33b43dd64b92e8d74ca0d6bce175",
         "type": "github"
       },
       "original": {
         "owner": "vacp2p",
-        "ref": "feat/cbind/poll-accept-stream",
+        "ref": "master",
         "repo": "nim-libp2p",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -875,16 +875,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1786465623,
-        "narHash": "sha256-DGuu3wX/EKetYG849E0ASZWD1GrYKH+0dfFsMmRbDT0=",
+        "lastModified": 1787230257,
+        "narHash": "sha256-uh1uEboviz6DMwFd7Evenrb04XWSRmvWvzLC3XBrSAc=",
         "owner": "vacp2p",
         "repo": "nim-libp2p",
-        "rev": "0253e455f4da4230ac3101105bcc51b21c037121",
+        "rev": "86439e860a7d04329af51f097ef3e46eb1249bec",
         "type": "github"
       },
       "original": {
         "owner": "vacp2p",
-        "ref": "master",
+        "ref": "feat/cbind/poll-accept-stream",
         "repo": "nim-libp2p",
         "type": "github"
       }

--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -154,9 +154,17 @@ void Libp2pModuleImpl::onIncomingStream(const IncomingStreamEvent* evt, void* ud
     auto* self = static_cast<Libp2pModuleImpl*>(ud);
     if (!self || !evt) return;
     try {
+        const std::string proto = nfStr(evt->proto);
+        const std::string peerId = nfStr(evt->peerId);
+        if (!self->m_inboundStreams.push(proto, InboundStream{evt->streamId, peerId})) {
+            self->releaseStreamNoWait(evt->streamId);
+            return;
+        }
+
         json j;
         j["streamId"] = evt->streamId;
-        j["proto"] = nfStr(evt->proto);
+        j["proto"] = proto;
+        j["peerId"] = peerId;
         self->emitEventSafe("protocolStream", j.dump());
     } catch (...) {}
 }

--- a/src/custom_handlers.cpp
+++ b/src/custom_handlers.cpp
@@ -3,10 +3,6 @@
 StdLogosResult Libp2pModuleImpl::mountProtocol(const std::string& proto) {
     if (!ctx) return {false, {}, "No libp2p context"};
     if (proto.empty()) return {false, {}, "Protocol string is empty"};
-    // Incoming streams for this protocol are delivered via the on_incoming_stream
-    // listener as protocolStream events; without emitEvent set no caller could
-    // ever read, close, or release them, leaking the stream on the Nim side.
-    if (!emitEvent) return {false, {}, "emitEvent must be set before mounting a protocol"};
     publishEmitEvent();
 
     return callSync("Failed to mount protocol", [&](SyncPromise* p) {

--- a/src/metric.h
+++ b/src/metric.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -19,6 +22,35 @@ struct Metric {
     double value = 0.0;
     int64_t timestamp = 0;
 };
+
+// One sample of a poll queue, taken under its lock and formatted outside it.
+struct QueueSample {
+    std::string key;
+    size_t depth;
+    uint64_t dropped;
+};
+
+struct QueueSeriesNames {
+    const char* label;
+    const char* depth;
+    const char* depthHelp;
+    const char* dropped;
+    const char* droppedHelp;
+};
+
+inline std::vector<Metric> queueSeries(std::vector<QueueSample> samples,
+                                       const QueueSeriesNames& names) {
+    std::vector<Metric> series;
+    series.reserve(samples.size() * 2);
+    for (auto& s : samples) {
+        series.push_back(Metric{names.depth, "gauge", names.depthHelp,
+                                {{names.label, s.key}}, static_cast<double>(s.depth)});
+        series.push_back(Metric{names.dropped, "counter", names.droppedHelp,
+                                {{names.label, std::move(s.key)}},
+                                static_cast<double>(s.dropped)});
+    }
+    return series;
+}
 
 inline void from_json(const nlohmann::json& j, Metric& m) {
     j.at("name").get_to(m.name);

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -31,6 +31,8 @@ LogosMap Libp2pModuleImpl::collectMetrics() {
     // The backlog lives on the C++ side, so nim-libp2p's registry cannot see it.
     auto queueSeries = m_topicQueues.metrics();
     series.insert(series.end(), queueSeries.begin(), queueSeries.end());
+    auto streamSeries = m_inboundStreams.metrics();
+    series.insert(series.end(), streamSeries.begin(), streamSeries.end());
 
     json payload;
     payload["metrics"] = series;

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -258,6 +258,7 @@ void Libp2pModuleImpl::destroyContext() {
     // streams) and frees the C-side context wrapper and listener boxes.
     destroyContextChecked(ctx);
     ctx = nullptr;
+    m_inboundStreams.releaseAll();
 }
 
 Libp2pModuleImpl::~Libp2pModuleImpl() {
@@ -284,6 +285,7 @@ StdLogosResult Libp2pModuleImpl::stop() {
     // A node that failed to stop is still delivering, so it keeps its backlog.
     if (res.success) {
         m_topicQueues.releaseAll();
+        m_inboundStreams.releaseAll();
     }
     return res;
 }

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -360,6 +360,16 @@ private:
         if (!r.ok) return {false, {}, std::string(errPrefix) + ": " + r.message};
         return transform(r);
     }
+
+    // Submits without awaiting, for a caller that must not block its thread.
+    template <class Invoke>
+    static void callAsync(Invoke&& invoke) {
+        auto* p = new SyncPromise();
+        auto f = p->get_future();
+        if (invoke(p) != 0 && f.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
+            delete p;
+        }
+    }
 };
 
 inline StdLogosResult setLogLevel(const std::string& level) {

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -6,7 +6,6 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <deque>
 #include <functional>
 #include <future>
 #include <map>
@@ -33,6 +32,7 @@
 
 #include "config.h"
 #include "metric.h"
+#include "stream_queues.h"
 #include "topic_queues.h"
 #include "utils.h"
 
@@ -204,6 +204,7 @@ public:
     StdLogosResult streamRelease(uint64_t streamId);
 
     StdLogosResult protocolRequest(const std::string& argsJson);
+    StdLogosResult pingPeer(const std::string& peerId, int64_t timeoutMs);
     StdLogosResult streamReadLpJson(const std::string& argsJson);
     StdLogosResult streamWriteLpJson(const std::string& argsJson);
     StdLogosResult streamCloseJson(const std::string& argsJson);
@@ -277,9 +278,10 @@ private:
 
     TopicQueues m_topicQueues;
 
-    std::mutex m_inboundStreamMutex;
-    std::condition_variable m_inboundStreamCond;
-    std::unordered_map<std::string, std::deque<uint64_t>> m_inboundStreamQueues;
+    InboundStreamQueues m_inboundStreams;
+
+    // Releases without waiting, for callers on the Nim dispatch thread that must not block it.
+    void releaseStreamNoWait(uint64_t streamId);
 
     void applyOptions(const Libp2pModuleOptions& options);
     StdLogosResult createContext();

--- a/src/protocol_bridge.cpp
+++ b/src/protocol_bridge.cpp
@@ -13,9 +13,13 @@ constexpr char kPingCodec[] = "/ipfs/ping/1.0.0";
 constexpr size_t kPingSize = 32;
 
 std::string randomPingPayload() {
+    static_assert(kPingSize % sizeof(std::random_device::result_type) == 0);
     std::random_device rd;
     std::string out(kPingSize, '\0');
-    for (auto& c : out) c = static_cast<char>(rd() & 0xff);
+    for (size_t i = 0; i < kPingSize; i += sizeof(std::random_device::result_type)) {
+        const auto draw = rd();
+        std::memcpy(out.data() + i, &draw, sizeof(draw));
+    }
     return out;
 }
 
@@ -89,8 +93,7 @@ StdLogosResult Libp2pModuleImpl::protocolRequest(const std::string& argsJson) {
 
     auto d = dial(peerId, proto);
     if (!d.success) return {false, {}, "protocolRequest: dial failed: " + d.error};
-    uint64_t streamId = 0;
-    try { streamId = d.value.get<uint64_t>(); } catch (...) {}
+    const uint64_t streamId = asStreamId(d.value);
     if (streamId == 0) return {false, {}, "protocolRequest: dial returned no stream"};
 
     auto w = streamWriteLp(streamId, requestBytes);
@@ -214,8 +217,7 @@ StdLogosResult Libp2pModuleImpl::protocolAcceptStream(const std::string& argsJso
 StdLogosResult Libp2pModuleImpl::pingPeer(const std::string& peerId, int64_t timeoutMs) {
     auto d = dial(peerId, kPingCodec);
     if (!d.success) return {false, {}, "pingPeer: dial failed: " + d.error};
-    uint64_t streamId = 0;
-    try { streamId = d.value.get<uint64_t>(); } catch (...) {}
+    const uint64_t streamId = asStreamId(d.value);
     if (streamId == 0) return {false, {}, "pingPeer: dial returned no stream"};
 
     const std::string payload = randomPingPayload();

--- a/src/protocol_bridge.cpp
+++ b/src/protocol_bridge.cpp
@@ -1,10 +1,23 @@
 #include "plugin.h"
 
 #include <charconv>
+#include <cstring>
+#include <random>
 
 using json = nlohmann::json;
 
 namespace {
+
+// The libp2p ping protocol: write 32 random bytes, expect them back.
+constexpr char kPingCodec[] = "/ipfs/ping/1.0.0";
+constexpr size_t kPingSize = 32;
+
+std::string randomPingPayload() {
+    std::random_device rd;
+    std::string out(kPingSize, '\0');
+    for (auto& c : out) c = static_cast<char>(rd() & 0xff);
+    return out;
+}
 
 uint64_t asStreamId(const json& v) {
     if (v.is_number_unsigned()) return v.get<uint64_t>();
@@ -188,24 +201,56 @@ StdLogosResult Libp2pModuleImpl::protocolAcceptStream(const std::string& argsJso
         return {false, {}, "protocolAcceptStream: bad args (need {proto, timeoutMs?})"};
     }
 
-    std::unique_lock<std::mutex> lock(m_inboundStreamMutex);
-    auto hasStream = [&] {
-        auto it = m_inboundStreamQueues.find(proto);
-        return it != m_inboundStreamQueues.end() && !it->second.empty();
-    };
-    if (!hasStream()) {
-        auto wait = std::chrono::milliseconds(timeoutMs > 0 ? timeoutMs : 0);
-        if (!m_inboundStreamCond.wait_for(lock, wait, hasStream)) {
-            return {false, {}, "timeout waiting for inbound stream"};
-        }
+    InboundStream stream;
+    if (!m_inboundStreams.pop(proto, timeoutMs > 0 ? timeoutMs : 0, stream)) {
+        return {false, {}, "timeout waiting for inbound stream"};
     }
-    auto it = m_inboundStreamQueues.find(proto);
-    if (it == m_inboundStreamQueues.end() || it->second.empty()) {
-        return {false, {}, "no inbound stream"};
-    }
-    uint64_t streamId = it->second.front();
-    it->second.pop_front();
-    lock.unlock();
 
-    return {true, json{{"streamId", streamId}, {"proto", proto}}, ""};
+    return {true,
+            json{{"streamId", stream.streamId}, {"proto", proto}, {"peerId", stream.peerId}},
+            ""};
+}
+
+StdLogosResult Libp2pModuleImpl::pingPeer(const std::string& peerId, int64_t timeoutMs) {
+    auto d = dial(peerId, kPingCodec);
+    if (!d.success) return {false, {}, "pingPeer: dial failed: " + d.error};
+    uint64_t streamId = 0;
+    try { streamId = d.value.get<uint64_t>(); } catch (...) {}
+    if (streamId == 0) return {false, {}, "pingPeer: dial returned no stream"};
+
+    const std::string payload = randomPingPayload();
+    const auto sentAt = std::chrono::steady_clock::now();
+
+    auto w = streamWrite(streamId, payload);
+    if (!w.success) {
+        streamRelease(streamId);
+        return {false, {}, "pingPeer: write failed: " + w.error};
+    }
+
+    StreamReadExactlyRequest readReq{};
+    readReq.streamId = streamId;
+    readReq.numBytes = static_cast<int64_t>(kPingSize);
+    std::vector<uint8_t> echo;
+    auto r = callSyncWith("pingPeer: read failed",
+        [&](SyncPromise* p) {
+            return libp2p_ctx_stream_read_exactly(ctx, &readReq, &Libp2pModuleImpl::cbRead, p);
+        },
+        [&](const SyncResult& s) -> StdLogosResult {
+            echo = s.buffer;
+            return {true, {}, ""};
+        },
+        awaitTimeoutFor(timeoutMs));
+    const auto rtt = std::chrono::steady_clock::now() - sentAt;
+    streamRelease(streamId);
+    if (!r.success) return r;
+
+    if (echo.size() != payload.size() ||
+        std::memcmp(echo.data(), payload.data(), payload.size()) != 0) {
+        return {false, {}, "pingPeer: peer echoed a different payload"};
+    }
+
+    json out;
+    out["peerId"] = peerId;
+    out["rttMs"] = std::chrono::duration<double, std::milli>(rtt).count();
+    return {true, out, ""};
 }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -71,7 +71,19 @@ StdLogosResult Libp2pModuleImpl::streamCloseWithEOF(uint64_t streamId) {
 }
 
 StdLogosResult Libp2pModuleImpl::streamRelease(uint64_t streamId) {
-    return callSync("Failed to release stream", [&](SyncPromise* p) {
+    auto res = callSync("Failed to release stream", [&](SyncPromise* p) {
         return libp2p_ctx_stream_release(ctx, streamId, &Libp2pModuleImpl::cbBool, p);
     });
+    m_inboundStreams.remove(streamId);
+    return res;
+}
+
+void Libp2pModuleImpl::releaseStreamNoWait(uint64_t streamId) {
+    if (!ctx) return;
+    auto* p = new SyncPromise();
+    auto f = p->get_future();
+    int ret = libp2p_ctx_stream_release(ctx, streamId, &Libp2pModuleImpl::cbBool, p);
+    if (ret != 0 && f.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
+        delete p;
+    }
 }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -80,10 +80,7 @@ StdLogosResult Libp2pModuleImpl::streamRelease(uint64_t streamId) {
 
 void Libp2pModuleImpl::releaseStreamNoWait(uint64_t streamId) {
     if (!ctx) return;
-    auto* p = new SyncPromise();
-    auto f = p->get_future();
-    int ret = libp2p_ctx_stream_release(ctx, streamId, &Libp2pModuleImpl::cbBool, p);
-    if (ret != 0 && f.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
-        delete p;
-    }
+    callAsync([&](SyncPromise* p) {
+        return libp2p_ctx_stream_release(ctx, streamId, &Libp2pModuleImpl::cbBool, p);
+    });
 }

--- a/src/stream_queues.cpp
+++ b/src/stream_queues.cpp
@@ -49,38 +49,27 @@ bool InboundStreamQueues::remove(uint64_t streamId) {
 void InboundStreamQueues::releaseAll() {
     std::lock_guard<std::mutex> lock(m_mutex);
     for (auto it = m_protocols.begin(); it != m_protocols.end();) {
-        it = it->second.retire() ? std::next(it) : m_protocols.erase(it);
+        const bool keepForDropCounter = it->second.retire();
+        it = keepForDropCounter ? std::next(it) : m_protocols.erase(it);
     }
 }
 
-// A scrape samples under the lock and formats outside it, so it never holds the enqueue path.
 std::vector<Metric> InboundStreamQueues::metrics() const {
-    struct Sample {
-        std::string proto;
-        size_t depth;
-        uint64_t dropped;
-    };
-    std::vector<Sample> samples;
+    std::vector<QueueSample> samples;
     {
         std::lock_guard<std::mutex> lock(m_mutex);
         samples.reserve(m_protocols.size());
         for (const auto& [proto, p] : m_protocols) {
-            samples.push_back(Sample{proto, p.streams.size(), p.dropped});
+            samples.push_back(QueueSample{proto, p.streams.size(), p.dropped});
         }
     }
 
-    std::vector<Metric> series;
-    series.reserve(samples.size() * 2);
-    for (auto& s : samples) {
-        series.push_back(Metric{"libp2p_module_protocol_stream_queue_depth", "gauge",
-                                "inbound streams waiting in the per-protocol accept queue",
-                                {{"proto", s.proto}}, static_cast<double>(s.depth)});
-        series.push_back(Metric{"libp2p_module_protocol_stream_dropped_total", "counter",
-                                "inbound streams dropped because the accept queue was full",
-                                {{"proto", std::move(s.proto)}},
-                                static_cast<double>(s.dropped)});
-    }
-    return series;
+    return queueSeries(std::move(samples),
+        QueueSeriesNames{"proto",
+                         "libp2p_module_protocol_stream_queue_depth",
+                         "inbound streams waiting in the per-protocol accept queue",
+                         "libp2p_module_protocol_stream_dropped_total",
+                         "inbound streams dropped because the accept queue was full"});
 }
 
 bool InboundStreamQueues::Protocol::retire() {

--- a/src/stream_queues.cpp
+++ b/src/stream_queues.cpp
@@ -1,0 +1,89 @@
+#include "stream_queues.h"
+
+#include <chrono>
+#include <iterator>
+#include <utility>
+
+bool InboundStreamQueues::push(const std::string& proto, InboundStream stream) {
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        auto& p = m_protocols[proto];
+        if (p.streams.size() >= kMaxInboundStreamsPerProtocol) {
+            ++p.dropped;
+            return false;
+        }
+        p.streams.push_back(std::move(stream));
+    }
+    m_cond.notify_all();
+    return true;
+}
+
+bool InboundStreamQueues::pop(const std::string& proto, int64_t timeoutMs, InboundStream& out) {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    auto ready = [&] {
+        auto it = m_protocols.find(proto);
+        return it != m_protocols.end() && !it->second.streams.empty();
+    };
+    if (!m_cond.wait_for(lock, std::chrono::milliseconds(timeoutMs), ready)) {
+        return false;
+    }
+    auto& p = m_protocols.find(proto)->second;
+    out = std::move(p.streams.front());
+    p.streams.pop_front();
+    return true;
+}
+
+bool InboundStreamQueues::remove(uint64_t streamId) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    for (auto& [proto, p] : m_protocols) {
+        for (auto it = p.streams.begin(); it != p.streams.end(); ++it) {
+            if (it->streamId == streamId) {
+                p.streams.erase(it);
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+void InboundStreamQueues::releaseAll() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    for (auto it = m_protocols.begin(); it != m_protocols.end();) {
+        it = it->second.retire() ? std::next(it) : m_protocols.erase(it);
+    }
+}
+
+// A scrape samples under the lock and formats outside it, so it never holds the enqueue path.
+std::vector<Metric> InboundStreamQueues::metrics() const {
+    struct Sample {
+        std::string proto;
+        size_t depth;
+        uint64_t dropped;
+    };
+    std::vector<Sample> samples;
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        samples.reserve(m_protocols.size());
+        for (const auto& [proto, p] : m_protocols) {
+            samples.push_back(Sample{proto, p.streams.size(), p.dropped});
+        }
+    }
+
+    std::vector<Metric> series;
+    series.reserve(samples.size() * 2);
+    for (auto& s : samples) {
+        series.push_back(Metric{"libp2p_module_protocol_stream_queue_depth", "gauge",
+                                "inbound streams waiting in the per-protocol accept queue",
+                                {{"proto", s.proto}}, static_cast<double>(s.depth)});
+        series.push_back(Metric{"libp2p_module_protocol_stream_dropped_total", "counter",
+                                "inbound streams dropped because the accept queue was full",
+                                {{"proto", std::move(s.proto)}},
+                                static_cast<double>(s.dropped)});
+    }
+    return series;
+}
+
+bool InboundStreamQueues::Protocol::retire() {
+    streams.clear();
+    return dropped != 0;
+}

--- a/src/stream_queues.h
+++ b/src/stream_queues.h
@@ -11,7 +11,7 @@
 
 #include "metric.h"
 
-// A queued entry is the only handle a polling consumer has: the stream stays open on the Nim side until the host releases it.
+// A handle, not a stream: the Nim side keeps the stream open until the host releases it.
 struct InboundStream {
     uint64_t streamId = 0;
     std::string peerId;
@@ -21,7 +21,7 @@ inline constexpr size_t kMaxInboundStreamsPerProtocol = 1024;
 
 class InboundStreamQueues {
 public:
-    /// Past the per-protocol cap the newest stream is dropped and counted; the caller then releases it.
+    /// Over the cap the newest stream is dropped and counted; the caller releases it.
     bool push(const std::string& proto, InboundStream stream);
 
     bool pop(const std::string& proto, int64_t timeoutMs, InboundStream& out);
@@ -29,7 +29,7 @@ public:
     /// Drops a stream the host released before anyone accepted it.
     bool remove(uint64_t streamId);
 
-    /// Frees the queued streams, keeping the drop counters, since a reset counter reads as a target restart.
+    /// Drops the queued handles once the node or the context is gone, which is what frees the streams.
     void releaseAll();
 
     std::vector<Metric> metrics() const;

--- a/src/stream_queues.h
+++ b/src/stream_queues.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "metric.h"
+
+// A queued entry is the only handle a polling consumer has: the stream stays open on the Nim side until the host releases it.
+struct InboundStream {
+    uint64_t streamId = 0;
+    std::string peerId;
+};
+
+inline constexpr size_t kMaxInboundStreamsPerProtocol = 1024;
+
+class InboundStreamQueues {
+public:
+    /// Past the per-protocol cap the newest stream is dropped and counted; the caller then releases it.
+    bool push(const std::string& proto, InboundStream stream);
+
+    bool pop(const std::string& proto, int64_t timeoutMs, InboundStream& out);
+
+    /// Drops a stream the host released before anyone accepted it.
+    bool remove(uint64_t streamId);
+
+    /// Frees the queued streams, keeping the drop counters, since a reset counter reads as a target restart.
+    void releaseAll();
+
+    std::vector<Metric> metrics() const;
+
+private:
+    struct Protocol {
+        std::deque<InboundStream> streams;
+        uint64_t dropped = 0;
+
+        bool retire();
+    };
+
+    mutable std::mutex m_mutex;
+    std::condition_variable m_cond;
+    std::unordered_map<std::string, Protocol> m_protocols;
+};

--- a/src/topic_queues.cpp
+++ b/src/topic_queues.cpp
@@ -60,35 +60,22 @@ void TopicQueues::releaseAll() {
     }
 }
 
-// A scrape must not hold the enqueue path while it builds its series, so it
-// takes one cheap sample per topic under the lock and formats outside it.
 std::vector<Metric> TopicQueues::metrics() const {
-    struct Sample {
-        std::string topic;
-        size_t depth;
-        uint64_t dropped;
-    };
-    std::vector<Sample> samples;
+    std::vector<QueueSample> samples;
     {
         std::lock_guard<std::mutex> lock(m_mutex);
         samples.reserve(m_topics.size());
         for (const auto& [topic, t] : m_topics) {
-            samples.push_back(Sample{topic, t.messages.size(), t.dropped});
+            samples.push_back(QueueSample{topic, t.messages.size(), t.dropped});
         }
     }
 
-    std::vector<Metric> series;
-    series.reserve(samples.size() * 2);
-    for (auto& s : samples) {
-        series.push_back(Metric{"libp2p_module_gossipsub_queue_depth", "gauge",
-                                "messages waiting in the per-topic poll queue",
-                                {{"topic", s.topic}}, static_cast<double>(s.depth)});
-        series.push_back(Metric{"libp2p_module_gossipsub_queue_dropped_total", "counter",
-                                "messages dropped because the per-topic poll queue was full",
-                                {{"topic", std::move(s.topic)}},
-                                static_cast<double>(s.dropped)});
-    }
-    return series;
+    return queueSeries(std::move(samples),
+        QueueSeriesNames{"topic",
+                         "libp2p_module_gossipsub_queue_depth",
+                         "messages waiting in the per-topic poll queue",
+                         "libp2p_module_gossipsub_queue_dropped_total",
+                         "messages dropped because the per-topic poll queue was full"});
 }
 
 size_t TopicQueues::topicCount() const {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,11 +12,13 @@ logos_test(
     MODULE_SOURCES
         ../src/utils.cpp
         ../src/topic_queues.cpp
+        ../src/stream_queues.cpp
     TEST_SOURCES
         main.cpp
         unit_config.cpp
         unit_metrics.cpp
         unit_sync.cpp
+        unit_stream_queues.cpp
         unit_topic_queues.cpp
     EXTRA_INCLUDES
         ../lib
@@ -39,6 +41,7 @@ if(LIBP2P_PATH)
         MODULE_SOURCES
             ../src/utils.cpp
             ../src/topic_queues.cpp
+            ../src/stream_queues.cpp
             ../src/plugin.cpp
             ../src/callbacks.cpp
             ../src/kademlia.cpp

--- a/tests/custom_handlers.cpp
+++ b/tests/custom_handlers.cpp
@@ -79,6 +79,7 @@ LOGOS_TEST(custom_handlers_protocol_stream_event) {
 
     LOGOS_ASSERT_TRUE(nodeA.start().success);
     auto [peerIdB, addrsB] = getPeerInfoPair(nodeB);
+    const std::string peerIdA = getPeerInfoPair(nodeA).first;
     LOGOS_ASSERT_TRUE(nodeA.connectPeer(peerIdB, addrsB, 500).success);
 
     auto dialResult = nodeA.dial(peerIdB, proto);
@@ -93,6 +94,7 @@ LOGOS_TEST(custom_handlers_protocol_stream_event) {
 
     auto j = json::parse(capturedData);
     LOGOS_ASSERT_TRUE(j["proto"].get<std::string>() == proto);
+    LOGOS_ASSERT_TRUE(j["peerId"].get<std::string>() == peerIdA);
     uint64_t serverStreamId = j["streamId"].get<uint64_t>();
     LOGOS_ASSERT_NE(serverStreamId, static_cast<uint64_t>(0));
 
@@ -118,14 +120,17 @@ LOGOS_TEST(protocol_bridge_request_accept_roundtrip) {
 
     const std::string request = "ping-over-the-bridge";
     auto [peerIdB, addrsB] = getPeerInfoPair(nodeB);
+    const std::string peerIdA = getPeerInfoPair(nodeA).first;
 
     std::string serverSawRequest;
+    std::string serverSawPeerId;
     bool serverOk = false;
     std::thread server([&] {
         auto acc = nodeB.protocolAcceptStream(json{{"proto", proto}, {"timeoutMs", 5000}}.dump());
         if (!acc.success) return;
         uint64_t sid = acc.value["streamId"].get<uint64_t>();
         if (sid == 0) return;
+        serverSawPeerId = acc.value["peerId"].get<std::string>();
 
         auto rd = nodeB.streamReadLpJson(json{{"streamId", sid}, {"timeoutMs", 5000}}.dump());
         if (!rd.success) return;
@@ -151,6 +156,7 @@ LOGOS_TEST(protocol_bridge_request_accept_roundtrip) {
 
     LOGOS_ASSERT_TRUE(serverOk);
     LOGOS_ASSERT_TRUE(serverSawRequest == request);
+    LOGOS_ASSERT_TRUE(serverSawPeerId == peerIdA);
     LOGOS_ASSERT_TRUE(resp.success);
     std::string respStr = base64Decode(resp.value["responseB64"].get<std::string>());
     LOGOS_ASSERT_TRUE(respStr == "echo:" + request);
@@ -248,6 +254,39 @@ LOGOS_TEST(protocol_bridge_release_purges_inbound_queue) {
     LOGOS_ASSERT_TRUE(nodeA.streamRelease(clientStreamId).success);
     LOGOS_ASSERT_TRUE(nodeA.stop().success);
     LOGOS_ASSERT_TRUE(nodeB.stop().success);
+}
+
+LOGOS_TEST(protocol_bridge_ping_peer) {
+    Libp2pModuleImpl nodeA;
+    Libp2pModuleImpl nodeB;
+
+    LOGOS_ASSERT_TRUE(nodeA.start().success);
+    LOGOS_ASSERT_TRUE(nodeB.start().success);
+
+    auto [peerIdB, addrsB] = getPeerInfoPair(nodeB);
+    LOGOS_ASSERT_TRUE(nodeA.connectPeer(peerIdB, addrsB, 500).success);
+
+    auto ping = nodeA.pingPeer(peerIdB, 5000);
+    LOGOS_ASSERT_TRUE(ping.success);
+    LOGOS_ASSERT_TRUE(ping.value["peerId"].get<std::string>() == peerIdB);
+    LOGOS_ASSERT_TRUE(ping.value["rttMs"].get<double>() >= 0.0);
+
+    LOGOS_ASSERT_TRUE(nodeA.stop().success);
+    LOGOS_ASSERT_TRUE(nodeB.stop().success);
+}
+
+LOGOS_TEST(protocol_bridge_ping_unknown_peer_fails) {
+    Libp2pModuleImpl nodeA;
+    Libp2pModuleImpl nodeC;
+
+    LOGOS_ASSERT_TRUE(nodeA.start().success);
+    LOGOS_ASSERT_TRUE(nodeC.start().success);
+
+    const std::string peerIdC = getPeerInfoPair(nodeC).first;
+    LOGOS_ASSERT_FALSE(nodeA.pingPeer(peerIdC, 1000).success);
+
+    LOGOS_ASSERT_TRUE(nodeA.stop().success);
+    LOGOS_ASSERT_TRUE(nodeC.stop().success);
 }
 
 LOGOS_TEST(protocol_bridge_write_requires_dataB64) {

--- a/tests/unit_stream_queues.cpp
+++ b/tests/unit_stream_queues.cpp
@@ -1,0 +1,87 @@
+// InboundStreamQueues in isolation (no Libp2pModuleImpl, links without libp2p.so).
+
+#include <logos_test.h>
+#include <stream_queues.h>
+
+#include <string>
+
+namespace {
+double metricValue(const std::vector<Metric>& series, const std::string& name) {
+    for (const auto& m : series) {
+        if (m.name == name) return m.value;
+    }
+    return -1.0;
+}
+}  // namespace
+
+LOGOS_TEST(stream_queues_pops_in_order_with_peer_id) {
+    InboundStreamQueues queues;
+    LOGOS_ASSERT_TRUE(queues.push("/p/1", InboundStream{1, "peer-a"}));
+    LOGOS_ASSERT_TRUE(queues.push("/p/1", InboundStream{2, "peer-b"}));
+
+    InboundStream out;
+    LOGOS_ASSERT_TRUE(queues.pop("/p/1", 0, out));
+    LOGOS_ASSERT_EQ(out.streamId, static_cast<uint64_t>(1));
+    LOGOS_ASSERT_TRUE(out.peerId == "peer-a");
+    LOGOS_ASSERT_TRUE(queues.pop("/p/1", 0, out));
+    LOGOS_ASSERT_EQ(out.streamId, static_cast<uint64_t>(2));
+    LOGOS_ASSERT_TRUE(out.peerId == "peer-b");
+    LOGOS_ASSERT_FALSE(queues.pop("/p/1", 0, out));
+}
+
+LOGOS_TEST(stream_queues_keep_protocols_apart) {
+    InboundStreamQueues queues;
+    LOGOS_ASSERT_TRUE(queues.push("/p/1", InboundStream{1, "peer-a"}));
+
+    InboundStream out;
+    LOGOS_ASSERT_FALSE(queues.pop("/p/2", 0, out));
+    LOGOS_ASSERT_TRUE(queues.pop("/p/1", 0, out));
+}
+
+LOGOS_TEST(stream_queues_drop_newest_over_cap) {
+    InboundStreamQueues queues;
+    for (size_t i = 0; i < kMaxInboundStreamsPerProtocol; ++i) {
+        LOGOS_ASSERT_TRUE(queues.push("/p/1", InboundStream{i + 1, "peer"}));
+    }
+    LOGOS_ASSERT_FALSE(queues.push("/p/1", InboundStream{9999, "peer"}));
+
+    auto series = queues.metrics();
+    LOGOS_ASSERT_EQ(metricValue(series, "libp2p_module_protocol_stream_queue_depth"),
+                    static_cast<double>(kMaxInboundStreamsPerProtocol));
+    LOGOS_ASSERT_EQ(metricValue(series, "libp2p_module_protocol_stream_dropped_total"), 1.0);
+
+    InboundStream out;
+    LOGOS_ASSERT_TRUE(queues.pop("/p/1", 0, out));
+    LOGOS_ASSERT_EQ(out.streamId, static_cast<uint64_t>(1));
+}
+
+LOGOS_TEST(stream_queues_remove_takes_a_stream_out) {
+    InboundStreamQueues queues;
+    LOGOS_ASSERT_TRUE(queues.push("/p/1", InboundStream{1, "peer-a"}));
+    LOGOS_ASSERT_TRUE(queues.push("/p/1", InboundStream{2, "peer-b"}));
+
+    LOGOS_ASSERT_TRUE(queues.remove(1));
+    LOGOS_ASSERT_FALSE(queues.remove(1));
+
+    InboundStream out;
+    LOGOS_ASSERT_TRUE(queues.pop("/p/1", 0, out));
+    LOGOS_ASSERT_EQ(out.streamId, static_cast<uint64_t>(2));
+}
+
+// releaseAll frees the streams; a drop counter already reported must survive it.
+LOGOS_TEST(stream_queues_release_all_keeps_the_drop_counter) {
+    InboundStreamQueues queues;
+    for (size_t i = 0; i < kMaxInboundStreamsPerProtocol + 1; ++i) {
+        queues.push("/p/1", InboundStream{i + 1, "peer"});
+    }
+    queues.push("/p/2", InboundStream{1, "peer"});
+    queues.releaseAll();
+
+    auto series = queues.metrics();
+    LOGOS_ASSERT_EQ(metricValue(series, "libp2p_module_protocol_stream_dropped_total"), 1.0);
+    LOGOS_ASSERT_EQ(metricValue(series, "libp2p_module_protocol_stream_queue_depth"), 0.0);
+    LOGOS_ASSERT_EQ(series.size(), size_t(2));
+
+    InboundStream out;
+    LOGOS_ASSERT_FALSE(queues.pop("/p/1", 0, out));
+}

--- a/tests/unit_stream_queues.cpp
+++ b/tests/unit_stream_queues.cpp
@@ -1,5 +1,3 @@
-// InboundStreamQueues in isolation (no Libp2pModuleImpl, links without libp2p.so).
-
 #include <logos_test.h>
 #include <stream_queues.h>
 
@@ -68,7 +66,7 @@ LOGOS_TEST(stream_queues_remove_takes_a_stream_out) {
     LOGOS_ASSERT_EQ(out.streamId, static_cast<uint64_t>(2));
 }
 
-// releaseAll frees the streams; a drop counter already reported must survive it.
+// A drop counter already reported must survive releaseAll.
 LOGOS_TEST(stream_queues_release_all_keeps_the_drop_counter) {
     InboundStreamQueues queues;
     for (size_t i = 0; i < kMaxInboundStreamsPerProtocol + 1; ++i) {


### PR DESCRIPTION
## What

Makes the custom-protocol bridge usable by another module that runs its own protocol on this node instead of starting a second libp2p node. First consumer: logos-co/logos-delivery-module#89.

## Why the accept path did not work

PR #82 added the inbound accept queue. The nim-ffi cbind migration (#77) rewrote `onIncomingStream` to only emit an event, so the queue lost its only writer and `protocolAcceptStream` always timed out. Nothing caught it, because `tests/CMakeLists.txt` skips every integration test when `lib/libp2p.so` is absent, and that is what CI does on every run.

## Changes

- `InboundStreamQueues` (`src/stream_queues.{h,cpp}`) holds inbound streams per protocol, in the shape `TopicQueues` already uses. The inbound-stream event enqueues `{streamId, peerId}` again.
- The queue holds 1024 streams per protocol. Past that the newest stream is dropped, released without a wait (the callback runs on the Nim dispatch thread) and counted in `libp2p_module_protocol_stream_dropped_total`, next to a `libp2p_module_protocol_stream_queue_depth` gauge.
- `protocolAcceptStream` returns `{streamId, proto, peerId}`. A service protocol answers the peer that opened the stream, so it needs to know which peer that is.
- `mountProtocol` no longer needs `emitEvent`. The module boundary carries no push events, so a consumer in another module can only poll, and the queue is what keeps the stream reachable.
- `streamRelease` takes the stream out of the queue, and `stop` frees the queues while the drop counters survive.
- New `pingPeer(peerId, timeoutMs)` returns `{peerId, rttMs}` over `/ipfs/ping/1.0.0`. The bridge had no way to check that a peer is still alive.
- `queueSeries()` (`src/metric.h`) formats the depth and drop series for both poll queues, so `TopicQueues` and `InboundStreamQueues` share one copy of that loop instead of two.
- `callAsync()` (`src/plugin.h`) holds the fire-and-forget half of the promise dance that the over-cap release path needs, next to the awaiting half that owns the same rule about who deletes the promise.

## Dependency

`libp2p` is pinned to `nim-libp2p` master, which carries `peerId` on `IncomingStreamEvent` since vacp2p/nim-libp2p#2969 (merged as `c7bed9be`).

## Tests

`tests/unit_stream_queues.cpp` covers order, per-protocol separation, the cap and its drop counter, removal, and the counter surviving a release. It links without `libp2p.so`, so CI runs it.

The two accept tests now assert the peer id, and `protocol_bridge_ping_peer` and `protocol_bridge_ping_unknown_peer_fails` are new. CI does not run that layer: `nix flake check` builds the test tree with no `lib/libp2p.so` and prints `[Libp2pTests] libp2p not found in ../lib — skipping integration tests`. Run it locally with a real `libp2p.so` staged in `lib/`.

## Known limits

- An accept pump waiting in `protocolAcceptStream` when the node stops waits out its own timeout, and a restart of this module invalidates every `streamId`.
- The over-cap release path calls into `ctx` from the Nim dispatch thread, while `destroyContext()` frees `ctx` from the module thread. Nothing orders the two, so a stop that races an inbound stream can reach a freed context. Every other call in the wrapper carries the same unguarded `if (!ctx)` check, so a context lifetime lock is its own change. #107 is that change, stacked on this branch: it guards `callAsync` with the same lock and drops the bare check in `releaseStreamNoWait`, which closes this path.
- A full queue drops the stream and emits no `protocolStream` event, so an event-driven consumer that stops releasing streams loses them with only the drop counter to say so. Drive a protocol from the queue or from the event, never from both.

