### PR TITLE
feat(flake): add nix binary cache

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,12 @@
 {
   description = "Logos Libp2p Module";
 
+  # Pull pre-built artifacts from the self-hosted Logos Attic cache(Nix binary cache).
+  nixConfig = {
+    extra-substituters = [ "https://cache.nix.logos.co/public" ];
+    extra-trusted-public-keys = [ "public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU=" ];
+  };
+
   inputs = {
     logos-module-builder.url = "github:logos-co/logos-module-builder";
     libp2p.url = "github:vacp2p/nim-libp2p/master";


### PR DESCRIPTION
Used by CI to store build artifacts.

## 🎯 Purpose

Stores nix build artifacts to Logos Nix binary cache. This allows you not to rebuild each time locally or on deployment machine, but fetch it directly from the cache

