### PR TITLE
fix(ctx): guard the libp2p context pointer against a concurrent destroy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,8 @@ jobs:
           "set -e;
           sudo apt-get update;
           sudo apt-get install -y curl git;
-          curl -fsSL https://install.determinate.systems/nix | sh -s -- install --no-confirm;
+          curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/nix-install.sh https://install.determinate.systems/nix;
+          sh /tmp/nix-install.sh install --no-confirm;
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh;
           nix flake check --system x86_64-linux --print-build-logs --show-trace
           --max-jobs 2 --cores 2 --max-silent-time 900

--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -153,6 +153,7 @@ void Libp2pModuleImpl::cbPeerStoreEntry(
 void Libp2pModuleImpl::onIncomingStream(const IncomingStreamEvent* evt, void* ud) {
     auto* self = static_cast<Libp2pModuleImpl*>(ud);
     if (!self || !evt) return;
+    std::shared_lock<std::shared_timed_mutex> guard(self->m_listenerLock);
     try {
         const std::string proto = nfStr(evt->proto);
         const std::string peerId = nfStr(evt->peerId);
@@ -172,6 +173,7 @@ void Libp2pModuleImpl::onIncomingStream(const IncomingStreamEvent* evt, void* ud
 void Libp2pModuleImpl::onPubsubMessage(const PubsubMessageEvent* evt, void* ud) {
     auto* self = static_cast<Libp2pModuleImpl*>(ud);
     if (!self || !evt) return;
+    std::shared_lock<std::shared_timed_mutex> guard(self->m_listenerLock);
     try {
         std::string topic = nfStr(evt->topic);
         auto bytes = nfBytes(evt->data);

--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -151,9 +151,11 @@ void Libp2pModuleImpl::cbPeerStoreEntry(
 // the whole body — a serialization failure (e.g. non-UTF-8 pubsub payload in
 // the emitted event) must not take the process down.
 void Libp2pModuleImpl::onIncomingStream(const IncomingStreamEvent* evt, void* ud) {
-    auto* self = static_cast<Libp2pModuleImpl*>(ud);
-    if (!self || !evt) return;
-    std::shared_lock<std::shared_timed_mutex> guard(self->m_listenerLock);
+    auto* gate = static_cast<ListenerGate*>(ud);
+    if (!gate || !evt) return;
+    std::shared_lock<std::shared_mutex> guard(gate->lock);
+    auto* self = gate->owner;
+    if (!self) return;
     try {
         const std::string proto = nfStr(evt->proto);
         const std::string peerId = nfStr(evt->peerId);
@@ -171,9 +173,11 @@ void Libp2pModuleImpl::onIncomingStream(const IncomingStreamEvent* evt, void* ud
 }
 
 void Libp2pModuleImpl::onPubsubMessage(const PubsubMessageEvent* evt, void* ud) {
-    auto* self = static_cast<Libp2pModuleImpl*>(ud);
-    if (!self || !evt) return;
-    std::shared_lock<std::shared_timed_mutex> guard(self->m_listenerLock);
+    auto* gate = static_cast<ListenerGate*>(ud);
+    if (!gate || !evt) return;
+    std::shared_lock<std::shared_mutex> guard(gate->lock);
+    auto* self = gate->owner;
+    if (!self) return;
     try {
         std::string topic = nfStr(evt->topic);
         auto bytes = nfBytes(evt->data);

--- a/src/custom_handlers.cpp
+++ b/src/custom_handlers.cpp
@@ -1,7 +1,7 @@
 #include "plugin.h"
 
 StdLogosResult Libp2pModuleImpl::mountProtocol(const std::string& proto) {
-    if (!ctx) return {false, {}, "No libp2p context"};
+    if (!hasCtx()) return {false, {}, "No libp2p context"};
     if (proto.empty()) return {false, {}, "Protocol string is empty"};
     publishEmitEvent();
 

--- a/src/gossipsub.cpp
+++ b/src/gossipsub.cpp
@@ -12,7 +12,7 @@ StdLogosResult Libp2pModuleImpl::gossipsubPublish(
 }
 
 StdLogosResult Libp2pModuleImpl::gossipsubSubscribe(const std::string& topic) {
-    if (!ctx) return {false, {}, "No libp2p context"};
+    if (!hasCtx()) return {false, {}, "No libp2p context"};
     // Delivered messages surface through the on_pubsub_message listener, which
     // needs the emit snapshot published to forward gossipsubMessage events.
     publishEmitEvent();
@@ -23,7 +23,7 @@ StdLogosResult Libp2pModuleImpl::gossipsubSubscribe(const std::string& topic) {
 }
 
 StdLogosResult Libp2pModuleImpl::gossipsubUnsubscribe(const std::string& topic) {
-    if (!ctx) return {false, {}, "No libp2p context"};
+    if (!hasCtx()) return {false, {}, "No libp2p context"};
     auto res = callSync("Failed to unsubscribe", [&](SyncPromise* p) {
         return libp2p_ctx_gossipsub_unsubscribe(ctx, nimffi_str(topic.c_str()),
                                                 &Libp2pModuleImpl::cbBool, p);

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -211,15 +211,25 @@ StdLogosResult Libp2pModuleImpl::createContext() {
         return {false, {}, m_initError};
     }
 
+    std::unique_lock<std::shared_mutex> lock(m_ctxLock);
     ctx = r.newCtx;
 
-    // Register listeners before start so incoming protocol streams and pubsub
-    // messages are delivered once the node is running. Destroying the context
-    // frees the listener boxes.
+    // Registered before start so incoming protocol streams and pubsub messages are delivered once the node runs; destroying the context frees the listener boxes.
     libp2p_ctx_add_on_incoming_stream_listener(ctx, &Libp2pModuleImpl::onIncomingStream, this);
     libp2p_ctx_add_on_pubsub_message_listener(ctx, &Libp2pModuleImpl::onPubsubMessage, this);
 
     return {true, {}, ""};
+}
+
+bool Libp2pModuleImpl::hasCtx() const {
+    std::shared_lock<std::shared_mutex> lock(m_ctxLock);
+    return ctx != nullptr;
+}
+
+StdLogosResult Libp2pModuleImpl::ensureContext() {
+    std::lock_guard<std::mutex> lock(m_createLock);
+    if (hasCtx()) return {true, {}, ""};
+    return createContext();
 }
 
 StdLogosResult Libp2pModuleImpl::createNode(const std::string& config) {
@@ -231,7 +241,8 @@ StdLogosResult Libp2pModuleImpl::createNode(const std::string& config) {
         fprintf(stderr, "libp2p_module: %s\n", msg.c_str());
         return {false, {}, msg};
     }
-    if (ctx) {
+    std::lock_guard<std::mutex> lock(m_createLock);
+    if (hasCtx()) {
         std::string msg = "createNode: node already created";
         fprintf(stderr, "libp2p_module: %s\n", msg.c_str());
         return {false, {}, msg};
@@ -250,14 +261,31 @@ StdLogosResult Libp2pModuleImpl::setLogLevel(const std::string& level) {
     return {true, {}, ""};
 }
 
-void Libp2pModuleImpl::destroyContext() {
-    if (!ctx) {
+void Libp2pModuleImpl::drainListeners() {
+    if (!m_listenerLock.try_lock_for(std::chrono::milliseconds(kDefaultOpTimeoutMs))) {
+        fprintf(stderr, "libp2p_module: an event listener is still running after %d ms;"
+                        " freeing the module under it\n", kDefaultOpTimeoutMs);
         return;
     }
-    // Synchronous: runs the Nim destructor (which drops the node and its
-    // streams) and frees the C-side context wrapper and listener boxes.
-    destroyContextChecked(ctx);
-    ctx = nullptr;
+    m_listenerLock.unlock();
+}
+
+void Libp2pModuleImpl::destroyContext() {
+    LibP2PCtx* doomed = nullptr;
+    {
+        // Scoped: a listener holds m_listenerLock and then wants m_ctxLock, so drainListeners below must not be reached with m_ctxLock still held.
+        std::unique_lock<std::shared_mutex> lock(m_ctxLock);
+        doomed = ctx;
+        ctx = nullptr;
+    }
+    if (!doomed) {
+        return;
+    }
+
+    // Synchronous: runs the Nim destructor (dropping the node and its streams) and frees the C-side context wrapper and listener boxes.
+    destroyContextChecked(doomed);
+
+    drainListeners();
     m_inboundStreams.releaseAll();
 }
 
@@ -268,10 +296,9 @@ Libp2pModuleImpl::~Libp2pModuleImpl() {
 }
 
 StdLogosResult Libp2pModuleImpl::start() {
-    if (!ctx) {
-        auto created = createContext();
-        if (!created.success) return created;
-    }
+    auto ready = ensureContext();
+    if (!ready.success) return ready;
+
     publishEmitEvent();
     return callSync("Failed to start libp2p", [&](SyncPromise* p) {
         return libp2p_ctx_start(ctx, &Libp2pModuleImpl::cbBool, p);
@@ -291,11 +318,11 @@ StdLogosResult Libp2pModuleImpl::stop() {
 }
 
 bool Libp2pModuleImpl::ok() {
-    return ctx != nullptr;
+    return hasCtx();
 }
 
 StdLogosResult Libp2pModuleImpl::status() {
-    if (ctx) return {true, {}, ""};
+    if (hasCtx()) return {true, {}, ""};
     return {false, {}, m_initError.empty() ? "libp2p not initialized" : m_initError};
 }
 
@@ -305,10 +332,9 @@ StdLogosResult Libp2pModuleImpl::newPrivateKey(const std::string& scheme) {
         return {false, {}, "Unknown key scheme '" + scheme +
                            "'; expected rsa, ed25519, secp256k1 or ecdsa"};
     }
-    if (!ctx) {
-        auto created = createContext();
-        if (!created.success) return created;
-    }
+    auto ready = ensureContext();
+    if (!ready.success) return ready;
+
     NewPrivateKeyRequest req{};
     req.scheme = static_cast<int64_t>(parsed);
     return callSyncWith("Failed to generate private key",

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -16,14 +16,14 @@ std::string defaultListenAddr(TransportType transport) {
     return "/ip4/127.0.0.1/tcp/0";
 }
 
-// Tears a context down and reports a failed teardown. The context is gone
-// either way, but a non-OK code means the Nim side could not stop cleanly and
-// its worker threads may still be live, which is worth a line in the log.
-void destroyContextChecked(LibP2PCtx* c) {
+// False means the Nim side could not stop cleanly, so its worker threads may still be live.
+bool destroyContextChecked(LibP2PCtx* c) {
     int rc = libp2p_ctx_destroy(c);
     if (rc != NIMFFI_RET_OK) {
         fprintf(stderr, "libp2p_module: libp2p_ctx_destroy failed (rc=%d)\n", rc);
+        return false;
     }
+    return true;
 }
 
 // Pulls the port out of a multiaddr (the segment after /tcp/ or /udp/).
@@ -214,9 +214,12 @@ StdLogosResult Libp2pModuleImpl::createContext() {
     std::unique_lock<std::shared_mutex> lock(m_ctxLock);
     ctx = r.newCtx;
 
+    m_gate = new ListenerGate();
+    m_gate->owner = this;
+
     // Registered before start so incoming protocol streams and pubsub messages are delivered once the node runs; destroying the context frees the listener boxes.
-    libp2p_ctx_add_on_incoming_stream_listener(ctx, &Libp2pModuleImpl::onIncomingStream, this);
-    libp2p_ctx_add_on_pubsub_message_listener(ctx, &Libp2pModuleImpl::onPubsubMessage, this);
+    libp2p_ctx_add_on_incoming_stream_listener(ctx, &Libp2pModuleImpl::onIncomingStream, m_gate);
+    libp2p_ctx_add_on_pubsub_message_listener(ctx, &Libp2pModuleImpl::onPubsubMessage, m_gate);
 
     return {true, {}, ""};
 }
@@ -261,19 +264,21 @@ StdLogosResult Libp2pModuleImpl::setLogLevel(const std::string& level) {
     return {true, {}, ""};
 }
 
-void Libp2pModuleImpl::drainListeners() {
-    if (!m_listenerLock.try_lock_for(std::chrono::milliseconds(kDefaultOpTimeoutMs))) {
-        fprintf(stderr, "libp2p_module: an event listener is still running after %d ms;"
-                        " freeing the module under it\n", kDefaultOpTimeoutMs);
+// Waits out a listener that is already running, and stops any later one before it touches the module. The wait has no timeout: a running listener holds a bare pointer to the module, and no deadline makes that pointer safe to free.
+void Libp2pModuleImpl::detachListeners() {
+    if (!m_gate) {
         return;
     }
-    m_listenerLock.unlock();
+    std::unique_lock<std::shared_mutex> lock(m_gate->lock);
+    m_gate->owner = nullptr;
 }
 
 void Libp2pModuleImpl::destroyContext() {
+    // Before the teardown, so the Nim event thread never sits in a module callback while the teardown waits to join it.
+    detachListeners();
+
     LibP2PCtx* doomed = nullptr;
     {
-        // Scoped: a listener holds m_listenerLock and then wants m_ctxLock, so drainListeners below must not be reached with m_ctxLock still held.
         std::unique_lock<std::shared_mutex> lock(m_ctxLock);
         doomed = ctx;
         ctx = nullptr;
@@ -283,9 +288,14 @@ void Libp2pModuleImpl::destroyContext() {
     }
 
     // Synchronous: runs the Nim destructor (dropping the node and its streams) and frees the C-side context wrapper and listener boxes.
-    destroyContextChecked(doomed);
+    const bool stopped = destroyContextChecked(doomed);
 
-    drainListeners();
+    // A failed teardown leaves the listener boxes, and the thread that reads them, alive: the gate they point at has to stay.
+    if (stopped) {
+        delete m_gate;
+    }
+    m_gate = nullptr;
+
     m_inboundStreams.releaseAll();
 }
 

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -249,16 +249,17 @@ public:
     LogosMap collectMetrics();
 
 private:
+    // Guards `ctx`: shared to submit, unique to swap it. Never held across an await or a teardown, which wait on Nim workers.
+    mutable std::shared_mutex m_ctxLock;
     LibP2PCtx* ctx = nullptr;
+
     Libp2pConfig m_libp2pConfig = {};
 
     // Set when construction fails; surfaced through status() since the
     // constructor cannot signal failure to the codegen default-constructor.
     std::string m_initError;
 
-    // Backing storage the Libp2pConfig's NimFfiStr/seq views borrow from; it
-    // must outlive every libp2p_ctx_create call. Built once in applyOptions and
-    // never mutated afterwards, so the views stay valid.
+    // Backing storage the Libp2pConfig's NimFfiStr/seq views borrow from. applyOptions rebuilds it, so it and every create run under m_createLock.
     std::vector<std::string> m_addrs;
     std::vector<NimFfiStr> m_addrsFfi;
 
@@ -284,9 +285,18 @@ private:
     void releaseStreamNoWait(uint64_t streamId);
 
     void applyOptions(const Libp2pModuleOptions& options);
+    bool hasCtx() const;
+
+    // Serializes the create path: applyOptions rebuilds the buffers the config views borrow, so it must not run under a create.
+    std::mutex m_createLock;
+    StdLogosResult ensureContext();
     StdLogosResult createContext();
     void destroyContext();
     StdLogosResult nodeInfoBoundPorts();
+
+    // Held shared for the body of an event listener, which runs on the Nim dispatch thread against a bare `this`. destroyContext takes it unique to wait one out.
+    std::shared_timed_mutex m_listenerLock;
+    void drainListeners();
 
     // Reply trampolines: one per generated response type. Each turns the typed
     // (err_code, reply, err_msg) callback into a SyncResult and resolves the
@@ -332,19 +342,37 @@ private:
     template <class Invoke, class Transform>
     StdLogosResult callSyncWith(const char* errPrefix, Invoke&& invoke, Transform&& transform,
                                 int awaitMs = kDefaultOpTimeoutMs) {
-        if (!ctx) return {false, {}, "No libp2p context"};
-        return callStaticWith(errPrefix, std::forward<Invoke>(invoke),
-                              std::forward<Transform>(transform), awaitMs);
+        SyncPromise* p = nullptr;
+        std::future<SyncResult> f;
+        int ret = 0;
+        {
+            // The check and the submit are one section: a destroy between them frees the context the binding is handed.
+            std::shared_lock<std::shared_mutex> lock(m_ctxLock);
+            if (!ctx) return {false, {}, "No libp2p context"};
+
+            p = new SyncPromise();
+            f = p->get_future();
+            ret = invoke(p);
+        }
+
+        return awaitReply(errPrefix, p, f, ret, std::forward<Transform>(transform), awaitMs);
     }
 
-    // Same dance without the context check, for the `{.ffiStatic.}` bindings:
-    // they take no ctx and run on the library's own static context.
+    // Same dance without the context check, for the `{.ffiStatic.}` bindings, which run on the library's own static context.
     template <class Invoke, class Transform>
     static StdLogosResult callStaticWith(const char* errPrefix, Invoke&& invoke, Transform&& transform,
                                          int awaitMs = kDefaultOpTimeoutMs) {
         auto* p = new SyncPromise();
         auto f = p->get_future();
         int ret = invoke(p);
+        return awaitReply(errPrefix, p, f, ret, std::forward<Transform>(transform), awaitMs);
+    }
+
+    // Second half of every op, run with no lock held: reclaim on a submit failure, else await and map.
+    template <class Transform>
+    static StdLogosResult awaitReply(const char* errPrefix, SyncPromise* p,
+                                     std::future<SyncResult>& f, int ret,
+                                     Transform&& transform, int awaitMs) {
         if (ret != 0) {
             // A submit-time failure (encode/OOM/missing-callback) fires the
             // reply callback synchronously — which owns and deletes p — before
@@ -363,7 +391,10 @@ private:
 
     // Submits without awaiting, for a caller that must not block its thread.
     template <class Invoke>
-    static void callAsync(Invoke&& invoke) {
+    void callAsync(Invoke&& invoke) {
+        std::shared_lock<std::shared_mutex> lock(m_ctxLock);
+        if (!ctx) return;
+
         auto* p = new SyncPromise();
         auto f = p->get_future();
         if (invoke(p) != 0 && f.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -164,13 +164,8 @@ inline StdLogosResult jsonResult(const SyncResult& r, nlohmann::json emptyDefaul
     return {true, r.data, ""};
 }
 
-class Libp2pModuleImpl;
-
-// Listener user_data. It outlives the module whenever the context teardown fails, because the Nim event thread may still fire: a late callback then reads a null owner instead of a freed module.
-struct ListenerGate {
-    std::shared_mutex lock;
-    Libp2pModuleImpl* owner = nullptr;
-};
+// Defined below the class. A forward declaration of the module class above it makes the codegen header parser read that declaration as the class body and publish no methods at all.
+struct ListenerGate;
 
 class Libp2pModuleImpl {
 public:
@@ -409,6 +404,12 @@ private:
             delete p;
         }
     }
+};
+
+// Listener user_data. It outlives the module whenever the context teardown fails, because the Nim event thread may still fire: a late callback then reads a null owner instead of a freed module.
+struct ListenerGate {
+    std::shared_mutex lock;
+    Libp2pModuleImpl* owner = nullptr;
 };
 
 inline StdLogosResult setLogLevel(const std::string& level) {

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -164,6 +164,14 @@ inline StdLogosResult jsonResult(const SyncResult& r, nlohmann::json emptyDefaul
     return {true, r.data, ""};
 }
 
+class Libp2pModuleImpl;
+
+// Listener user_data. It outlives the module whenever the context teardown fails, because the Nim event thread may still fire: a late callback then reads a null owner instead of a freed module.
+struct ListenerGate {
+    std::shared_mutex lock;
+    Libp2pModuleImpl* owner = nullptr;
+};
+
 class Libp2pModuleImpl {
 public:
     Libp2pModuleImpl(const Libp2pModuleOptions& options = Libp2pModuleOptions::load());
@@ -294,9 +302,9 @@ private:
     void destroyContext();
     StdLogosResult nodeInfoBoundPorts();
 
-    // Held shared for the body of an event listener, which runs on the Nim dispatch thread against a bare `this`. destroyContext takes it unique to wait one out.
-    std::shared_timed_mutex m_listenerLock;
-    void drainListeners();
+    // Handed to the event listeners instead of `this`; owned by the module until a teardown that reports failure hands it to the event thread for good.
+    ListenerGate* m_gate = nullptr;
+    void detachListeners();
 
     // Reply trampolines: one per generated response type. Each turns the typed
     // (err_code, reply, err_msg) callback into a SyncResult and resolves the

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -79,7 +79,6 @@ StdLogosResult Libp2pModuleImpl::streamRelease(uint64_t streamId) {
 }
 
 void Libp2pModuleImpl::releaseStreamNoWait(uint64_t streamId) {
-    if (!ctx) return;
     callAsync([&](SyncPromise* p) {
         return libp2p_ctx_stream_release(ctx, streamId, &Libp2pModuleImpl::cbBool, p);
     });

--- a/tests/sync.cpp
+++ b/tests/sync.cpp
@@ -2,6 +2,9 @@
 #include <plugin.h>
 #include "test_helpers.h"
 
+#include <atomic>
+#include <thread>
+
 LOGOS_TEST(sync_connect_disconnect_peer) {
     Libp2pModuleImpl plugin;
     LOGOS_ASSERT_TRUE(plugin.start().success);
@@ -253,5 +256,47 @@ LOGOS_TEST(sync_kad_random_records) {
     LOGOS_ASSERT_TRUE(res.success);
     LOGOS_ASSERT_TRUE(res.value.is_array());
 
+    LOGOS_ASSERT_TRUE(plugin.stop().success);
+}
+
+LOGOS_TEST(sync_stop_without_a_context_is_rejected) {
+    Libp2pModuleImpl plugin;
+
+    auto res = plugin.stop();
+    LOGOS_ASSERT_FALSE(res.success);
+    LOGOS_ASSERT_TRUE(res.error == "No libp2p context");
+}
+
+// A reader on another thread while start() installs the context: every call sees either no context or a fully installed one, and TSAN sees no race on the pointer.
+LOGOS_TEST(sync_reader_races_context_create) {
+    Libp2pModuleImpl plugin;
+
+    std::atomic<bool> reading{false};
+    std::atomic<bool> done{false};
+    std::atomic<bool> unexpectedError{false};
+
+    std::thread reader([&] {
+        reading.store(true, std::memory_order_release);
+        while (!done.load(std::memory_order_relaxed)) {
+            auto res = plugin.peerInfo();
+            if (!res.success && res.error != "No libp2p context" &&
+                res.error.rfind("Failed to get peer info", 0) != 0) {
+                unexpectedError.store(true, std::memory_order_relaxed);
+            }
+        }
+    });
+
+    // The reader must be inside its loop before the create publishes the pointer, or there is no race to observe.
+    while (!reading.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+
+    LOGOS_ASSERT_TRUE(plugin.start().success);
+    done.store(true, std::memory_order_relaxed);
+    reader.join();
+
+    LOGOS_ASSERT_FALSE(unexpectedError.load());
+    // The hammering left a usable context behind, not one the race half-installed.
+    LOGOS_ASSERT_TRUE(plugin.peerInfo().success);
     LOGOS_ASSERT_TRUE(plugin.stop().success);
 }


### PR DESCRIPTION
## Summary

`Libp2pModuleImpl::ctx` was a plain `LibP2PCtx*` that nothing synchronized. Every host-facing call tested it for null and then passed it to a binding as two separate steps, so a `destroyContext()` that landed between the check and the submit was invisible to the check: the reader handed a pointer that `libp2p_ctx_destroy` had already freed to the Nim side. The pointer itself was also a plain data race, written by one thread and read by others with no atomic and no lock.

This PR gives the pointer the same shape of guard `emitEvent` already has through `m_emitEventLock`. A new `m_ctxLock` (`std::shared_mutex`) covers `ctx`: readers hold it shared across the null check *and* the submit into libp2p, and `createContext`/`destroyContext` hold it unique. The lock never covers an await, and `libp2p_ctx_destroy` runs outside it, because the teardown waits on Nim workers that may themselves be blocked on the lock.

Two neighbours of the same bug came with it. `applyOptions` rebuilds the buffers `m_libp2pConfig`'s `NimFfiStr`/seq views borrow, and `libp2p_ctx_create` reads those views for the length of a 5 s await, so a second `createNode` could free the array under an in-flight create; the create path now runs under `m_createLock`. And both event listeners run on the Nim dispatch thread against a bare `this`, so `~Libp2pModuleImpl` was free to run while one of them was inside `m_topicQueues` or `emitEventSafe`; they now receive a heap `ListenerGate` as their `user_data` instead of `this`, hold its lock shared for their whole body, and reach the module through `gate->owner`. `destroyContext` takes that lock unique and nulls the owner before it tears the context down. The wait carries no deadline, because a deadline that expires still frees a module a listener is inside.

## Affected Areas

- `src/plugin.h`: `m_ctxLock` guards `ctx`. `callSyncWith` owns the whole submit window (check, `invoke`, release) and the promise/await tail moved into a shared `awaitReply`, so `callStaticWith` keeps its ctx-free path instead of being borrowed for the ctx path. `callAsync` stops being static and takes the same shared lock, which covers the fire-and-forget submits from the dispatch thread.
- `src/plugin.cpp`: `createContext` installs the pointer and registers the listeners under the unique lock, against a fresh `ListenerGate`. `destroyContext` detaches the listeners first, nulls the pointer under the unique lock, then tears down outside it. `ensureContext()` serializes `applyOptions` and every create under `m_createLock`. `hasCtx()` replaces the raw reads in `ok`, `status` and `createNode`.
- `src/gossipsub.cpp`, `src/custom_handlers.cpp`: the pre-checks that gate `publishEmitEvent` read through `hasCtx()`.
- `src/callbacks.cpp`: both listeners take the gate lock shared for their body and return when the owner is null.
- `src/stream.cpp`: `releaseStreamNoWait` drops its own `if (!ctx) return;`. The guarded `callAsync` now carries that check.
- `tests/sync.cpp`: `sync_reader_races_context_create` hammers `peerInfo()` from a second thread, with a handshake so the loop is provably live while `start()` publishes the pointer. `sync_stop_without_a_context_is_rejected` pins the `stop()` behaviour change.

## The hazard from #103

#103 lists it under its known limits: the over-cap release path calls `libp2p_ctx_stream_release` from `onIncomingStream` on the Nim dispatch thread, through `releaseStreamNoWait` and `callAsync`, while `destroyContext()` frees `ctx` from the module thread. This PR closes it. `callAsync` holds `m_ctxLock` shared across its own null check and its submit, `releaseStreamNoWait` no longer checks on its own, and the gate keeps the listener that calls it from running against a freed module.

## Impact on Library Users

No API change. Three behaviour changes:

- `stop()` used to read `ctx` with no check at all and pass it straight to `libp2p_ctx_stop`. It now routes through the guarded `callSync`, so calling it without a context returns `"No libp2p context"`.
- `createNode`, `start` and `newPrivateKey` serialize against each other for the length of a create (up to `kNewContextTimeoutMs`) instead of racing.
- `~Libp2pModuleImpl` blocks until a listener that is already running returns. The wait has no deadline. A teardown that reports failure leaks one `ListenerGate` (a mutex and a pointer) instead of freeing a module the Nim event thread still points at.

The cost on the hot path is one uncontended shared lock per FFI call.

## Risk Assessment

- The guard covers the submit only. An operation already in flight when the context is destroyed still depends on the Nim side failing its callbacks cleanly; this narrows the window rather than removing it, which a `shared_ptr`-owned context would.
- A listener the Nim side dispatches *after* a failed `libp2p_ctx_destroy` finds a null owner and returns. The price is one leaked gate per failed teardown. That is the case `src/plugin.cpp` already documents above `destroyContextChecked`: a non-OK teardown means the Nim workers may still be live.
- Lock order is one way (gate lock, then ctx lock; create lock, then ctx lock) and nothing holds a lock across an await, so the teardown cannot deadlock against a worker. `detachListeners()` releases the gate lock before `destroyContext` takes `m_ctxLock`, and the teardown itself runs with neither held.
- No CI job exercises any of this. `tests/CMakeLists.txt` skips the whole integration target when `lib/libp2p.so` is absent, which is what every job does, and the sanitizer jobs build the same unit-only target. The new tests need a staged `libp2p.so` to run at all, so TSAN in CI will not report the race they pin.

## References

- Issue: `ctx` has no lifetime guard, found while reviewing #103.
- Base is #103's branch, `feat/delivery-support`. Merge #103 first.

